### PR TITLE
POC: enable coverage in PlatformIO native build, add a script to gene…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ gui/build
 __pycache__/
 last_graph.dat
 .pytype/
+
+controller_coverage

--- a/controller/controller_coverage.sh
+++ b/controller/controller_coverage.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-# Usage: ./controller_coverage.sh
+# This script generates an HTML coverage report for the controller unit tests.
+# It requires lcov to run.
+#
+# Usage: ./controller_coverage.sh [repo root]
 # Then run: firefox controller_coverage/index.html
+
 
 set -e
 set -x
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")"/..
 ENVIRONMENT=native
 OUTPUT_DIR=controller_coverage
 SRC_DIR=".pio/build/$ENVIRONMENT"
@@ -19,7 +23,7 @@ pio test -e native
 
 
 # delete the old report as "safely" as possible
-find "$OUTPUT_DIR" -name "*.html" -delete
+find "$OUTPUT_DIR" -name "*.html" -delete || true
 mkdir -p "$OUTPUT_DIR"
 lcov --directory "$SRC_DIR" --capture --output-file "$OUTPUT_DIR/$ENVIRONMENT.info"
 

--- a/controller/controller_coverage.sh
+++ b/controller/controller_coverage.sh
@@ -29,7 +29,7 @@ lcov --directory "$SRC_DIR" --capture --output-file "$OUTPUT_DIR/$ENVIRONMENT.in
 
 # the file "output_export.cpp" causes an lcov error, but it doesn't appear to be part of our source, so I'm excluding it
 lcov -r "$OUTPUT_DIR/$ENVIRONMENT.info" --output-file "$OUTPUT_DIR/${ENVIRONMENT}_trimmed.info" \
-    "*output_export.cpp" \
+    "*output_export.c*" \
     "*.pio/libdeps/*" \
     "/usr/include*"
 genhtml "$OUTPUT_DIR/${ENVIRONMENT}_trimmed.info" --output-directory "$OUTPUT_DIR"

--- a/controller_coverage.sh
+++ b/controller_coverage.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Usage: bash ./controller_coverage.sh
+# Then run: firefox controller_coverage/index.html
+
+set -e
+set -x
+
+# delete coverage files
+#find .pio -name "*.gcno" -delete
+
+# run tests
+pio test -e native
+
+ENVIRONMENT=native
+OUTPUT_DIR=controller_coverage
+rm -rf $OUTPUT_DIR
+mkdir -p $OUTPUT_DIR
+lcov --directory .pio/build/$ENVIRONMENT --capture --output-file $OUTPUT_DIR/$ENVIRONMENT.info
+
+# the file "output_export.cpp" causes an lcov error, but it doesn't appear to be part of our source, so I'm excluding it
+lcov -r $OUTPUT_DIR/$ENVIRONMENT.info --output-file $OUTPUT_DIR/${ENVIRONMENT}_trimmed.info \
+    "*output_export.cpp" \
+    "*.pio/libdeps/*" \
+    "/usr/include*"
+genhtml $OUTPUT_DIR/${ENVIRONMENT}_trimmed.info --output-directory $OUTPUT_DIR

--- a/controller_coverage.sh
+++ b/controller_coverage.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-# Usage: bash ./controller_coverage.sh
+# Usage: ./controller_coverage.sh
 # Then run: firefox controller_coverage/index.html
 
 set -e
 set -x
+
+cd "$(dirname "$0")"
+ENVIRONMENT=native
+OUTPUT_DIR=controller_coverage
+SRC_DIR=".pio/build/$ENVIRONMENT"
 
 # delete coverage files
 #find .pio -name "*.gcno" -delete
@@ -12,15 +17,17 @@ set -x
 # run tests
 pio test -e native
 
-ENVIRONMENT=native
-OUTPUT_DIR=controller_coverage
-rm -rf $OUTPUT_DIR
-mkdir -p $OUTPUT_DIR
-lcov --directory .pio/build/$ENVIRONMENT --capture --output-file $OUTPUT_DIR/$ENVIRONMENT.info
+
+# delete the old report as "safely" as possible
+find "$OUTPUT_DIR" -name "*.html" -delete
+mkdir -p "$OUTPUT_DIR"
+lcov --directory "$SRC_DIR" --capture --output-file "$OUTPUT_DIR/$ENVIRONMENT.info"
 
 # the file "output_export.cpp" causes an lcov error, but it doesn't appear to be part of our source, so I'm excluding it
-lcov -r $OUTPUT_DIR/$ENVIRONMENT.info --output-file $OUTPUT_DIR/${ENVIRONMENT}_trimmed.info \
+lcov -r "$OUTPUT_DIR/$ENVIRONMENT.info" --output-file "$OUTPUT_DIR/${ENVIRONMENT}_trimmed.info" \
     "*output_export.cpp" \
     "*.pio/libdeps/*" \
     "/usr/include*"
-genhtml $OUTPUT_DIR/${ENVIRONMENT}_trimmed.info --output-directory $OUTPUT_DIR
+genhtml "$OUTPUT_DIR/${ENVIRONMENT}_trimmed.info" --output-directory "$OUTPUT_DIR"
+
+echo "Coverage report generated. Open '$OUTPUT_DIR/index.html' in a browser to view it."

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,7 +98,7 @@ lib_extra_dirs =
   ${env.lib_extra_dirs}
   common/test_libs
 ; googletest requires pthread.
-build_flags = ${env.build_flags} -DTEST_MODE -pthread -g
+build_flags = ${env.build_flags} -DTEST_MODE -pthread -g --coverage -lgcov
 lib_deps =
   googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.


### PR DESCRIPTION
…rate an HTML report

Next step will be to integrate with CI, perhaps using coveralls.io or codecov.io.



As a side note, the code coverage percentage doesn't look too bad, even when including thirdparty dir. (Nice work!)