### PR TITLE
Feed fio2 to the GUI

### DIFF
--- a/software/common/generated_libs/network_protocol/network_protocol.pb.h
+++ b/software/common/generated_libs/network_protocol/network_protocol.pb.h
@@ -30,6 +30,7 @@ typedef struct _SensorsProto {
     float outflow_pressure_diff_cm_h2o;
     uint64_t breath_id;
     float flow_correction_ml_per_min;
+    float fio2;
 } SensorsProto;
 
 typedef struct _VentParams {
@@ -67,11 +68,11 @@ typedef struct _GuiStatus {
 #define GuiStatus_init_default                   {0, VentParams_init_default}
 #define ControllerStatus_init_default            {0, VentParams_init_default, SensorsProto_init_default, 0, 0}
 #define VentParams_init_default                  {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0}
-#define SensorsProto_init_default                {0, 0, 0, 0, 0, 0, 0}
+#define SensorsProto_init_default                {0, 0, 0, 0, 0, 0, 0, 0}
 #define GuiStatus_init_zero                      {0, VentParams_init_zero}
 #define ControllerStatus_init_zero               {0, VentParams_init_zero, SensorsProto_init_zero, 0, 0}
 #define VentParams_init_zero                     {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0}
-#define SensorsProto_init_zero                   {0, 0, 0, 0, 0, 0, 0}
+#define SensorsProto_init_zero                   {0, 0, 0, 0, 0, 0, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define SensorsProto_patient_pressure_cm_h2o_tag 1
@@ -81,6 +82,7 @@ typedef struct _GuiStatus {
 #define SensorsProto_outflow_pressure_diff_cm_h2o_tag 5
 #define SensorsProto_breath_id_tag               6
 #define SensorsProto_flow_correction_ml_per_min_tag 7
+#define SensorsProto_fio2_tag 8
 #define VentParams_mode_tag                      1
 #define VentParams_peep_cm_h2o_tag               3
 #define VentParams_breaths_per_min_tag           4
@@ -135,7 +137,8 @@ X(a, STATIC,   REQUIRED, FLOAT,    flow_ml_per_min,   3) \
 X(a, STATIC,   REQUIRED, FLOAT,    inflow_pressure_diff_cm_h2o,   4) \
 X(a, STATIC,   REQUIRED, FLOAT,    outflow_pressure_diff_cm_h2o,   5) \
 X(a, STATIC,   REQUIRED, UINT64,   breath_id,         6) \
-X(a, STATIC,   REQUIRED, FLOAT,    flow_correction_ml_per_min,   7)
+X(a, STATIC,   REQUIRED, FLOAT,    flow_correction_ml_per_min,   7)\
+X(a, STATIC,   REQUIRED, FLOAT,    fio2,   8)
 #define SensorsProto_CALLBACK NULL
 #define SensorsProto_DEFAULT NULL
 
@@ -154,7 +157,7 @@ extern const pb_msgdesc_t SensorsProto_msg;
 #define GuiStatus_size                           55
 #define ControllerStatus_size                    108
 #define VentParams_size                          42
-#define SensorsProto_size                        41
+#define SensorsProto_size                        45
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/software/common/generated_libs/network_protocol/network_protocol.proto
+++ b/software/common/generated_libs/network_protocol/network_protocol.proto
@@ -191,4 +191,5 @@ message SensorsProto {
   // flow_ml_per_min, in an attempt to make the volume graph look "right".  If
   // this is a large negative number, it may indicate a leak in the system.
   required float flow_correction_ml_per_min = 7;
+  required float fio2 = 8;
 }

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -59,6 +59,7 @@ static SensorsProto AsSensorsProto(const SensorReadings &r,
   proto.volume_ml = c.patient_volume.ml();
   proto.breath_id = c.breath_id;
   proto.flow_correction_ml_per_min = c.flow_correction.ml_per_min();
+  proto.fio2 = r.fio2;
   return proto;
 }
 


### PR DESCRIPTION
Add fio2 sensor reading to the comms interface.

I modified the network_protocol files manually, as I still can't get nanopb to run on my machine.
This is a simple change and should not bring any problem, but if someone can run nanopb on their end and give me a diff, I'll push it here.

This will require non-regression tests on the comms protocol with the GUI hooked up, which I cannot run on my own for now.