### PR TITLE
Recalibrate pressure sensors while running

### DIFF
--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -55,13 +55,17 @@ private:
 
   // These objects accumulate flow to calculate volume.
   //
-  // For debugging, we accumulate flow with and without error correction.  See
-  // FlowIntegrator definition for description of errors.
+  // For debugging, we accumulate flow with and without error correction, with
+  // raw flow (no re-zero) and with rezero-ed flow.  See FlowIntegrator
+  // definition for description of errors.
   //
   // These are never nullopt; we use std::optional to let us clear/reset these
   // objects.
   std::optional<FlowIntegrator> flow_integrator_ = FlowIntegrator();
   std::optional<FlowIntegrator> uncorrected_flow_integrator_ = FlowIntegrator();
+  std::optional<FlowIntegrator> flow_integrator_raw_ = FlowIntegrator();
+  std::optional<FlowIntegrator> flow_integrator_raw_corrected_ =
+      FlowIntegrator();
 
   // This state tells the controller whether the vent was already On when Run()
   // was last called, and allows resetting integrators when transitioning from

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -26,12 +26,24 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 static DebugFloat dbg_dp_inhale("dp_inhale", "Inhale diff pressure, cmH2O");
 static DebugFloat dbg_dp_exhale("dp_exhale", "Exhale diff pressure, cmH2O");
 static DebugFloat dbg_pressure("pressure", "Patient pressure, cmH2O");
+static DebugFloat dbg_dp_inhale_raw("dp_inhale_raw",
+                                    "Inhale diff pressure - no rezero, cmH2O");
+static DebugFloat dbg_dp_exhale_raw("dp_exhale_raw",
+                                    "Exhale diff pressure - no rezero, cmH2O");
+static DebugFloat dbg_raw_flow_inhale("flow_inhale_raw",
+                                      "Inhale flow rate - no rezero, cc/sec");
+static DebugFloat dbg_raw_flow_exhale("flow_exhale_raw",
+                                      "Exhale flow rate - no rezero, cc/sec");
 static DebugFloat dbg_flow_inhale("flow_inhale", "Inhale flow rate, cc/sec");
 static DebugFloat dbg_flow_exhale("flow_exhale", "Exhale flow rate, cc/sec");
 static DebugFloat dbg_fio2("fio2", "Fraction of inspired oxygen, [0.0 - 1.0]");
 // Flow correction happens as part of volume computation, in the Controller.
 static DebugFloat dbg_flow_uncorrected("flow_uncorrected",
                                        "Uncorrected net flow rate, cc/sec");
+static DebugFloat dbg_inhale_offset("rezero_inhale",
+                                    "Inhale re-zero value, mV");
+static DebugFloat dbg_exhale_offset("rezero_exhale",
+                                    "Exhale re-zero value, mV");
 
 //@TODO: Potential Caution: Density of air slightly varies over temperature and
 // altitude - need mechanism to adjust based on delivery? Constant involving
@@ -53,6 +65,15 @@ constexpr static float kVenturiCorrection{0.97f};
 static_assert(kVenturiPortDiameter > kVenturiChokeDiameter);
 static_assert(kVenturiChokeDiameter > meters(0));
 
