### PR TITLE
clang-tidy and cppcheck

### DIFF
--- a/.circleci/controller_tests_Dockerfile
+++ b/.circleci/controller_tests_Dockerfile
@@ -2,7 +2,7 @@
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install build-essential python-pip lcov git curl -y \
+RUN apt-get update && apt-get install build-essential python-pip lcov git curl libtinfo5 -y \
     && pip install -U pip \
     && pip install platformio codecov \
     && platformio update
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install build-essential python-pip lcov git curl -
 WORKDIR /root/Ventilator
 COPY . ./
 CMD /bin/bash \
-    software/controller/test.sh && \
+    software/controller/test.sh --no-checks && \
     software/controller/controller_coverage.sh && \
     cd software/controller && \
     curl https://codecov.io/bash > codecov_uploader.sh && \

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -381,9 +381,9 @@ public:
   }
   [[nodiscard]] constexpr float minutes() const { return seconds() / 60; }
 
-  constexpr friend Time operator+(const Time &a, const Duration &b);
-  constexpr friend Time operator+(const Duration &a, const Time &b);
-  constexpr friend Time operator-(const Time &a, const Duration &b);
+  constexpr friend Time operator+(const Time &t, const Duration &dt);
+  constexpr friend Time operator+(const Duration &dt, const Time &t);
+  constexpr friend Time operator-(const Time &t, const Duration &dt);
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
 private:
