### PR TITLE
clang-tidy & cppcheck - GUI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,23 +55,6 @@ jobs:
             git reset --soft $merge_base
             pre-commit run --show-diff-on-failure --files $changed_files
 
-  gui-static-analysis:
-    machine:
-      resource_class: 2xlarge
-      image: ubuntu-1604:201903-01
-      docker_layer_caching: true
-    steps:
-      - checkout
-      - run:
-          name: Install cppcheck
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y cppcheck
-      - run:
-          name: Run cppcheck on /software/gui
-          command: |
-            cd ~/project/software/gui && cppcheck -ithird_party . --error-exitcode=1 && cd -
-
   controller-tests:
     # See https://circleci.com/docs/2.0/executor-types/#docker-benefits-and-limitations
     # We use a machine executor here because we must run the container in privileged mode.
@@ -116,4 +99,3 @@ workflows:
       - common-precommit-checks
       - controller-tests
       - gui-tests
-      - gui-static-analysis

--- a/.circleci/gui_tests_Dockerfile
+++ b/.circleci/gui_tests_Dockerfile
@@ -2,15 +2,17 @@
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install build-essential python-pip lcov git curl -y \
-    && pip install -U pip \
-    && pip install codecov
+RUN apt-get update && \
+    apt-get install build-essential python-pip lcov git curl -y && \
+    pip install -U pip && \
+    pip install codecov
 
 WORKDIR /root/Ventilator
 COPY . ./
+
 CMD /bin/bash \
     software/gui/gui.sh --install && \
-    software/gui/gui.sh --build -f -j && \
+    software/gui/gui.sh --build -f -j --no-checks && \
     software/gui/gui.sh --test -f -x && \
     cd software/gui/build/tests && \
     curl https://codecov.io/bash > codecov_uploader.sh && \


### PR DESCRIPTION
We use bear to generate a compile database when the GUI build files are created. Cppcheck and clang-tidy then use this database to check these files. See the gui-tests CI job for the results of these two checks.

Pertains to #885 