+// The pressure sensors output 1-5V, and each additional 1V of output
+// corresponds to an additional 1kPa of pressure difference.
+// https://www.nxp.com/docs/en/data-sheet/MPXV5004G.pdf.
+//
+// The pressure sensor is scaled to 0-3.3V, which is the range captured by
+// our ADC.  Therefore, if we multiply the received voltage by 5/3.3, we get
+// a pressure in kPa.
+static const float kPressureSensorGain{5.f / 3.3f};
+
 AnalogPin Sensors::PinFor(Sensor s) {
   switch (s) {
   case Sensor::kPatientPressure:
@@ -69,6 +90,95 @@ AnalogPin Sensors::PinFor(Sensor s) {
 }
 
 Sensors::Sensors() = default;
+
+FlowSensorRezero::FlowSensorRezero() {}
+
+Voltage FlowSensorRezero::ZeroOffset(Pressure dp) {
+  // TODO: refine value for these drift-suppression parameters
+  static constexpr int rezero_sampling = 10;
+  static constexpr Pressure max_drift = cmH2O(0.01f);
+  static constexpr Pressure max_sum_outliers = cmH2O(0);
+  // TODO: refine these sensor characterisation values with new venturi geometry
+  static constexpr Pressure zero_flow_noise = cmH2O(0.012f);
+  static constexpr float dp_signal_to_noise = 0.1f;
+  // maximum value to allow rezeroing: if the measure is higher than this dp,
+  // the noise model we are using fails, rezeroing is harder to perform and may
+  // lead to wrong re-zeroing.
+  static constexpr Pressure max_zeroing_dp = kPa(0.75f);
+
+  // Compute rolling averages and error integrals with deadband to eventually
+  // re-zero the sensors:
+  average_dp_ += dp / static_cast<float>(rezero_sampling);
+  if ((dp < min_dp_) || (dp > max_dp_)) {
+    // Sum absolute value in order to make sure one high outlier does not
+    // compensate a low one that occured previously. This is used to check
+    // whether some measures in the integration interval could be attributed to
+    // actual signal rather than noise.
+    if (dp > last_average_dp_) {
+      error_sum_ += (dp - last_average_dp_);
+    } else {
+      error_sum_ += (last_average_dp_ - dp);
+    }
+  }
+
+  Voltage sensor_zero_delta = volts(0);
+  if (cycles_ % rezero_sampling == 0) {
+    // TODO: define sample time outside this method
+    duration_since_last_rezero_ += rezero_sampling * milliseconds(10.0f);
+    // First rezeroing condition: no outlier in signal
+    if (error_sum_ <= max_sum_outliers) {
+      // Max pressure that can be attributed to drift when pressure is close to
+      // zero, maxed out at 2 seconds of max drift.
+      Pressure max_zero =
+          max_drift * std::min(2.0f, duration_since_last_rezero_.seconds());
+      // Note that negative average is always attributed to drift, as it does
+      // not correspond to an actual physical phenomenon in the flow sensor
+      if (average_dp_ < max_zero) {
+        sensor_zero_delta = volts(average_dp_.kPa() / kPressureSensorGain);
+        // In essence, this made it so average_dp_ = 0.
+        average_dp_ = kPa(0);
+        duration_since_last_rezero_ = seconds(0);
+      } else {
+        // compute local change for rezeroing with non-zero flow
+        Pressure dp_change = kPa(0);
+        if (average_dp_ > last_average_dp_) {
+          dp_change = average_dp_ - last_average_dp_;
+        } else {
+          dp_change = last_average_dp_ - average_dp_;
+        }
+        if (dp_change < max_drift) {
+          sensor_zero_delta = volts((average_dp_ - last_average_dp_).kPa() /
+                                    kPressureSensorGain);
+          // In essence, this made it so average_dp_ = last_average_dp_.
+          average_dp_ = last_average_dp_;
+          // In this case we don't update duration_since_last_rezero_ since
+          // this is not going fully to zero, but making a non-zero
+        }
+      }
+    }
+    // compute new deadband
+    Pressure dp_noise = kPa(fabsf(average_dp_.kPa())) / dp_signal_to_noise;
+    if (dp_noise > zero_flow_noise) {
+      dp_noise = zero_flow_noise;
+    }
+    // Don't allow noise if value is too high. In effect what this does is make
+    // the integral pick up all the noise and become large, preventing any
+    // rezeroing
+    if (average_dp_ > max_zeroing_dp) {
+      dp_noise = kPa(0);
+    }
+    min_dp_ = average_dp_ - dp_noise;
+    max_dp_ = average_dp_ + dp_noise;
+
+    last_average_dp_ = average_dp_;
+    // reset summation states
+    average_dp_ = kPa(0);
+    error_sum_ = kPa(0);
+  }
+  cycles_ = (cycles_ + 1) % rezero_sampling;
+
+  return sensor_zero_delta;
+};
 
 // NOTE - I can't do this in the constructor now because it gets called before
 // the HAL is set up, so the busy wait never finishes.
@@ -94,6 +204,10 @@ void Sensors::Calibrate() {
   for (Sensor s : {Sensor::kPatientPressure, Sensor::kInflowPressureDiff,
                    Sensor::kOutflowPressureDiff, Sensor::kFIO2}) {
     sensors_zero_vals_[static_cast<int>(s)] = Hal.analogRead(PinFor(s));
+    // Used for Before/After comparison - remove this once we have enough
+    // comparison data
+    initial_sensors_zero_vals_[static_cast<int>(s)] =
+        sensors_zero_vals_[static_cast<int>(s)];
   }
 }
 
@@ -101,17 +215,18 @@ void Sensors::Calibrate() {
 //
 // @TODO: Add alarms if sensor value is out of expected range?
 Pressure Sensors::ReadPressureSensor(Sensor s) const {
-  // The pressure sensors output 1-5V, and each additional 1V of output
-  // corresponds to an additional 1kPa of pressure difference.
-  // https://www.nxp.com/docs/en/data-sheet/MPXV5004G.pdf.
-  //
-  // The pressure sensor is scaled to 0-3.3V, which is the range captured by
-  // our ADC.  Therefore, if we multiply the received voltage by 5/3.3, we get
-  // a pressure in kPa.
-  static const float kPressureSensorGain{5.f / 3.3f};
   return kPa(kPressureSensorGain * (Hal.analogRead(PinFor(s)) -
                                     sensors_zero_vals_[static_cast<int>(s)])
                                        .volts());
+}
+
+// Used for Before/After comparison - remove this once we have enough
+// comparison data
+Pressure Sensors::OldReadPressureSensor(Sensor s) const {
+  return kPa(kPressureSensorGain *
+             (Hal.analogRead(PinFor(s)) -
+              initial_sensors_zero_vals_[static_cast<int>(s)])
+                 .volts());
 }
 
 // Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
@@ -158,7 +273,7 @@ VolumetricFlow Sensors::PressureDeltaToFlow(Pressure delta) {
       std::sqrt(pow2(portArea) - pow2(chokeArea)));
 }
 
-SensorReadings Sensors::GetReadings() const {
+SensorReadings Sensors::GetReadings() {
   auto patient_pressure = ReadPressureSensor(Sensor::kPatientPressure);
   // Flow rate is inhalation flow minus exhalation flow. Positive value is flow
   // into lungs, and negative is flow out of lungs.
@@ -170,6 +285,24 @@ SensorReadings Sensors::GetReadings() const {
   Pressure p_ambient = kPa(101.3f);
   auto fio2 = ReadOxygenSensor(p_ambient);
 
+  // used for sensor-rezero evaluation - to be removed once we have enough data
+  auto inflow_delta_raw = OldReadPressureSensor(Sensor::kInflowPressureDiff);
+  auto outflow_delta_raw = OldReadPressureSensor(Sensor::kOutflowPressureDiff);
+  VolumetricFlow inflow_raw = PressureDeltaToFlow(inflow_delta_raw);
+  VolumetricFlow outflow_raw = PressureDeltaToFlow(outflow_delta_raw);
+
+  // Update the flow sensors zeros if possible
+  Voltage inhale_offset = inhale_zero_.ZeroOffset(inflow_delta);
+  Voltage exhale_offset = exhale_zero_.ZeroOffset(outflow_delta);
+  sensors_zero_vals_[static_cast<int>(Sensor::kInflowPressureDiff)] +=
+      inhale_offset;
+  sensors_zero_vals_[static_cast<int>(Sensor::kOutflowPressureDiff)] +=
+      exhale_offset;
+
+  // reacquire deltas based on the new zero
+  inflow_delta = ReadPressureSensor(Sensor::kInflowPressureDiff);
+  outflow_delta = ReadPressureSensor(Sensor::kOutflowPressureDiff);
+
   VolumetricFlow inflow = PressureDeltaToFlow(inflow_delta);
   VolumetricFlow outflow = PressureDeltaToFlow(outflow_delta);
   VolumetricFlow uncorrected_flow = inflow - outflow;
@@ -179,15 +312,23 @@ SensorReadings Sensors::GetReadings() const {
   dbg_dp_exhale.Set(outflow_delta.cmH2O());
   dbg_pressure.Set(patient_pressure.cmH2O());
   dbg_fio2.Set(fio2);
+  dbg_dp_inhale_raw.Set(inflow_delta_raw.cmH2O());
+  dbg_dp_exhale_raw.Set(outflow_delta_raw.cmH2O());
+  dbg_raw_flow_inhale.Set(inflow_raw.ml_per_sec());
+  dbg_raw_flow_exhale.Set(outflow_raw.ml_per_sec());
   dbg_flow_inhale.Set(inflow.ml_per_sec());
   dbg_flow_exhale.Set(outflow.ml_per_sec());
   dbg_flow_uncorrected.Set(uncorrected_flow.ml_per_sec());
+  dbg_inhale_offset.Set(inhale_offset.volts() * 1000.0f);
+  dbg_exhale_offset.Set(exhale_offset.volts() * 1000.0f);
 
   return {
       .patient_pressure = patient_pressure,
       .inflow_pressure_diff = inflow_delta,
       .outflow_pressure_diff = outflow_delta,
       .fio2 = fio2,
+      .inflow_raw = inflow_raw,
+      .outflow_raw = outflow_raw,
       .inflow = inflow,
       .outflow = outflow,
   };

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -39,15 +39,81 @@ struct SensorReadings {
   // Inflow and outflow at the two venturis, calculated from inflow/outflow
   // pressure diff.
   //
-  // These are "uncorrected" values.  We account for high-frequency noise by
-  // e.g. averaging many samples, but we don't account here for low-frequency
-  // sensor zero-point drift.
+  // These are raw values (i.e uncorrected). We account for high-frequency noise
+  // by e.g. averaging many samples, but we don't account here for low-frequency
+  // sensor zero-point drift - for sensor-rezero evaluation
+  VolumetricFlow inflow_raw;
+  VolumetricFlow outflow_raw;
+  // These are corrected values, which autozero when the flow is low enough or
+  // constant enough to allow a rezero : drift is taken into account when the
+  // ventilator is Off and when the flow is near-constant (assume the dynamic
+  // of the system is fast, compared to sensor drift)
   VolumetricFlow inflow;
   VolumetricFlow outflow;
 };
 
-// Provides calibrated sensor readings, including tidal volume (TV)
-// integrated from flow.
+// Provides a re-zeroing algorithm for the flow sensors, and correct for their
+// estimated zero-point drift:
+// Monitor the pressure measurements and check whether their evolution can be
+// attributed to drift, in which case we can declare a new sensor zero.
+//
+// Mathematically:
+// Periodically compute:
+//   A = average of the last n measurements (goal is to remove the noise).
+//   S = sum of measurement we know are not noise (any measurement outside
+//     A (from previous period) +/- noise)
+// If S. is 0 (no data point is *definitely* not noise) and compute a new
+// sensor zero, using either one of these logics:
+//   - A is close enough to 0 to be attributed to drift over time since the
+//     last successful re-zero ==> bring sensor zero to average
+//   - A is close enough to "A from previous period" to be attributed to drift
+//     over 1 period ==> bring sensor zero to previous zero + change in average
+//
+// Some known limits of this algorithm:
+// - This makes us blind to minute leaks (while we are only near-sighted in
+//   this regard when not using this)
+// - Similarly, any leak that starts out small and slowly increases over time
+//   will be harder to detect (but it can be detected by making sure the sensor
+//   zero does not get too high - something we are not doing for now)
+// - More importantly, this makes us blind to minute changes in flow that can
+//   occur when ventilating a patient. My assumption right now is that this is
+//   not happening on "normal" breathing (even for an ARDS patient) but this
+//   needs confirmation.
+class FlowSensorRezero {
+public:
+  FlowSensorRezero();
+  // ZeroOffset needs to be called every loop iteration to update the average dp
+  // and summation states, even if there is no need or we don't meet the
+  // conditions to rezero the sensor.
+  // Output is a "voltage delta" that needs to be incorporated into the sensor
+  // zero value. This new zero should also lead to a new computation of sensor
+  // output in order for the new value to take this new zero into account.
+  Voltage ZeroOffset(Pressure dp);
+
+private:
+  // cycles counter to keep track of passing time
+  int cycles_ = 0;
+
+  // States to know how the average dp changed.
+  Pressure average_dp_ = kPa(0);
+  Pressure last_average_dp_ = kPa(0);
+
+  // States to integrate deviation from average and evaluate whether it is close
+  // enough to zero to allow re-zeroing the corresponding sensor
+  Pressure error_sum_ = kPa(0);
+
+  // States for deadband definition (deadband is last_average_dp_ +/- noise).
+  // Init at noise around 0.
+  Pressure min_dp_ = cmH2O(-0.013f);
+  Pressure max_dp_ = cmH2O(0.013f);
+
+  // Duration since last rezero, used to compute max sensor average that can be
+  // attributed to drift, as allowable_drift * duration, capped to an absolute
+  // maximum
+  Duration duration_since_last_rezero_ = seconds(0);
+};
+
+// Provides calibrated sensor readings.
 class Sensors {
 public:
   Sensors();
@@ -58,7 +124,7 @@ public:
   void Calibrate();
 
   // Read the sensors.
-  SensorReadings GetReadings() const;
+  SensorReadings GetReadings();
 
   // min/max possible reading from MPXV5004GP pressure sensors
   // The canonical list of hardware in the device is: https://bit.ly/3aERr69
@@ -95,6 +161,15 @@ private:
 
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[kNumSensors];
+
+  // States used to access rezero_algorithms
+  FlowSensorRezero inhale_zero_;
+  FlowSensorRezero exhale_zero_;
+
+  // Used for Before/After comparison - remove this once we have enough
+  // comparison data
+  Pressure OldReadPressureSensor(Sensor s) const;
+  Voltage initial_sensors_zero_vals_[kNumSensors];
 };
 
 #endif // SENSORS_H

--- a/software/controller/test/controller/controller_test.cpp
+++ b/software/controller/test/controller/controller_test.cpp
@@ -45,6 +45,8 @@ TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
       .inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
       .fio2 = 0.21f,
+      .inflow_raw = ml_per_min(0),
+      .outflow_raw = ml_per_min(0),
       .inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
@@ -63,14 +65,14 @@ TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
         static_cast<float>(i % steps_per_breath) / steps_per_breath;
     Pressure inflow_pressure = cmH2O(0.5f + (breath_pos < 0.5 ? 1.f : 0.f));
     Pressure outflow_pressure = cmH2O(0.4f + (breath_pos >= 0.5 ? 1.f : 0.f));
-    readings = {
-        .patient_pressure = kPa(0),
-        .inflow_pressure_diff = inflow_pressure,
-        .outflow_pressure_diff = outflow_pressure,
-        .fio2 = 0.21f,
-        .inflow = Sensors::PressureDeltaToFlow(inflow_pressure),
-        .outflow = Sensors::PressureDeltaToFlow(outflow_pressure),
-    };
+    readings = {.patient_pressure = kPa(0),
+                .inflow_pressure_diff = inflow_pressure,
+                .outflow_pressure_diff = outflow_pressure,
+                .fio2 = 0.21f,
+                .inflow_raw = Sensors::PressureDeltaToFlow(inflow_pressure),
+                .outflow_raw = Sensors::PressureDeltaToFlow(outflow_pressure),
+                .inflow = Sensors::PressureDeltaToFlow(inflow_pressure),
+                .outflow = Sensors::PressureDeltaToFlow(outflow_pressure)};
     VolumetricFlow uncorrected_flow = readings.inflow - readings.outflow;
     flow_integrator.AddFlow(now, uncorrected_flow);
 


### PR DESCRIPTION
resurrected from #515

This still needs some tuning and testing, but the results are promising, and I want to get your feedback on the code so I can clean it up and we can decide whether we want to merge it for Wednesday's code freeze based on algorithm results rather than code quality.
Compared to previous versions, I changed the sensor re-zero class to work on dp rather than flow, which allowed me to keep current PressureDeltaToFlow and remove the flow deadband for volume integration (both can be put back but I wanted a version with as little change as possible it to ease comparison with the current algorithm).