@@ -424,9 +424,9 @@ class Time : public units_detail::Scalar<Time, uint64_t> {
 public:
   [[nodiscard]] uint64_t microsSinceStartup() const { return val_; }
 
-  constexpr friend Time operator+(const Time &a, const Duration &b);
-  constexpr friend Time operator+(const Duration &a, const Time &b);
-  constexpr friend Time operator-(const Time &a, const Duration &b);
+  constexpr friend Time operator+(const Time &t, const Duration &dt);
+  constexpr friend Time operator+(const Duration &dt, const Time &t);
+  constexpr friend Time operator-(const Time &t, const Duration &dt);
   constexpr friend Duration operator-(const Time &a, const Time &b);
   Time &operator+=(const Duration &dt) { return *this = *this + dt; }
   Time &operator-=(const Duration &dt) { return *this = *this - dt; }

--- a/software/controller/README.md
+++ b/software/controller/README.md
@@ -85,6 +85,8 @@ You'll need to install [Atom](https://atom.io/),
 and [Python](https://www.python.org/downloads/windows/).
 (Note: you may be asked to install Python 2.7, but PlatformIO works with Python 3.5+ as well, ostensibly.)
 
+You also need to install the package `libtinfo5` on Linux. Clang-tidy needs this package to run its checks, but platformio will just say all checks have passed without giving an error if it's missing.
+
 ## Building and testing
 
 After installing platformio, you should be able to build and test as follows.

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -242,7 +242,7 @@ Controller::Run(Time now, const VentParams &params,
   dbg_flow_correction.Set(flow_integrator_->FlowCorrection().ml_per_sec());
 
   // Handle DebugVars that force the actuators.
-  auto set_force = [](DebugFloat &var, auto &state) {
+  auto set_force = [](const DebugFloat &var, auto &state) {
     float v = var.Get();
     if (v >= 0 && v <= 1) {
       state = v;

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -118,7 +118,7 @@ Pressure Sensors::ReadPressureSensor(Sensor s) const {
 //
 // Output scales with partial pressure of O2, so ambient pressure must be
 // compensated to get an accurate FIO2.
-float Sensors::ReadOxygenSensor(const Pressure p_ambient) const {
+float Sensors::ReadOxygenSensor(Pressure p_ambient) const {
   // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
   // http://www.medicalsolutiontechnology.com/wp-content/uploads/2012/09/GO-04-DATA-SHEET.pdf
   // Sensitivity of 0.060V/fio2, where fio2 is 0.0 to 1.0, at pressure = 1atm

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -91,7 +91,7 @@ private:
 
   static AnalogPin PinFor(Sensor s);
   Pressure ReadPressureSensor(Sensor s) const;
-  float ReadOxygenSensor(const Pressure p_ambient) const;
+  float ReadOxygenSensor(Pressure p_ambient) const;
 
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[kNumSensors];

--- a/software/controller/lib/debug/debug.h
+++ b/software/controller/lib/debug/debug.h
@@ -63,7 +63,7 @@ class DebugCmd {
   static DebugCmd *cmd_registry_[256];
 
 public:
-  DebugCmd(DbgCmdCode opcode);
+  explicit DebugCmd(DbgCmdCode opcode);
 
   // Command handler.
   //   data_in - Buffer holding command data on entry.

--- a/software/controller/lib/debug/sprintf.cpp
+++ b/software/controller/lib/debug/sprintf.cpp
@@ -438,7 +438,7 @@ static int FormatLong(FieldInfo *info, long long val, char *str, int max) {
 
 static int FormatFloat(FieldInfo *info, float val, char *str, int max) {
   // Check for outliers
-  const char *bad = 0;
+  const char *bad = nullptr;
   if (isnan(val))
     bad = (val < 0) ? "-nan" : "nan";
   if (isinf(val))

--- a/software/controller/lib/debug/vars.h
+++ b/software/controller/lib/debug/vars.h
@@ -137,7 +137,7 @@ public:
       : DebugVar(name, &value_, help, fmt), value_(init) {}
 
   void Set(int32_t v) { value_ = v; }
-  int32_t Get() { return value_; }
+  int32_t Get() const { return value_; }
 
 private:
   int32_t value_;
@@ -150,7 +150,7 @@ public:
       : DebugVar(name, &value_, help, fmt), value_(init) {}
 
   void Set(uint32_t v) { value_ = v; }
-  uint32_t Get() { return value_; }
+  uint32_t Get() const { return value_; }
 
 private:
   uint32_t value_;
@@ -163,7 +163,7 @@ public:
       : DebugVar(name, &value_, help, fmt), value_(init) {}
 
   void Set(float v) { value_ = v; }
-  float Get() { return value_; }
+  float Get() const { return value_; }
 
 private:
   float value_;

--- a/software/controller/lib/hal/flash.cpp
+++ b/software/controller/lib/hal/flash.cpp
@@ -123,9 +123,7 @@ bool HalApi::FlashWrite(uint32_t addr, void *data, int ct) {
   reg->ctrl.program = 0;
   reg->ctrl.lock = 1;
 
-  if (reg->status & 0x0000C3FA)
-    return false;
-  return true;
+  return !(reg->status & 0x0000C3FA);
 }
 
 #endif

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -324,7 +324,7 @@ public:
   // Returns true if interrupts are currently enabled.
   //
   // Where possible, prefer using the BlockInterrupts RAII class.
-  bool interruptsEnabled();
+  bool interruptsEnabled() const;
 
   // Return true if we are currently executing in an interrupt handler
   bool InInterruptHandler();
@@ -425,7 +425,7 @@ inline void HalApi::disableInterrupts() {
   asm volatile("cpsid i" ::: "memory");
 }
 inline void HalApi::enableInterrupts() { asm volatile("cpsie i" ::: "memory"); }
-inline bool HalApi::interruptsEnabled() {
+inline bool HalApi::interruptsEnabled() const {
   int ret;
   asm volatile("mrs %[output], primask" : [output] "=r"(ret));
   return ret == 0;
@@ -508,7 +508,7 @@ inline void HalApi::test_debugPutIncomingData(const char *data, uint16_t len) {
 
 inline void HalApi::disableInterrupts() { interruptsEnabled_ = false; }
 inline void HalApi::enableInterrupts() { interruptsEnabled_ = true; }
-inline bool HalApi::interruptsEnabled() { return interruptsEnabled_; }
+inline bool HalApi::interruptsEnabled() const { return interruptsEnabled_; }
 inline bool HalApi::InInterruptHandler() { return false; }
 
 inline uint32_t HalApi::crc32(uint8_t *data, uint32_t length) {

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -64,7 +64,7 @@ extern "C" void _init() { Hal.EarlyInit(); }
 // If we ever did call abort we would just get here and loop until
 // the watchdog timer kills us.
 extern "C" void abort() {
-  while (1) {
+  while (true) {
   };
 }
 

--- a/software/controller/lib/hal/nvparams.cpp
+++ b/software/controller/lib/hal/nvparams.cpp
@@ -56,7 +56,7 @@ static void Invalidate(uint32_t addr);
 static bool SaveBlock(NVparams *blk, uint32_t addr);
 
 // One time init of non-volatile parameter area.
-void NVparamsInit(void) {
+void NVparamsInit() {
 
   // Total structures in two pages of flash
   int N = flash_params_size / nvparam_size;
@@ -108,7 +108,7 @@ void NVparamsInit(void) {
   nvparam_addr = flash_params_start;
 }
 
-const NVparams *GetNvParams(void) {
+const NVparams *GetNvParams() {
   return reinterpret_cast<const NVparams *>(nvparam_addr);
 }
 
@@ -216,9 +216,9 @@ static void Invalidate(uint32_t addr) {
 
 static NVparams fakeParams;
 
-void NVparamsInit(void) {}
+void NVparamsInit() {}
 
-const NVparams *GetNvParams(void) { return &fakeParams; }
+const NVparams *GetNvParams() { return &fakeParams; }
 
 bool NVparamsUpdtOff(uint32_t offset, const void *value, uint8_t len) {
   if ((offset < 8) || ((offset + len) > nvparam_size))

--- a/software/controller/lib/hal/nvparams.h
+++ b/software/controller/lib/hal/nvparams.h
@@ -39,8 +39,8 @@ struct NVparams {
 static_assert(sizeof(NVparams) == 512);
 
 // prototypes
-void NVparamsInit(void);
-const NVparams *GetNvParams(void);
+void NVparamsInit();
+const NVparams *GetNvParams();
 bool NVparamsUpdtOff(uint32_t offset, const void *value, uint8_t len);
 
 // Convenience macro to update a member of the non-volatile
@@ -50,10 +50,10 @@ bool NVparamsUpdtOff(uint32_t offset, const void *value, uint8_t len);
 
 // Update a 32-bit non-volatile parameter
 #define NVparamsUpdt32(member, value)                                          \
-  NVparamsUpdtOff(offsetof(NVparams, member), &value, sizeof(uint32_t))
+  NVparamsUpdtOff(offsetof(NVparams, (member)), &(value), sizeof(uint32_t))
 
 // Update a float non-volatile parameter
 #define NVparamsUpdtFlt(member, value)                                         \
-  NVparamsUpdtOff(offsetof(NVparams, member), &value, sizeof(float))
+  NVparamsUpdtOff(offsetof(NVparams, (member)), &(value), sizeof(float))
 
 #endif

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -85,7 +85,7 @@ static const int ustep_per_step_ = 128;
 inline void CS_High() { GPIO_SetPin(GPIO_B_BASE, 6); }
 inline void CS_Low() { GPIO_ClrPin(GPIO_B_BASE, 6); }
 
-StepMotor::StepMotor() {}
+StepMotor::StepMotor() = default;
 
 StepMtrErr StepMotor::SetParam(StepMtrParam param, uint32_t value) {
   uint8_t p = static_cast<uint8_t>(param);
@@ -318,7 +318,7 @@ void StepMotor::OneTimeInit() {
 
 // Convert a velocity from Deg/sec units to the value to program
 // into one of the stepper controller registers
-float StepMotor::DpsToVelReg(float vel, float cnv) {
+float StepMotor::DpsToVelReg(float vel, float cnv) const {
 
   // Convert to steps / sec
   float step_per_sec = vel * static_cast<float>(steps_per_rev_) / 360.0f;
@@ -328,7 +328,7 @@ float StepMotor::DpsToVelReg(float vel, float cnv) {
 }
 
 // Convert a velocity from a register value to deg/sec
-float StepMotor::RegVelToDps(int32_t val, float cnv) {
+float StepMotor::RegVelToDps(int32_t val, float cnv) const {
   return static_cast<float>(val) * 360.0f /
          (cnv * static_cast<float>(steps_per_rev_));
 }
@@ -592,7 +592,7 @@ StepMtrErr StepMotor::GetStatus(StepperStatus *stat) {
   return err;
 }
 
-int32_t StepMotor::DegToUstep(float deg) {
+int32_t StepMotor::DegToUstep(float deg) const {
   uint32_t ustep_per_rev = ustep_per_step_ * steps_per_rev_;
 
   float steps = static_cast<float>(ustep_per_rev) * deg / 360.0f;
@@ -782,7 +782,7 @@ void StepMotor::UpdateComState() {
       if (motor_[i].save_response_) {
         *motor_[i].cmd_ptr_++ = dma_buff_[i];
         if (--motor_[i].cmd_remain_ <= 0)
-          motor_[i].cmd_ptr_ = 0;
+          motor_[i].cmd_ptr_ = nullptr;
       }
 
       // If this motor has an active command to send,

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -194,7 +194,7 @@ public:
   // degrees and steps.
   void SetStepsPerRev(int spr) { steps_per_rev_ = spr; }
 
-  int GetStepsPerRev() { return steps_per_rev_; }
+  int GetStepsPerRev() const { return steps_per_rev_; }
 
   // Read the current absolute motor velocity and return it
   // in deg/sec units
@@ -310,7 +310,7 @@ private:
   // This pointer and count are used to hold the command being
   // sent to the motor and its response.
   // They're volatile because the interrupt handler updates them
-  volatile uint8_t *volatile cmd_ptr_{0};
+  volatile uint8_t *volatile cmd_ptr_{nullptr};
   volatile int cmd_remain_{0};
   bool save_response_{false};
 
@@ -318,9 +318,9 @@ private:
   // Defaults to the standard value for most steppers
   int steps_per_rev_{200};
 
-  float DpsToVelReg(float vel, float cnv);
-  float RegVelToDps(int32_t val, float cnv);
-  int32_t DegToUstep(float deg);
+  float DpsToVelReg(float vel, float cnv) const;
+  float RegVelToDps(int32_t val, float cnv) const;
+  int32_t DegToUstep(float deg) const;
   StepMtrErr SetKval(StepMtrParam param, float amp);
 
   // Send a command and wait for the response

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -66,6 +66,21 @@ build_flags =
 board_build.ldscript = platformio/build_config/stm32_ldscript.ld
 extra_scripts = pre:platformio/build_config/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src_test/> -<integration_tests/>
+check_tool = cppcheck, clangtidy
+check_flags =
+  cppcheck: --enable=all
+  ; The actual checks are defined in .clang-tidy.
+  clangtidy: --checks='-*' --extra-arg-before=-xc++ --extra-arg-before=-std=c++17
+check_patterns =
+  ../controller/lib
+  ../controller/src
+  ../controller/src_test
+  ../controller/integration_tests
+  ../common/include
+  ../common/libs
+  ../common/test_libs
+  ; Do not include ../common/generated_libs
+  ; Do not include ../common/third_party
 
 # Experimental integration test for STM32 with DMA-based communication.
 [env:stm32-test]
@@ -117,15 +132,18 @@ src_filter = ${env.src_filter} -<src_test/> -<integration_tests/>
 ;
 ; TODO(jlebar): Is this still necessary now that we have dropped support for
 ; Uno?  If so, will it still be necessary when we drop support for Nucleo?
-check_tool = clangtidy
+check_tool = cppcheck, clangtidy
 check_flags =
+  cppcheck: --enable=all
   ; The actual checks are defined in .clang-tidy.
   clangtidy: --checks='-*' --extra-arg-before=-xc++ --extra-arg-before=-std=c++17
 check_patterns =
+  ../controller/lib
+  ../controller/src
+  ../controller/src_test
+  ../controller/integration_tests
   ../common/include
   ../common/libs
   ../common/test_libs
   ; Do not include ../common/generated_libs
   ; Do not include ../common/third_party
-  ../controller
-  ../gui

--- a/software/controller/src_test/main.cpp
+++ b/software/controller/src_test/main.cpp
@@ -59,7 +59,7 @@ int main() {
     debugPrint("!");
   }
 
-  while (1) {
+  while (true) {
     Hal.watchdog_handler();
     char i[1];
     if (1 == debugRead(i, 1)) {


### PR DESCRIPTION
Clang-tidy now runs with the same checks (from .clang-tidy) on native and stm32. The issue was a missing dependency (libtinfo5) that clang-tidy needs to run in platformio checks, but it doesn't complain if it's missing.  

Cppcheck is now also working for native. 

Both clang-tidy and cppcheck checks have been added to the controller test script and set to fail on high level defects in CI.

Pertains to #132 

TODO: 
- cppcheck for stm32 (and both checks for the rest of the environments)
- clang-tidy for the GUI, probably using something like bears