### PR TITLE
First pass through the HAL. Do some light editing and cleanup

### DIFF
--- a/software/common/libs/checksum/checksum.cpp
+++ b/software/common/libs/checksum/checksum.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, Edwin Chiu
+/* Copyright 2020-2021, Edwin Chiu
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ uint32_t crc32_single(uint32_t crc, uint8_t data) {
   return crc;
 }
 
-uint32_t soft_crc32(const char *data, uint32_t count) {
+uint32_t soft_crc32(const uint8_t *data, uint32_t count) {
   if (0 == count) {
     return 0;
   }

--- a/software/common/libs/checksum/checksum.h
+++ b/software/common/libs/checksum/checksum.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, Edwin Chiu
+/* Copyright 2020-2021, Edwin Chiu
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ uint16_t checksum_fletcher16(const char *data, uint8_t count,
 // 2002.] https://users.ece.cmu.edu/~koopman/crc/
 constexpr uint32_t CRC32_POLYNOMIAL = 0x741B8CD7;
 
-uint32_t soft_crc32(const char *data, uint32_t count);
+uint32_t soft_crc32(const uint8_t *data, uint32_t count);
 
 // Computes check bytes for a fletcher16 checksum.
 //

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ static constexpr uint32_t size{sizeof(Structure)};
 
 // Calculate the CRC of the params at this address
 static uint32_t CRC(Structure *param) {
-  char *ptr = reinterpret_cast<char *>(param);
+  uint8_t *ptr = reinterpret_cast<uint8_t *>(param);
   return soft_crc32(ptr + sizeof(uint32_t), size - sizeof(uint32_t));
 }
 
@@ -70,8 +70,8 @@ void NVParams::Handler::Init(I2Ceeprom *eeprom) {
     // check its validity
     if (IsValid(&nv_param_)) {
       // Still read the flop in case they are both valid (which normally
-      // shouldn't happen but could if power is lost at just the right time when
-      // writing).
+      // shouldn't happen but could if power is lost at just the right
+      // time when writing).
       Structure Flop;
       ReadFullParams(Address::kFlop, &Flop, eeprom_);
       // check its validity
@@ -179,8 +179,8 @@ void NVParams::Handler::Update(const Time now, VentParams *params) {
     last_update_ = now;
   }
 
-  // assert that the size of VentParams is still good - if it isn't, we need to
-  // update the condition below to capture all members
+  // assert that the size of VentParams is still good - if it isn't, we need
+  // to update the condition below to capture all members
   static_assert(sizeof(VentParams) == 32);
 
   if (params->mode != nv_param_.last_settings.mode ||

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ limitations under the License.
 ////////////////////////////////////////////////////////////////////
 //
 // This file contains code to read the A/D inputs used in the system.
+// The A/D converters are described in [RM] section 16.
 //
 // The A/D inputs all connect to relatively slow signals that we want
 // to read precisely, so to improve the results we do a lot of
@@ -114,7 +115,7 @@ static volatile uint16_t adc_buff[adc_samp_history * kAdcChannels];
 // - We want the A/D reading to be fast, so summing up a really large
 //   array might be too slow.
 //
-// If you get hit with this assertion you may beed to rethink the
+// If you get hit with this assertion you may need to rethink the
 // way this function works.
 static_assert(adc_samp_history < 100);
 
@@ -138,10 +139,10 @@ void HalApi::InitADC() {
   // internal voltage regulator.
   adc->adc[0].ctrl = 0x10000000;
 
-  // Wait for the startup time specified in the STM32
-  // datasheet for the voltage regulator to become ready.
-  // The time in the datasheet is 20 microseconds, but
-  // I'll wait for 30 just to be extra conservative
+  // Wait for the startup time ([RM] 16.4.6) specified in the STM32
+  // [DS] for the voltage regulator to become ready.
+  // The time in the [DS] is 20 microseconds ([DS] 6.3.18)
+  // but I'll wait for 30 just to be extra conservative
   Hal.delay(microseconds(30));
 
   // Calibrate the A/D for single ended channels ([RM] 16.4.8)
@@ -203,7 +204,7 @@ void HalApi::InitADC() {
   dma->channel[C1].config.htie = 0;
   dma->channel[C1].config.teie = 0;
   dma->channel[C1].config.dir =
-      static_cast<REG>(DmaChannelDir::PERIPHERAL_TO_MEM);
+      static_cast<uint32_t>(DmaChannelDir::PERIPHERAL_TO_MEM);
   dma->channel[C1].config.circular = 1;
   dma->channel[C1].config.perInc = 0;
   dma->channel[C1].config.memInc = 1;

--- a/software/controller/lib/hal/flash.h
+++ b/software/controller/lib/hal/flash.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,19 +17,12 @@ limitations under the License.
 #ifndef FLASH_H_
 #define FLASH_H_
 
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 // Flash memory location & size info
-inline constexpr uint32_t flash_start_addr = 0x08000000;
-inline constexpr uint32_t flash_size = 0x00080000;
-inline constexpr uint32_t flash_page_size = 0x00000800;
-
-// Main program memory area
-inline constexpr uint32_t flash_code_start = 0x08000000;
-inline constexpr uint32_t flash_code_size = 0x0007f000;
-
-// Last two flash pages used for parameter storage
-inline constexpr uint32_t flash_params_start = 0x0807f000;
-inline constexpr uint32_t flash_params_size = 0x00001000;
+inline constexpr uint32_t flash_start_addr{0x08000000};
+inline constexpr size_t flash_size{32 * 1024};
+inline constexpr size_t flash_page_size{2 * 1024};
 
 #endif

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,8 +66,8 @@ limitations under the License.
 // Mode of a digital pin.
 // Usage: PinMode::INPUT etc.
 enum class PinMode {
-  // Test code relies on INPUT being the first enumeration (to get the behavior
-  // that INPUT pins are the default).
+  // Test code relies on INPUT being the first enumeration (to get the
+  // behavior that INPUT pins are the default).
   INPUT,
   OUTPUT,
   INPUT_PULLUP
@@ -124,7 +124,7 @@ enum class BinaryPin {
 enum class IntPriority {
   CRITICAL = 2, // Very important interrupt
   STANDARD = 5, // Normal hardware interrupts
-  LOW = 8,      // Less important.  Hardware interrutps can interrupt this
+  LOW = 8,      // Less important.  Hardware interrupts can interrupt this
 };
 
 enum class InterruptVector;
@@ -164,14 +164,14 @@ public:
 
   // Sleeps for some number of milliseconds.
   //
-  // Faked when testing.  Does not sleep, but does advance the time returned by
-  // millis().
+  // Faked when testing.  Does not sleep, but does advance the time returned
+  // by millis().
   void delay(Duration d);
 
-  // Caveat for people new to Arduino: analogRead and analogWrite are completely
-  // separate from each other and do not even refer to the same pins.
-  // analogRead() reads the value of an analog input pin. analogWrite() writes
-  // to a PWM pin - some of the digital pins are PWM pins.
+  // Caveat for people new to Arduino: analogRead and analogWrite are
+  // completely separate from each other and do not even refer to the same
+  // pins. analogRead() reads the value of an analog input pin. analogWrite()
+  // writes to a PWM pin - some of the digital pins are PWM pins.
 
   // Reads from analog sensor using an analog-to-digital converter.
   //
@@ -187,8 +187,8 @@ public:
   // Causes `pin` to output a square wave with the given duty cycle (range
   // [0, 1]).
   //
-  // Perhaps a better name would be "pwmWrite", but we also want to be somewhat
-  // consistent with the Arduino API that people are familiar with.
+  // Perhaps a better name would be "pwmWrite", but we also want to be
+  // somewhat consistent with the Arduino API that people are familiar with.
   void analogWrite(PwmPin pin, float duty);
 
   // Sets `pin` to high or low.
@@ -210,11 +210,11 @@ public:
 
   // Sends bytes to the GUI controller along the serial bus.
   //
-  // Arduino's SerialIO will block if len > serialBytesAvailableForWrite(), but
-  // this function will never block.  Instead, it returns the number of bytes
-  // written.  number of bytes written.  It's up to you to check how many bytes
-  // were actually written and handle "short writes" where we wrote less than
-  // the whole buffer.
+  // Arduino's SerialIO will block if len > serialBytesAvailableForWrite(),
+  // but this function will never block.  Instead, it returns the number of
+  // bytes written.  number of bytes written.  It's up to you to check how
+  // many bytes were actually written and handle "short writes" where we wrote
+  // less than the whole buffer.
   [[nodiscard]] uint16_t serialWrite(const char *buf, uint16_t len);
   [[nodiscard]] uint16_t serialWrite(uint8_t data) {
     return serialWrite(reinterpret_cast<const char *>(&data), 1);
@@ -229,8 +229,7 @@ public:
   uint16_t debugBytesAvailableForWrite();
   uint16_t debugBytesAvailableForRead();
 
-  // Buzzer used for alarms.  These functions turn the buzzer
-  // on/off.
+  // Buzzer used for alarms.  These functions turn the buzzer on/off.
   void BuzzerOn(float volume = 1.0f);
   void BuzzerOff();
 
@@ -250,7 +249,7 @@ public:
   // @param data - Pointer to data to write
   // @param ct   - Number of bytes to write
   //               NOTE - must be a multiple of 8
-  bool FlashWrite(uint32_t addr, void *data, int ct);
+  bool FlashWrite(uint32_t addr, void *data, size_t ct);
 
 #ifndef TEST_MODE
   // Translates to a numeric pin that can be passed to the Arduino API.
@@ -262,8 +261,8 @@ public:
   void EarlyInit();
 
 #else
-  // Reads up to `len` bytes of data "sent" via serialWrite.  Returns the total
-  // number of bytes read.
+  // Reads up to `len` bytes of data "sent" via serialWrite.  Returns the
+  // total number of bytes read.
   //
   // TODO: Once we have explicit message framing, this should simply read one
   // message.
@@ -330,7 +329,7 @@ public:
   bool InInterruptHandler();
 
   // Calculate CRC32 for data buffer
-  uint32_t crc32(uint8_t *data, uint32_t length);
+  uint32_t crc32(const uint8_t *data, uint32_t length);
 
 private:
   // Initializes watchdog, sets appropriate pins to OUTPUT, etc.  Called by
@@ -353,7 +352,7 @@ private:
   void InitSysTimer();
   void InitPwmOut();
   void InitUARTs();
-  void EnableClock(void *ptr);
+  void EnableClock(volatile void *ptr);
   void EnableInterrupt(InterruptVector vec, IntPriority pri);
   void StepperMotorInit();
   void InitBuzzer();
@@ -403,8 +402,8 @@ public:
     }
   }
 
-  // Not copyable or moveable.  (Technically we could make this class
-  // moveable if necessary, but it probably isn't!)
+  // Not copyable or movable.  (Technically we could make this class
+  // movable if necessary, but it probably isn't!)
   BlockInterrupts(const BlockInterrupts &) = delete;
   BlockInterrupts(BlockInterrupts &&) = delete;
   BlockInterrupts &operator=(const BlockInterrupts &) = delete;
@@ -512,8 +511,8 @@ inline void HalApi::enableInterrupts() { interruptsEnabled_ = true; }
 inline bool HalApi::interruptsEnabled() const { return interruptsEnabled_; }
 inline bool HalApi::InInterruptHandler() { return false; }
 
-inline uint32_t HalApi::crc32(uint8_t *data, uint32_t length) {
-  return soft_crc32(reinterpret_cast<char *>(data), length);
+inline uint32_t HalApi::crc32(const uint8_t *data, uint32_t length) {
+  return soft_crc32(data, length);
 }
 
 inline uint16_t TestSerialPort::Read(char *buf, uint16_t len) {
@@ -568,7 +567,7 @@ inline void BuzzerOff() {}
 inline void InitPSOL() {}
 inline void PSOL_Value(float val) {}
 inline bool HalApi::FlashErasePage(uint32_t address) { return true; }
-inline bool HalApi::FlashWrite(uint32_t addr, void *data, int ct) {
+inline bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) {
   return true;
 }
 

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -272,7 +272,7 @@ void HalApi::InitSysTimer() {
   TimerRegs *tmr = TIMER6_BASE;
 
   // The reload register gives the number of clock ticks (100ns in our case)
-  // -1 until the clock wraps back to zero and generates an interrupt This
+  // -1 until the clock wraps back to zero and generates an interrupt. This
   // setting will cause an interrupt every 10,000 clocks or 1 millisecond
   tmr->reload = 9999;
   tmr->prescale = (CPU_FREQ_MHZ / 10 - 1);

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ extern "C" void _init() { Hal.EarlyInit(); }
 // the watchdog timer kills us.
 extern "C" void abort() {
   while (true) {
+    ; // noop
   };
 }
 
@@ -90,7 +91,7 @@ void HalApi::EarlyInit() {
   SysCtrl_Reg *sysCtl = SYSCTL_BASE;
   sysCtl->cpac = 0x00F00000;
 
-  // Reset caches and set latency for 80MHz opperation
+  // Reset caches and set latency for 80MHz operation
   // See chapter 3 of [RM] for details on the embedded flash module
   EnableClock(FLASH_BASE);
   FlashReg *flash = FLASH_BASE;
@@ -116,7 +117,7 @@ void HalApi::EarlyInit() {
   // The PLL can generate several clocks with somewhat
   // less then descriptive names in the [RM].
   // These clocks are:
-  //   P clock - Used for the SAI peripherial.  Not used here
+  //   P clock - Used for the SAI peripheral.  Not used here
   //   Q clock - 48MHz output clock used for USB.  Not used here.
   //   R clock - This is the main system clock.  We care about this one.
   //
@@ -170,7 +171,7 @@ void HalApi::init() {
 
 // Reset the processor
 [[noreturn]] void HalApi::reset_device() {
-  // Note that the system control registers are a standard ARM peripherial
+  // Note that the system control registers are a standard ARM peripheral
   // they are documented in the [PM] rather than the [RM].
   // The register we use to reset the system is called the
   // "Application interrupt and reset control register (AIRCR)"
@@ -179,6 +180,7 @@ void HalApi::init() {
 
   // We promised we wouldn't return, so...
   while (true) {
+    ; // noop
   }
 }
 
@@ -189,7 +191,7 @@ void HalApi::init() {
  *
  * Please refer to the PCB schematic as the ultimate source of which
  * pin is used for which function.  A less definitive, but perhaps
- * easier to read version is availabe in [PCBsp]
+ * easier to read version is available in [PCBsp]
  *
  * ID inputs.  These can be used to identify the PCB revision
  * we're running on.
@@ -269,9 +271,9 @@ void HalApi::InitSysTimer() {
   // Just set the timer up to count every microsecond.
   TimerRegs *tmr = TIMER6_BASE;
 
-  // The reload register gives the numer of clock ticks (100ns in our case) -1
-  // until the clock wraps back to zero and generates an interrupt
-  // This setting will cause an interrupt every 10,000 clocks or 1 millisecond
+  // The reload register gives the number of clock ticks (100ns in our case)
+  // -1 until the clock wraps back to zero and generates an interrupt This
+  // setting will cause an interrupt every 10,000 clocks or 1 millisecond
   tmr->reload = 9999;
   tmr->prescale = (CPU_FREQ_MHZ / 10 - 1);
   tmr->event = 1;
@@ -412,7 +414,7 @@ void HalApi::InitPwmOut() {
   // I'm just picking a reasonable number.  This can be refined later
   //
   // The selection of PWM frequency is a trade off between latency and
-  // resolution.  Higher frequencies give lower latency and lower resoution.
+  // resolution.  Higher frequencies give lower latency and lower resolution.
   //
   // Latency is the time between setting the value and it taking effect,
   // this is essentially the PWM period (1/frequency).  For example, a
@@ -464,7 +466,8 @@ void HalApi::analogWrite(PwmPin pin, float duty) {
     __builtin_unreachable();
   }();
 
-  tmr->compare[chan] = static_cast<REG>(static_cast<float>(tmr->reload) * duty);
+  tmr->compare[chan] =
+      static_cast<uint32_t>(static_cast<float>(tmr->reload) * duty);
 }
 
 /******************************************************************
@@ -503,11 +506,11 @@ public:
 
     // See if we received a new byte.
     if (reg->status.s.rxne) {
-      // Add the byte to rxDat.  If the buffer is full, we'll drop it -- what
-      // else can we do?
+      // Add the byte to rxDat.  If the buffer is full, we'll drop it --
+      // what else can we do?
       //
-      // TODO: Perhaps log a warning here so we have an idea of whether this
-      // buffer is hitting capacity frequently.
+      // TODO: Perhaps log a warning here so we have an idea of whether
+      // this buffer is hitting capacity frequently.
       (void)rxDat.Put(static_cast<uint8_t>(reg->rxDat));
     }
 
@@ -591,7 +594,7 @@ extern UART_DMA dmaUART;
 //
 // Please refer to the PCB schematic as the ultimate source of which
 // pin is used for which function.  A less definitive, but perhaps
-// easier to read version is availabe at [PCBsp].
+// easier to read version is available at [PCBsp].
 //
 // These pins are connected to UART3
 // The UART is described in [RM] chapter 38
@@ -722,8 +725,8 @@ uint32_t HalApi::crc32_get() {
   //
   // TODO(jlebar): I think the nops likely are not necessary. The chip should
   // stall the processor if the data isn't available.  Moreover if it *is*
-  // necessary, asm volatile may not be enough of a memory barrier; we may need
-  // to say that these instructions also clobber "memory".
+  // necessary, asm volatile may not be enough of a memory barrier; we may
+  // need to say that these instructions also clobber "memory".
   asm volatile("nop");
   asm volatile("nop");
   asm volatile("nop");
@@ -737,7 +740,7 @@ void HalApi::crc32_reset() {
   crc->ctrl = 1;
 }
 
-uint32_t HalApi::crc32(uint8_t *data, uint32_t length) {
+uint32_t HalApi::crc32(const uint8_t *data, uint32_t length) {
   crc32_reset();
   while (length--) {
     crc32_accumulate(*data++);
@@ -745,16 +748,23 @@ uint32_t HalApi::crc32(uint8_t *data, uint32_t length) {
   return crc32_get();
 }
 
-// Enable clocks to a specific peripherial.
-// On the STM32 the clocks going to various peripherials on the chip
+// Fault handlers
+[[noreturn]] static void fault() {
+  while (true) {
+    ; // noop
+  }
+}
+
+// Enable clocks to a specific peripheral.
+// On the STM32 the clocks going to various peripherals on the chip
 // are individually selectable and for the most part disabled on startup.
-// Clocks to the specific peripherials need to be enabled through the
-// RCC (Reset and Clock Controller) module before the peripherial can be
+// Clocks to the specific peripherals need to be enabled through the
+// RCC (Reset and Clock Controller) module before the peripheral can be
 // used.
-// Pass in the base address of the peripherial to enable its clock
-void HalApi::EnableClock(void *ptr) {
+// Pass in the base address of the peripheral to enable its clock
+void HalApi::EnableClock(volatile void *ptr) {
   static struct {
-    void *base;
+    volatile void *base;
     int ndx;
     int bit;
   } rccInfo[] = {
@@ -767,7 +777,7 @@ void HalApi::EnableClock(void *ptr) {
       {I2C1_BASE, 4, 21},
       // The following entries are probably correct, but have
       // not been tested yet.  When adding support for one of
-      // these peripherials just comment out the line.  And
+      // these peripherals just comment out the line.  And
       // test of course.
       //      {CRC_BASE, 0, 12},
       //      {TIMER3_BASE, 4, 1},
@@ -781,8 +791,8 @@ void HalApi::EnableClock(void *ptr) {
       //      {TIMER16_BASE, 6, 17},
   };
 
-  // I don't include all the peripherials here, just the ones that we currently
-  // use or seem likely to be used in the future.  To add more peripherials,
+  // I don't include all the peripherals here, just the ones that we currently
+  // use or seem likely to be used in the future.  To add more peripherals,
   // just look up the appropriate bit in [RM] chapter 6.
   int ndx = -1;
   int bit = 0;
@@ -794,17 +804,16 @@ void HalApi::EnableClock(void *ptr) {
     }
   }
 
-  // If the input address wasn't found then its definitly
+  // If the input address wasn't found then its definitely
   // a bug.  I'll just loop forever here causing the code
   // to crash.  That should make it easier to find the
   // bug during development.
   if (ndx < 0) {
     Hal.disableInterrupts();
-    while (true) {
-    }
+    fault();
   }
 
-  // Enable the clock of the requested peripherial
+  // Enable the clock of the requested peripheral
   RCC_Regs *rcc = RCC_BASE;
   rcc->periphClkEna[ndx] |= (1 << bit);
 }
@@ -816,12 +825,6 @@ static void StepperISR() { StepMotor::DMA_ISR(); }
  * pointers to the various interrupt functions.  It is stored at the
  * very start of the flash memory.
  *****************************************************************/
-
-// Fault handlers
-static void fault() {
-  while (true) {
-  }
-}
 
 static void NMI() { fault(); }
 static void FaultISR() { fault(); }
@@ -840,7 +843,7 @@ __attribute__((section(".isr_vector"))) void (*const vectors[101])() = {
 
     // The second ISR entry is the reset vector which is an
     // assembly language routine that does some basic memory
-    // initilization and then calls main().
+    // initialization and then calls main().
     // Note that the LSB of the reset vector needs to be set
     // (hence the +1 below).  This tells the ARM that this is
     // thumb code.  The cortex m4 processor only supports
@@ -970,7 +973,7 @@ void HalApi::EnableInterrupt(InterruptVector vec, IntPriority pri) {
 
   // The STM32 processor implements bits 4-7 of the NVIM priority register.
   int p = static_cast<int>(pri);
-  nvic->priority[id] = static_cast<BREG>(p << 4);
+  nvic->priority[id] = static_cast<uint8_t>(p << 4);
 }
 
 #endif

--- a/software/controller/lib/hal/hal_stm32.h
+++ b/software/controller/lib/hal/hal_stm32.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -98,12 +98,12 @@ inline void GPIO_PinAltFunc(GPIO_Regs *gpio, int pin, int func) {
 
 // Set a specific output pin
 inline void GPIO_SetPin(GPIO_Regs *gpio, int pin) {
-  gpio->set = static_cast<SREG>(1 << pin);
+  gpio->set = static_cast<uint16_t>(1 << pin);
 }
 
 // Clear a specific output pin
 inline void GPIO_ClrPin(GPIO_Regs *gpio, int pin) {
-  gpio->clr = static_cast<SREG>(1 << pin);
+  gpio->clr = static_cast<uint16_t>(1 << pin);
 }
 
 // Return the current value of an input pin

--- a/software/controller/lib/hal/hal_stm32_regs.h
+++ b/software/controller/lib/hal/hal_stm32_regs.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,15 +18,6 @@ limitations under the License.
 
 #include <stdint.h>
 
-// Represents a 32-bit register
-typedef volatile uint32_t REG;
-
-// 16-bit short register
-typedef volatile uint16_t SREG;
-
-// 8-bit byte sized register
-typedef volatile uint8_t BREG;
-
 /*
 The structures below represent the STM32 registers used
 to configure various modules (like timers, serial ports, etc).
@@ -38,411 +29,430 @@ Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 */
 
 // [PM] 4.4 System control block (SCB) (pg 221)
-struct RCC_Regs { // <Offset> <Name>
-  REG clkCtrl;    // 0x00 clock control register (RCC_CR)
-  REG clkCal;    // 0x04 Internal clock sources calibration register (RCC_ICSCR)
-  REG clkCfg;    // 0x08 clock configuration register (RCC_CFGR)
-  REG pllCfg;    // 0x0C PLL configuration register (RCC_PLLCFGR)
-  REG pllSaiCfg; // 0x10 PLLSAI1 configuration register (RCC_PLLSAI1CFGR)
-  REG rsvd1;
-  REG clkIntEna; // 0x18 Clock interrupt enable register ( RCC_CIER)
-  REG clkIntFlg; // 0x1C Clock interrupt flag register ( RCC_CIFR)
-  REG clkIntClr; // 0x20 Clock interrupt clear register ( RCC_CICR)
-  REG rsvd2;
-  REG periphReset[8];  // 0x28 peripheral reset registers
-  REG periphClkEna[8]; // 0x48 peripheral clock registers
-  REG sleepClkEna[8];  // 0x68 Clock enable in sleep
-  REG indClkCfg; // 0x88 Peripherals independent clock configuration register
-                 // (RCC_CCIPR)
-  REG rsvd3;
-  REG backup;     // 0x90 Backup domain control register (RCC_BDCR)
-  REG status;     // 0x94 control & status register (RCC_CSR)
-  REG recovery;   // 0x98 Clock recovery RC register (RCC_CRRCR)
-  REG indClkCfg2; // 0x9C Peripherals independent clock configuration register
-                  // (RCC_CCIPR2)
+struct RCC_Regs_ {    // <Offset> <Name>
+  uint32_t clkCtrl;   // 0x00 clock control register (RCC_CR)
+  uint32_t clkCal;    // 0x04 Internal clock sources calibration register
+                      // (RCC_ICSCR)
+  uint32_t clkCfg;    // 0x08 clock configuration register (RCC_CFGR)
+  uint32_t pllCfg;    // 0x0C PLL configuration register (RCC_PLLCFGR)
+  uint32_t pllSaiCfg; // 0x10 PLLSAI1 configuration register (RCC_PLLSAI1CFGR)
+  uint32_t rsvd1;
+  uint32_t clkIntEna; // 0x18 Clock interrupt enable register ( RCC_CIER)
+  uint32_t clkIntFlg; // 0x1C Clock interrupt flag register ( RCC_CIFR)
+  uint32_t clkIntClr; // 0x20 Clock interrupt clear register ( RCC_CICR)
+  uint32_t rsvd2;
+  uint32_t periphReset[8];  // 0x28 peripheral reset registers
+  uint32_t periphClkEna[8]; // 0x48 peripheral clock registers
+  uint32_t sleepClkEna[8];  // 0x68 Clock enable in sleep
+  uint32_t indClkCfg;       // 0x88 Peripherals independent clock configuration
+                            // register (RCC_CCIPR)
+  uint32_t rsvd3;
+  uint32_t backup;     // 0x90 Backup domain control register (RCC_BDCR)
+  uint32_t status;     // 0x94 control & status register (RCC_CSR)
+  uint32_t recovery;   // 0x98 Clock recovery RC register (RCC_CRRCR)
+  uint32_t indClkCfg2; // 0x9C Peripherals independent clock configuration
+                       // register
+                       // (RCC_CCIPR2)
 };
+typedef volatile RCC_Regs_ RCC_Regs;
 inline RCC_Regs *const RCC_BASE = reinterpret_cast<RCC_Regs *>(0x40021000);
 
 // [PM] 4.4 System control block (SCB) (pg 221)
-struct SysCtrl_Reg {
-  REG rsvd0;      // 0xE000E000
-  REG intType;    // 0xE000E004
-  REG auxCtrl;    // 0xE000E008 - Auxiliary Control Register
-  REG rsvd1;      // 0xE000E00C
-  REG systick[3]; // 0xE000E010 - SysTick Timer
-  REG rsvd2[57];
-  REG nvic[768]; // 0xE000E100 - NVIC Register [RM] 4.3 (pg 208)
-  REG cpuid;     // 0xE000ED00 - CPUID Base Register
-  REG intCtrl;   // 0xE000ED04 - Interrupt Control and State Register
-  REG vtable;    // 0xE000ED08 - Vector Table Offset Register
-  REG apInt;   // 0xE000ED0C - Application Interrupt and Reset Control Register
-  REG sysCtrl; // 0xE000ED10 - System Control Register
-  REG cfgCtrl; // 0xE000ED14 - Configuration and Control Register
-  REG sysPri[3];     // 0xE000ED18 - System Handler Priority Registers (1-3)
-  REG sysHdnCtrl;    // 0xE000ED24 - System Handler Control and State Register
-  REG faultStat;     // 0xE000ED28 - Configurable Fault Status Register
-  REG hardFaultStat; // 0xE000ED2C - Hard Fault Status Register
-  REG rsvd3;
-  REG mmFaultAddr; // 0xE000ED34 - Memory Management Fault Address Register
-  REG faultAddr;   // 0xE000ED38 - Bus Fault Address Register
-  REG rsvd4[19];
-  REG cpac; // 0xE000ED88 - Coprocessor access control register
+struct SysCtrl_Reg_ {
+  uint32_t rsvd0;      // 0xE000E000
+  uint32_t intType;    // 0xE000E004
+  uint32_t auxCtrl;    // 0xE000E008 - Auxiliary Control Register
+  uint32_t rsvd1;      // 0xE000E00C
+  uint32_t systick[3]; // 0xE000E010 - SysTick Timer
+  uint32_t rsvd2[57];
+  uint32_t nvic[768];  // 0xE000E100 - NVIC Register [RM] 4.3 (pg 208)
+  uint32_t cpuid;      // 0xE000ED00 - CPUID Base Register
+  uint32_t intCtrl;    // 0xE000ED04 - Interrupt Control and State Register
+  uint32_t vtable;     // 0xE000ED08 - Vector Table Offset Register
+  uint32_t apInt;      // 0xE000ED0C - Application Interrupt and Reset Control
+                       // Register
+  uint32_t sysCtrl;    // 0xE000ED10 - System Control Register
+  uint32_t cfgCtrl;    // 0xE000ED14 - Configuration and Control Register
+  uint32_t sysPri[3];  // 0xE000ED18 - System Handler Priority Registers (1-3)
+  uint32_t sysHdnCtrl; // 0xE000ED24 - System Handler Control and State
+                       // Register
+  uint32_t faultStat;  // 0xE000ED28 - Configurable Fault Status Register
+  uint32_t hardFaultStat; // 0xE000ED2C - Hard Fault Status Register
+  uint32_t rsvd3;
+  uint32_t mmFaultAddr; // 0xE000ED34 - Memory Management Fault Address
+                        // Register
+  uint32_t faultAddr;   // 0xE000ED38 - Bus Fault Address Register
+  uint32_t rsvd4[19];
+  uint32_t cpac; // 0xE000ED88 - Coprocessor access control register
 };
+typedef volatile SysCtrl_Reg_ SysCtrl_Reg;
 inline SysCtrl_Reg *const SYSCTL_BASE =
     reinterpret_cast<SysCtrl_Reg *>(0xE000E000);
 
 // [PM] 4.3 Nested vectored interrupt controller (NVIC) (pg 208)
-struct IntCtrl_Regs {
-  REG setEna[32];
-  REG clrEna[32];
-  REG setPend[32];
-  REG clrPend[32];
-  REG active[64];
-  BREG priority[1024];
+struct IntCtrl_Regs_ {
+  uint32_t setEna[32];
+  uint32_t clrEna[32];
+  uint32_t setPend[32];
+  uint32_t clrPend[32];
+  uint32_t active[64];
+  uint8_t priority[1024];
 };
+typedef volatile IntCtrl_Regs_ IntCtrl_Regs;
 inline IntCtrl_Regs *const NVIC_BASE =
     reinterpret_cast<IntCtrl_Regs *>(0xE000E100);
 
 // [RM] 38.8 USART Registers (pg 1238)
-struct UART_Regs {
+struct UART_Regs_ {
   union {
     struct {
-      REG ue : 1;     // USART enable
-      REG uesm : 1;   // USART enable in Stop mode
-      REG re : 1;     // Receiver enable
-      REG te : 1;     // Transmitter enable
-      REG idleie : 1; // IDLE interrupt enable
-      REG rxneie : 1; // RXNE interrupt enable
-      REG tcie : 1;   // Transmission complete interrupt enable
-      REG txeie : 1;  // Transmit interrupt enable
-      REG peie : 1;   // Parity Error interrupt enable
-      REG ps : 1;     // Parity selection
-      REG pce : 1;    // Parity control enable
-      REG wake : 1;   // Receiver wakeup method
-      REG m0 : 1;     // Word length 0
-      REG mme : 1;    // Mute mode enable
-      REG cmie : 1;   // Character match interrupt enable
-      REG over8 : 1;  // Oversampling mode
-      REG dedt : 5;   // Driver Enable de-assertion time
-      REG deat : 5;   // Driver Enable assertion time
-      REG rtoie : 1;  // Receiver timeout interrupt enable
-      REG eobie : 1;  // End of Block interrupt enable
-      REG m1 : 1;     // Word length 1
-      REG rsvd : 3;
+      uint32_t ue : 1;     // USART enable
+      uint32_t uesm : 1;   // USART enable in Stop mode
+      uint32_t re : 1;     // Receiver enable
+      uint32_t te : 1;     // Transmitter enable
+      uint32_t idleie : 1; // IDLE interrupt enable
+      uint32_t rxneie : 1; // RXNE interrupt enable
+      uint32_t tcie : 1;   // Transmission complete interrupt enable
+      uint32_t txeie : 1;  // Transmit interrupt enable
+      uint32_t peie : 1;   // Parity Error interrupt enable
+      uint32_t ps : 1;     // Parity selection
+      uint32_t pce : 1;    // Parity control enable
+      uint32_t wake : 1;   // Receiver wakeup method
+      uint32_t m0 : 1;     // Word length 0
+      uint32_t mme : 1;    // Mute mode enable
+      uint32_t cmie : 1;   // Character match interrupt enable
+      uint32_t over8 : 1;  // Oversampling mode
+      uint32_t dedt : 5;   // Driver Enable de-assertion time
+      uint32_t deat : 5;   // Driver Enable assertion time
+      uint32_t rtoie : 1;  // Receiver timeout interrupt enable
+      uint32_t eobie : 1;  // End of Block interrupt enable
+      uint32_t m1 : 1;     // Word length 1
+      uint32_t rsvd : 3;
     } s;
-    REG r;
+    uint32_t r;
   } ctrl1; // Control Register 1 (USART_CR1) [RM] 38.8.1 (pg 1238)
   union {
     struct {
-      REG rsvd2 : 4;
-      REG addm7 : 1; // 7-bit Address Detection/4-bit Address Detection
-      REG lbdl : 1;  // LIN break detection length
-      REG lbdie : 1; // LIN break detection interrupt enable
-      REG rsvd1 : 1;
-      REG lbcl : 1;     // Last bit clock pulse
-      REG cpha : 1;     // Clock phase
-      REG cpol : 1;     // Clock polarity
-      REG clken : 1;    // Clock enable
-      REG stop : 2;     // STOP bits
-      REG linen : 1;    // LIN mode enable
-      REG swap : 1;     // Swap TX/RX pins
-      REG rxinv : 1;    // RX pin active level inversion
-      REG txinv : 1;    // TX pin active level inversion
-      REG datainv : 1;  // Binary data inversion
-      REG msbfirst : 1; // Most significant bit first
-      REG abren : 1;    // Auto baud rate enable
-      REG abrmod : 2;   // Auto baud rate mode
-      REG rtoen : 1;    // Receiver timeout enable
-      REG addr : 8;     // used for character detection during normal reception
-                        // This bit field can only be written when reception is
-                        // disabled (RE = 0) or the USART is disabled (UE=0)
+      uint32_t rsvd2 : 4;
+      uint32_t addm7 : 1; // 7-bit Address Detection/4-bit Address
+                          // Detection
+      uint32_t lbdl : 1;  // LIN break detection length
+      uint32_t lbdie : 1; // LIN break detection interrupt enable
+      uint32_t rsvd1 : 1;
+      uint32_t lbcl : 1;     // Last bit clock pulse
+      uint32_t cpha : 1;     // Clock phase
+      uint32_t cpol : 1;     // Clock polarity
+      uint32_t clken : 1;    // Clock enable
+      uint32_t stop : 2;     // STOP bits
+      uint32_t linen : 1;    // LIN mode enable
+      uint32_t swap : 1;     // Swap TX/RX pins
+      uint32_t rxinv : 1;    // RX pin active level inversion
+      uint32_t txinv : 1;    // TX pin active level inversion
+      uint32_t datainv : 1;  // Binary data inversion
+      uint32_t msbfirst : 1; // Most significant bit first
+      uint32_t abren : 1;    // Auto baud rate enable
+      uint32_t abrmod : 2;   // Auto baud rate mode
+      uint32_t rtoen : 1;    // Receiver timeout enable
+      uint32_t addr : 8;     // used for character detection during normal
+                             // reception This bit field can only be written
+                             // when reception is disabled (RE = 0) or the
+                             // USART is disabled (UE=0)
     } s;
-    REG r;
+    uint32_t r;
   } ctrl2; // Control Register 2 (USART_CR2) [RM] 38.8.2 (pg 1241)
   union {
     struct {
-      REG eie : 1;    // Error interrupt enable
-      REG iren : 1;   // IrDA mode enable
-      REG irlp : 1;   // IrDA low-power
-      REG hdsel : 1;  // Half-duplex selection
-      REG nack : 1;   // Smartcard NACK enable
-      REG scen : 1;   // Smartcard mode enable
-      REG dmar : 1;   // DMA enable receiver
-      REG dmat : 1;   // DMA enable transmitter
-      REG rtse : 1;   // RTS enable
-      REG ctse : 1;   // CTS enable
-      REG ctsie : 1;  // CTS interrupt enable
-      REG onebit : 1; // One sample bit method enable
-      REG ovrdis : 1; // Overrun Disable
-      REG ddre : 1;   // DMA Disable on Reception Error
-      REG dem : 1;    // Driver enable mode
-      REG dep : 1;    // Driver enable polarity selection
-      REG rsvd2 : 1;
-      REG scarcnt : 3; // Smartcard auto-retry count
-      REG wus : 2;     // Wakeup from Stop mode interrupt flag selection
-      REG wufie : 1;   // Wakeup from Stop mode interrupt enable
-      REG ucesm : 1;   // USART Clock Enable in Stop mode.
-      REG tcbgtie : 1; // Transmission complete before guard time interrupt
-                       // enable
-      REG rsvd : 7;
+      uint32_t eie : 1;    // Error interrupt enable
+      uint32_t iren : 1;   // IrDA mode enable
+      uint32_t irlp : 1;   // IrDA low-power
+      uint32_t hdsel : 1;  // Half-duplex selection
+      uint32_t nack : 1;   // Smartcard NACK enable
+      uint32_t scen : 1;   // Smartcard mode enable
+      uint32_t dmar : 1;   // DMA enable receiver
+      uint32_t dmat : 1;   // DMA enable transmitter
+      uint32_t rtse : 1;   // RTS enable
+      uint32_t ctse : 1;   // CTS enable
+      uint32_t ctsie : 1;  // CTS interrupt enable
+      uint32_t onebit : 1; // One sample bit method enable
+      uint32_t ovrdis : 1; // Overrun Disable
+      uint32_t ddre : 1;   // DMA Disable on Reception Error
+      uint32_t dem : 1;    // Driver enable mode
+      uint32_t dep : 1;    // Driver enable polarity selection
+      uint32_t rsvd2 : 1;
+      uint32_t scarcnt : 3; // Smartcard auto-retry count
+      uint32_t wus : 2;     // Wakeup from Stop mode interrupt flag selection
+      uint32_t wufie : 1;   // Wakeup from Stop mode interrupt enable
+      uint32_t ucesm : 1;   // USART Clock Enable in Stop mode.
+      uint32_t tcbgtie : 1; // Transmission complete before guard time
+                            // interrupt enable
+      uint32_t rsvd : 7;
     } s;
-    REG r;
+    uint32_t r;
   } ctrl3; // Control Register 3 [RM] 38.8.3  (pg 1245)
-  REG baud;
-  REG guard;
+  uint32_t baud;
+  uint32_t guard;
   union {
     struct {
-      REG rto : 24; // receiver timeout
-      REG blen : 8; // block length
+      uint32_t rto : 24; // receiver timeout
+      uint32_t blen : 8; // block length
     } s;
-    REG r;
+    uint32_t r;
   } timeout; // Receiver Timeout Register (USART_RTOR) [RM] 38.8.6 (pg 1251)
   union {
     struct {
-      REG abrrq : 1; // auto baud rate request
-      REG sbkrq : 1; // send break request
-      REG mmrq : 1;  // mute  mode request
-      REG rxfrq : 1; // receive data flush request
-      REG txfrq : 1; // transmit data flush request
-      REG rsvd : 27;
+      uint32_t abrrq : 1; // auto baud rate request
+      uint32_t sbkrq : 1; // send break request
+      uint32_t mmrq : 1;  // mute  mode request
+      uint32_t rxfrq : 1; // receive data flush request
+      uint32_t txfrq : 1; // transmit data flush request
+      uint32_t rsvd : 27;
     } s;
-    REG r;
+    uint32_t r;
   } request; // Request Register (USART_QRQ) [RM] 38.8.7 (pg 1252)
   union {
     struct {
-      const REG pe : 1;    // parity error
-      const REG fe : 1;    // framing error
-      const REG nf : 1;    // START bit noise detection flag
-      const REG ore : 1;   // overrun error
-      const REG idle : 1;  // idle line detected
-      const REG rxne : 1;  // read data register not empty
-      const REG tc : 1;    // transmission complete
-      const REG txe : 1;   // transmit data register empty
-      const REG lbdf : 1;  // LIN break detection flag
-      const REG ctsif : 1; // CTS interrupt flag
-      const REG cts : 1;   // CTS flag
-      const REG rtof : 1;  // receiver timeout
-      const REG eobf : 1;  // end of block flag
-      const REG rsvd : 1;
-      const REG abre : 1;  // auto baud rate error
-      const REG abrf : 1;  // auto baud rate flag
-      const REG busy : 1;  // busy flag
-      const REG cmf : 1;   // character match flag
-      const REG sbkf : 1;  // send break flag
-      const REG rwu : 1;   // receiver wakeup from Mute mode
-      const REG wuf : 1;   // wakeup from Stop mode flag
-      const REG teack : 1; // transmit enable acknowledge flag
-      const REG reack : 1; // receive enable acknowledge flag
-      const REG rsvd2 : 2;
-      const REG tcbgt : 1; // trans. complete before guard time completion
-      const REG rsvd3 : 6;
+      const uint32_t pe : 1;    // parity error
+      const uint32_t fe : 1;    // framing error
+      const uint32_t nf : 1;    // START bit noise detection flag
+      const uint32_t ore : 1;   // overrun error
+      const uint32_t idle : 1;  // idle line detected
+      const uint32_t rxne : 1;  // read data register not empty
+      const uint32_t tc : 1;    // transmission complete
+      const uint32_t txe : 1;   // transmit data register empty
+      const uint32_t lbdf : 1;  // LIN break detection flag
+      const uint32_t ctsif : 1; // CTS interrupt flag
+      const uint32_t cts : 1;   // CTS flag
+      const uint32_t rtof : 1;  // receiver timeout
+      const uint32_t eobf : 1;  // end of block flag
+      const uint32_t rsvd : 1;
+      const uint32_t abre : 1;  // auto baud rate error
+      const uint32_t abrf : 1;  // auto baud rate flag
+      const uint32_t busy : 1;  // busy flag
+      const uint32_t cmf : 1;   // character match flag
+      const uint32_t sbkf : 1;  // send break flag
+      const uint32_t rwu : 1;   // receiver wakeup from Mute mode
+      const uint32_t wuf : 1;   // wakeup from Stop mode flag
+      const uint32_t teack : 1; // transmit enable acknowledge flag
+      const uint32_t reack : 1; // receive enable acknowledge flag
+      const uint32_t rsvd2 : 2;
+      const uint32_t tcbgt : 1; // trans. complete before guard time
+                                // completion
+      const uint32_t rsvd3 : 6;
     } s;
-    REG r;
+    uint32_t r;
   } status; // [RM] 38.8.8 Interrupt And Status Register (USART_ISR) (pg 1253)
   union {
     struct {
-      REG pecf : 1;   // parity error clear flag
-      REG fecf : 1;   // framing error clear flag
-      REG ncf : 1;    // noise detected clear flag
-      REG orecf : 1;  // overrun error clear flag
-      REG idlecf : 1; // idle line detected clear flag
-      REG rsvd : 1;
-      REG tccf : 1;    // transmission complete clear flag
-      REG tcbgtcf : 1; // transmission completed before guard time clear fl.
-      REG lbdcf : 1;   // LIN break detection clear flag
-      REG ctscf : 1;   // CTS clear flag
-      REG rsvd2 : 1;
-      REG rtocf : 1; // receiver timeout clear flag
-      REG eobcf : 1; // end of block clear flag
-      REG rsvd3 : 4;
-      REG cmcf : 1; // character match clear flag
-      REG rsvd4 : 2;
-      REG wucf : 1; // wakeup from stop mode clear flag
-      REG rsvd5 : 11;
+      uint32_t pecf : 1;   // parity error clear flag
+      uint32_t fecf : 1;   // framing error clear flag
+      uint32_t ncf : 1;    // noise detected clear flag
+      uint32_t orecf : 1;  // overrun error clear flag
+      uint32_t idlecf : 1; // idle line detected clear flag
+      uint32_t rsvd : 1;
+      uint32_t tccf : 1;    // transmission complete clear flag
+      uint32_t tcbgtcf : 1; // transmission completed before guard time
+                            // clear fl.
+      uint32_t lbdcf : 1;   // LIN break detection clear flag
+      uint32_t ctscf : 1;   // CTS clear flag
+      uint32_t rsvd2 : 1;
+      uint32_t rtocf : 1; // receiver timeout clear flag
+      uint32_t eobcf : 1; // end of block clear flag
+      uint32_t rsvd3 : 4;
+      uint32_t cmcf : 1; // character match clear flag
+      uint32_t rsvd4 : 2;
+      uint32_t wucf : 1; // wakeup from stop mode clear flag
+      uint32_t rsvd5 : 11;
     } s;
-    REG r;
-  } intClear; // [RM] 38.8.9 Interrupt Flag Clear Register (USART_ICR) (pg 1257)
-  REG rxDat;
-  REG txDat;
+    uint32_t r;
+  } intClear; // [RM] 38.8.9 Interrupt Flag Clear Register (USART_ICR) (pg
+              // 1257)
+  uint32_t rxDat;
+  uint32_t txDat;
 };
+typedef volatile UART_Regs_ UART_Regs;
 inline UART_Regs *const UART1_BASE = reinterpret_cast<UART_Regs *>(0x40013800);
 inline UART_Regs *const UART2_BASE = reinterpret_cast<UART_Regs *>(0x40004400);
 inline UART_Regs *const UART3_BASE = reinterpret_cast<UART_Regs *>(0x40004800);
 inline UART_Regs *const UART4_BASE = reinterpret_cast<UART_Regs *>(0x40004C00);
 
 // [RM] 16.6 ADC Registers (for each ADC) (pg 450)
-struct ADC_Regs {
+struct ADC_Regs_ {
   // A/D specific registers (0x100 total length)
   struct {
-    REG stat;   // 0x00 - interrupt and status register (ADC_ISR)
-    REG intEna; // 0x04 - interrupt enable register (ADC_IER)
-    REG ctrl;   // 0x08 - control register (ADC_CR)
+    uint32_t stat;   // 0x00 - interrupt and status register (ADC_ISR)
+    uint32_t intEna; // 0x04 - interrupt enable register (ADC_IER)
+    uint32_t ctrl;   // 0x08 - control register (ADC_CR)
     struct {
-      REG dmaen : 1;      // DMA enable
-      REG dmacfg : 1;     // DMA config
-      REG dfsdmcfg : 1;   //
-      REG resolution : 2; // A/D resolution
-      REG align : 1;      // Data alignment
-      REG extsel : 4;     // External trigger selection
-      REG exten : 2;      // External trigger enable
-      REG ovrmod : 1;     // Over run mode
-      REG cont : 1;       // Continuous conversion mode
-      REG autdlh : 1;     // Delayed conversion mode
-      REG rsvd1 : 1;      //
-      REG discen : 1;     // Discontinuous mode
-      REG discnum : 3;    // Discontinuous mode channel count
-      REG jdiscen : 1;    // Discontinuous mode on injected channels
-      REG jqm : 1;        // JSQR mode
-      REG awd1sgl : 1;
-      REG awd1en : 1;
-      REG jawd1en : 1;
-      REG jauto : 1;
-      REG awd1ch : 5;
-      REG jqdis : 1;
-    } cfg1; // 0x0C - [RM] 16.6.4 ADC Configuration Register (ADC_CFGR) (pg 458)
+      uint32_t dmaen : 1;      // DMA enable
+      uint32_t dmacfg : 1;     // DMA config
+      uint32_t dfsdmcfg : 1;   //
+      uint32_t resolution : 2; // A/D resolution
+      uint32_t align : 1;      // Data alignment
+      uint32_t extsel : 4;     // External trigger selection
+      uint32_t exten : 2;      // External trigger enable
+      uint32_t ovrmod : 1;     // Over run mode
+      uint32_t cont : 1;       // Continuous conversion mode
+      uint32_t autdlh : 1;     // Delayed conversion mode
+      uint32_t rsvd1 : 1;      //
+      uint32_t discen : 1;     // Discontinuous mode
+      uint32_t discnum : 3;    // Discontinuous mode channel count
+      uint32_t jdiscen : 1;    // Discontinuous mode on injected channels
+      uint32_t jqm : 1;        // JSQR mode
+      uint32_t awd1sgl : 1;
+      uint32_t awd1en : 1;
+      uint32_t jawd1en : 1;
+      uint32_t jauto : 1;
+      uint32_t awd1ch : 5;
+      uint32_t jqdis : 1;
+    } cfg1; // 0x0C - [RM] 16.6.4 ADC Configuration Register (ADC_CFGR) (pg
+            // 458)
 
     struct {
-      REG rovse : 1; // bit 0    - regular oversampling enable
-      REG jovse : 1; // bit 1    - injected oversampling enable
-      REG ovsr : 3;  // bits 2-4 - oversampling ratio
-      REG ovss : 4;  // bits 5-8 - oversampling shift (max 0b1000)
-      REG trovs : 1; // bit 9    - triggered regular oversampling
-      REG rovsm : 1; // bit 10   - regular oversampling mode
-      REG rsvd : 21;
+      uint32_t rovse : 1; // bit 0    - regular oversampling enable
+      uint32_t jovse : 1; // bit 1    - injected oversampling enable
+      uint32_t ovsr : 3;  // bits 2-4 - oversampling ratio
+      uint32_t ovss : 4;  // bits 5-8 - oversampling shift (max 0b1000)
+      uint32_t trovs : 1; // bit 9    - triggered regular oversampling
+      uint32_t rovsm : 1; // bit 10   - regular oversampling mode
+      uint32_t rsvd : 21;
     } cfg2; // [RM] 16.6.5 ADC configuration register 2 (ADC_CFGR2) (pg 462)
 
     struct {
-      REG smp0 : 3; // Sample time for channel 0
-      REG smp1 : 3; // Sample time for channel 1
-      REG smp2 : 3; // Sample time for channel 2
-      REG smp3 : 3; // Sample time for channel 3
-      REG smp4 : 3; // Sample time for channel 4
-      REG smp5 : 3; // Sample time for channel 5
-      REG smp6 : 3; // Sample time for channel 6
-      REG smp7 : 3; // Sample time for channel 7
-      REG smp8 : 3; // Sample time for channel 8
-      REG smp9 : 3; // Sample time for channel 9
-      REG rsvd : 2;
+      uint32_t smp0 : 3; // Sample time for channel 0
+      uint32_t smp1 : 3; // Sample time for channel 1
+      uint32_t smp2 : 3; // Sample time for channel 2
+      uint32_t smp3 : 3; // Sample time for channel 3
+      uint32_t smp4 : 3; // Sample time for channel 4
+      uint32_t smp5 : 3; // Sample time for channel 5
+      uint32_t smp6 : 3; // Sample time for channel 6
+      uint32_t smp7 : 3; // Sample time for channel 7
+      uint32_t smp8 : 3; // Sample time for channel 8
+      uint32_t smp9 : 3; // Sample time for channel 9
+      uint32_t rsvd : 2;
 
-      REG smp10 : 3; // Sample time for channel 10
-      REG smp11 : 3; // Sample time for channel 11
-      REG smp12 : 3; // Sample time for channel 12
-      REG smp13 : 3; // Sample time for channel 13
-      REG smp14 : 3; // Sample time for channel 14
-      REG smp15 : 3; // Sample time for channel 15
-      REG smp16 : 3; // Sample time for channel 16
-      REG smp17 : 3; // Sample time for channel 17
-      REG smp18 : 3; // Sample time for channel 18
-      REG rsvd2 : 5;
+      uint32_t smp10 : 3; // Sample time for channel 10
+      uint32_t smp11 : 3; // Sample time for channel 11
+      uint32_t smp12 : 3; // Sample time for channel 12
+      uint32_t smp13 : 3; // Sample time for channel 13
+      uint32_t smp14 : 3; // Sample time for channel 14
+      uint32_t smp15 : 3; // Sample time for channel 15
+      uint32_t smp16 : 3; // Sample time for channel 16
+      uint32_t smp17 : 3; // Sample time for channel 17
+      uint32_t smp18 : 3; // Sample time for channel 18
+      uint32_t rsvd2 : 5;
     } samp; // [RM] 16.6.6 ADC Sample Time Register 1 (ADC_SMPR1) (pg 464)
 
-    REG rsvd1;
-    REG wdog[3]; // 0x20 - [RM] 16.6.8 ADC Watchdog
-                 // Threshold Register 1 (ADC_TR1) (pg 465)
-    REG rsvd2;
+    uint32_t rsvd1;
+    uint32_t wdog[3]; // 0x20 - [RM] 16.6.8 ADC Watchdog
+    uint32_t rsvd2;
 
     // 4x sequence registers.  These registers are used
     // to define the number of A/D readings and the
     // channel numbers being read.
     struct {
       // [RM] 16.6.11 ADC Regular Sequence Register 1 (ADC_SQR1) (pg 468)
-      REG len : 6;
-      REG sq1 : 6;
-      REG sq2 : 6;
-      REG sq3 : 6;
-      REG sq4 : 6;
-      REG rsvd1 : 2;
+      uint32_t len : 6;
+      uint32_t sq1 : 6;
+      uint32_t sq2 : 6;
+      uint32_t sq3 : 6;
+      uint32_t sq4 : 6;
+      uint32_t rsvd1 : 2;
 
       // [RM] 16.6.12 ADC Regular Sequence Register 2 (ADC_SQR2) (pg 469)
-      REG sq5 : 6;
-      REG sq6 : 6;
-      REG sq7 : 6;
-      REG sq8 : 6;
-      REG sq9 : 6;
-      REG rsvd2 : 2;
+      uint32_t sq5 : 6;
+      uint32_t sq6 : 6;
+      uint32_t sq7 : 6;
+      uint32_t sq8 : 6;
+      uint32_t sq9 : 6;
+      uint32_t rsvd2 : 2;
 
       // [RM] 16.6.13 ADC regular sequence register 3 (ADC_SQR3) (pg 470)
-      REG sq10 : 6;
-      REG sq11 : 6;
-      REG sq12 : 6;
-      REG sq13 : 6;
-      REG sq14 : 6;
-      REG rsvd3 : 2;
+      uint32_t sq10 : 6;
+      uint32_t sq11 : 6;
+      uint32_t sq12 : 6;
+      uint32_t sq13 : 6;
+      uint32_t sq14 : 6;
+      uint32_t rsvd3 : 2;
 
       // [RM] 16.6.14 ADC Regular Sequence Register 4 (ADC_SQR4) (pg 471)
-      REG sq15 : 6;
-      REG sq16 : 6;
-      REG rsvd4 : 20;
+      uint32_t sq15 : 6;
+      uint32_t sq16 : 6;
+      uint32_t rsvd4 : 20;
     } seq; // ADC Regular Sequence Register
 
-    REG data; // 0x40 - Regular Data Register [RM] 16.6.15 (pg 471)
-    REG rsvd3[2];
-    REG iSeq; // 0x4C - Injected Sequence Register [RM] 16.6.16 (pg 472)
-    REG rsvd4[4];
-    REG offset[4]; // 0x60 - Offset Register [RM] 16.6.17 (pg 473)
-    REG rsvd5[4];
-    REG iData[4]; // 0x80 - Injected Chan Data Reg [RM] 16.6.18 (pg 474)
-    REG rsvd6[4];
-    REG wdCfg[2]; // 0xA0 - Anlg Watchdog Config Reg [RM] 16.6.19 (pg 474)
-    REG rsvd7[2];
-    REG diffSel; // 0xB0 - Differential Mode Selection Reg [RM] 16.6.21 (pg 476)
-    REG cal;     // 0xB4 - Calibration Factors [RM] 16.6.22 (pg 476)
-    REG rsvd8[18];
+    uint32_t data; // 0x40 - Regular Data Register [RM] 16.6.15 (pg 471)
+    uint32_t rsvd3[2];
+    uint32_t iSeq; // 0x4C - Injected Sequence Register [RM] 16.6.16 (pg
+                   // 472)
+    uint32_t rsvd4[4];
+    uint32_t offset[4]; // 0x60 - Offset Register [RM] 16.6.17 (pg 473)
+    uint32_t rsvd5[4];
+    uint32_t iData[4]; // 0x80 - Injected Chan Data Reg [RM] 16.6.18 (pg
+                       // 474)
+    uint32_t rsvd6[4];
+    uint32_t wdCfg[2]; // 0xA0 - Analog Watchdog Config Reg [RM] 16.6.19 (pg
+                       // 474)
+    uint32_t rsvd7[2];
+    uint32_t diffSel; // 0xB0 - Differential Mode Selection Reg [RM] 16.6.21
+                      // (pg 476)
+    uint32_t cal;     // 0xB4 - Calibration Factors [RM] 16.6.22 (pg 476)
+    uint32_t rsvd8[18];
   } adc[2]; // Master ADC1, Slave ADC2
 
-  // [RM] 16.7.1 ADC Common Registers (pg 477)
-  REG comStat; // 0x300 - Common Status Register [RM] 16.7.1 (pg 477)
-  REG rsvd9;
-  REG comCtrl; // 0x304 - Common Control Register [RM] 16.7.2 (pg 479)
-  REG comData; // 0x308 - Common Data Reg Dual Mode [RM] 16.7.3 (pg 482)
+  uint32_t comStat; // 0x300 - Common Status Register [RM] 16.7.1 (pg 477)
+  uint32_t rsvd9;
+  uint32_t comCtrl; // 0x304 - Common Control Register [RM] 16.7.2 (pg 479)
+  uint32_t comData; // 0x308 - Common Data Reg Dual Mode [RM] 16.7.3 (pg 482)
 };
+typedef volatile ADC_Regs_ ADC_Regs;
 inline ADC_Regs *const ADC_BASE = reinterpret_cast<ADC_Regs *>(0X50040000);
 
 // Timer Register
 // NOTE: Offset values and applicable registers depend on timer used
-struct TimerRegs {
+struct TimerRegs_ {
   union {
     struct {
-      REG cen : 1;  // counter enable
-      REG udis : 1; // update disable
-      REG urs : 1;  // update request source
-      REG opm : 1;  // one-pulse mode
-      REG dir : 1;  // direction
-      REG cms : 2;  // center-aligned mode selection
-      REG arpe : 1; // auto-reload preload enable
-      REG ckd : 2;  // clock division
-      REG rsvd : 1;
-      REG uifremap : 1; // UIF status bit remapping
-      REG rsvd2 : 20;
+      uint32_t cen : 1;  // counter enable
+      uint32_t udis : 1; // update disable
+      uint32_t urs : 1;  // update request source
+      uint32_t opm : 1;  // one-pulse mode
+      uint32_t dir : 1;  // direction
+      uint32_t cms : 2;  // center-aligned mode selection
+      uint32_t arpe : 1; // auto-reload preload enable
+      uint32_t ckd : 2;  // clock division
+      uint32_t rsvd : 1;
+      uint32_t uifremap : 1; // UIF status bit remapping
+      uint32_t rsvd2 : 20;
     } s;
-    REG r;
+    uint32_t r;
   } ctrl1;
-  REG ctrl2;     // Control Register 2
-  REG slaveCtrl; // Slave Mode Control Register
-  REG intEna;    // DMA/Interrupt Enable Register
-  REG status;    // Status Register
-  REG event;     // Even Generation Register
-  REG ccMode[2]; // Capture/Compare Mode Register (1,2)
-  REG ccEnable;  // Capture/Compare Enable Register
+  uint32_t ctrl2;     // Control Register 2
+  uint32_t slaveCtrl; // Slave Mode Control Register
+  uint32_t intEna;    // DMA/Interrupt Enable Register
+  uint32_t status;    // Status Register
+  uint32_t event;     // Even Generation Register
+  uint32_t ccMode[2]; // Capture/Compare Mode Register (1,2)
+  uint32_t ccEnable;  // Capture/Compare Enable Register
   // The topmost bit of counter will contain contain UIFCOPY if UIFREMAP is
   // enabled, but *this register should not be decomposed into a bitfield
   // struct*.  The idea behind UIFREMAP is to read the counter plus the UIFCOPY
   // value atomically, in one go.
-  REG counter;    // Counter
-  REG prescale;   // Prescaler
-  REG reload;     // Auto-reload Register
-  REG repeat;     // Repetition Counter Register
-  REG compare[4]; // Capture/Compare Register (1-4)
-  REG deadTime;   // Break and Dead-time Register
-  REG dmaCtrl;    // DMA Control Register
-  REG dmaAddr;    // DMA Address for Full Transfer
-  REG opt1;       // Option Register 1
-  REG ccMode3;    // Capture/Compare Mode Register 3
-  REG compare5;   // Capture/Compare Register 5
-  REG compare6;   // Capture/Compare Register 6
-  REG opt2;       // Option Register 2
-  REG opt3;       // Option Register 3
+  uint32_t counter;    // Counter
+  uint32_t prescale;   // Prescaler
+  uint32_t reload;     // Auto-reload Register
+  uint32_t repeat;     // Repetition Counter Register
+  uint32_t compare[4]; // Capture/Compare Register (1-4)
+  uint32_t deadTime;   // Break and Dead-time Register
+  uint32_t dmaCtrl;    // DMA Control Register
+  uint32_t dmaAddr;    // DMA Address for Full Transfer
+  uint32_t opt1;       // Option Register 1
+  uint32_t ccMode3;    // Capture/Compare Mode Register 3
+  uint32_t compare5;   // Capture/Compare Register 5
+  uint32_t compare6;   // Capture/Compare Register 6
+  uint32_t opt2;       // Option Register 2
+  uint32_t opt3;       // Option Register 3
 };
+typedef volatile TimerRegs_ TimerRegs;
 
 // [RM] 26 Advanced-control Timers (TIM1) (pg 718)
 inline TimerRegs *const TIMER1_BASE = reinterpret_cast<TimerRegs *>(0x40012C00);
@@ -459,55 +469,56 @@ inline TimerRegs *const TIMER16_BASE =
     reinterpret_cast<TimerRegs *>(0x40014400);
 
 // [RM] 3.7 Flash Registers (pg 100)
-struct FlashReg {
+struct FlashReg_ {
 
   // Access control register
   struct {
-    REG latency : 3; // Number of ait states
-    REG rsvd1 : 5;
-    REG prefecth_ena : 1; // Enable pre-fetch
-    REG icache_ena : 1;   // Instruction cache enable
-    REG dcache_ena : 1;   // Data cache enable
-    REG icache_rst : 1;   // Instruction cache reset
-    REG dcache_rst : 1;   // Data cache reset
-    REG run_pd : 1;       // Power-down during run or low power mode
-    REG sleep_pd : 1;     // Power-down during sleep mode
-    REG rsvd2 : 17;
+    uint32_t latency : 3; // Number of ait states
+    uint32_t rsvd1 : 5;
+    uint32_t prefecth_ena : 1; // Enable pre-fetch
+    uint32_t icache_ena : 1;   // Instruction cache enable
+    uint32_t dcache_ena : 1;   // Data cache enable
+    uint32_t icache_rst : 1;   // Instruction cache reset
+    uint32_t dcache_rst : 1;   // Data cache reset
+    uint32_t run_pd : 1;       // Power-down during run or low power mode
+    uint32_t sleep_pd : 1;     // Power-down during sleep mode
+    uint32_t rsvd2 : 17;
   } access;
 
-  REG pdKey;  // 0x04 - Power-down Key Register (FLASH_PDKEYR)
-  REG key;    // 0x08 - Key Register (FLASH_KEYR)
-  REG optKey; // 0x0C - Option Key Register (FLASH_OPTKEYR)
-  REG status; // 0x10 - Status Register (FLASH_SR)
+  uint32_t pdKey;  // 0x04 - Power-down Key Register (FLASH_PDKEYR)
+  uint32_t key;    // 0x08 - Key Register (FLASH_KEYR)
+  uint32_t optKey; // 0x0C - Option Key Register (FLASH_OPTKEYR)
+  uint32_t status; // 0x10 - Status Register (FLASH_SR)
 
   // 0x14 - Control Register (FLASH_CR)
   struct {
-    REG program : 1;    // Set to program flash
-    REG page_erase : 1; // Pase erase
-    REG mass_erase : 1; // Mass erase
-    REG page : 8;       // Page number
-    REG rsvd1 : 5;
-    REG start : 1;     // Flash operation start
-    REG opt_start : 1; // Options modification start
-    REG fast_prog : 1; // Fast programming
-    REG rsvd2 : 5;
-    REG eop_ie : 1;     // End of operation interrupt enable
-    REG err_ie : 1;     // Error interrupt enable
-    REG rderr_ie : 1;   // read error interrupt enable
-    REG obl_launch : 1; // Force option byte reloading
-    REG rsvd3 : 2;
-    REG opt_lock : 1; // Lock the options area
-    REG lock : 1;     // Lock the flash
+    uint32_t program : 1;    // Set to program flash
+    uint32_t page_erase : 1; // Pase erase
+    uint32_t mass_erase : 1; // Mass erase
+    uint32_t page : 8;       // Page number
+    uint32_t rsvd1 : 5;
+    uint32_t start : 1;     // Flash operation start
+    uint32_t opt_start : 1; // Options modification start
+    uint32_t fast_prog : 1; // Fast programming
+    uint32_t rsvd2 : 5;
+    uint32_t eop_ie : 1;     // End of operation interrupt enable
+    uint32_t err_ie : 1;     // Error interrupt enable
+    uint32_t rderr_ie : 1;   // read error interrupt enable
+    uint32_t obl_launch : 1; // Force option byte reloading
+    uint32_t rsvd3 : 2;
+    uint32_t opt_lock : 1; // Lock the options area
+    uint32_t lock : 1;     // Lock the flash
   } ctrl;
 
-  REG ecc; // 0x18 - EEC Register (FLASH_EECR)
-  REG rsvd1;
-  REG option;     // 0x20 - Option Register (FLASH_OPTR)
-  REG pcropStart; // 0x24 - PCROP Start Address Register (FLASH_PCROP1SR)
-  REG pcropEnd;   // 0x28 - PCROP End Address Register (FLASH_PCROP1ER)
-  REG wrpA;       // 0x2C - WRP Area A Address Register (FLASH_WRP1AR)
-  REG wrpB;       // 0x30 - WRP Area B Address Register (FLAS_WRP1BR)
+  uint32_t ecc; // 0x18 - EEC Register (FLASH_EECR)
+  uint32_t rsvd1;
+  uint32_t option;     // 0x20 - Option Register (FLASH_OPTR)
+  uint32_t pcropStart; // 0x24 - PCROP Start Address Register (FLASH_PCROP1SR)
+  uint32_t pcropEnd;   // 0x28 - PCROP End Address Register (FLASH_PCROP1ER)
+  uint32_t wrpA;       // 0x2C - WRP Area A Address Register (FLASH_WRP1AR)
+  uint32_t wrpB;       // 0x30 - WRP Area B Address Register (FLAS_WRP1BR)
 };
+typedef volatile FlashReg_ FlashReg;
 inline FlashReg *const FLASH_BASE = reinterpret_cast<FlashReg *>(0x40022000);
 
 // [RM] 11.4.4 DMA channels (pg 302)
@@ -524,119 +535,120 @@ enum class DMA_Chan {
 enum class DmaChannelDir { PERIPHERAL_TO_MEM = 0, MEM_TO_PERIPHERAL = 1 };
 enum class DmaTransferSize { BITS8 = 0, BITS16 = 1, BITS32 = 2 };
 
-struct DMA_Regs {
+struct DMA_Regs_ {
   union {
     struct {
-      REG gif1 : 1;  // global interrupt flag
-      REG tcif1 : 1; // transfer complete (TC) flag
-      REG htif1 : 1; // half transfer (HT) flag
-      REG teif1 : 1; // transfer error (TE) flag
-      REG gif2 : 1;  // global interrupt flag
-      REG tcif2 : 1; // transfer complete (TC) flag
-      REG htif2 : 1; // half transfer (HT) flag
-      REG teif2 : 1; // transfer error (TE) flag
-      REG gif3 : 1;  // global interrupt flag
-      REG tcif3 : 1; // transfer complete (TC) flag
-      REG htif3 : 1; // half transfer (HT) flag
-      REG teif3 : 1; // transfer error (TE) flag
-      REG gif4 : 1;  // global interrupt flag
-      REG tcif4 : 1; // transfer complete (TC) flag
-      REG htif4 : 1; // half transfer (HT) flag
-      REG teif4 : 1; // transfer error (TE) flag
-      REG gif5 : 1;  // global interrupt flag
-      REG tcif5 : 1; // transfer complete (TC) flag
-      REG htif5 : 1; // half transfer (HT) flag
-      REG teif5 : 1; // transfer error (TE) flag
-      REG gif6 : 1;  // global interrupt flag
-      REG tcif6 : 1; // transfer complete (TC) flag
-      REG htif6 : 1; // half transfer (HT) flag
-      REG teif6 : 1; // transfer error (TE) flag
-      REG gif7 : 1;  // global interrupt flag
-      REG tcif7 : 1; // transfer complete (TC) flag
-      REG htif7 : 1; // half transfer (HT) flag
-      REG teif7 : 1; // transfer error (TE) flag
-      REG rsvd : 4;
+      uint32_t gif1 : 1;  // global interrupt flag
+      uint32_t tcif1 : 1; // transfer complete (TC) flag
+      uint32_t htif1 : 1; // half transfer (HT) flag
+      uint32_t teif1 : 1; // transfer error (TE) flag
+      uint32_t gif2 : 1;  // global interrupt flag
+      uint32_t tcif2 : 1; // transfer complete (TC) flag
+      uint32_t htif2 : 1; // half transfer (HT) flag
+      uint32_t teif2 : 1; // transfer error (TE) flag
+      uint32_t gif3 : 1;  // global interrupt flag
+      uint32_t tcif3 : 1; // transfer complete (TC) flag
+      uint32_t htif3 : 1; // half transfer (HT) flag
+      uint32_t teif3 : 1; // transfer error (TE) flag
+      uint32_t gif4 : 1;  // global interrupt flag
+      uint32_t tcif4 : 1; // transfer complete (TC) flag
+      uint32_t htif4 : 1; // half transfer (HT) flag
+      uint32_t teif4 : 1; // transfer error (TE) flag
+      uint32_t gif5 : 1;  // global interrupt flag
+      uint32_t tcif5 : 1; // transfer complete (TC) flag
+      uint32_t htif5 : 1; // half transfer (HT) flag
+      uint32_t teif5 : 1; // transfer error (TE) flag
+      uint32_t gif6 : 1;  // global interrupt flag
+      uint32_t tcif6 : 1; // transfer complete (TC) flag
+      uint32_t htif6 : 1; // half transfer (HT) flag
+      uint32_t teif6 : 1; // transfer error (TE) flag
+      uint32_t gif7 : 1;  // global interrupt flag
+      uint32_t tcif7 : 1; // transfer complete (TC) flag
+      uint32_t htif7 : 1; // half transfer (HT) flag
+      uint32_t teif7 : 1; // transfer error (TE) flag
+      uint32_t rsvd : 4;
     };
-    REG r;
+    uint32_t r;
   } intStat; // Interrupt Status Register (DMA_ISR) [RM] 11.6.1 (pg 308)
 
   union {
     struct {
-      REG gif1 : 1;  // global interrupt flag
-      REG tcif1 : 1; // transfer complete (TC) flag
-      REG htif1 : 1; // half transfer (HT) flag
-      REG teif1 : 1; // transfer error (TE) flag
-      REG gif2 : 1;  // global interrupt flag
-      REG tcif2 : 1; // transfer complete (TC) flag
-      REG htif2 : 1; // half transfer (HT) flag
-      REG teif2 : 1; // transfer error (TE) flag
-      REG gif3 : 1;  // global interrupt flag
-      REG tcif3 : 1; // transfer complete (TC) flag
-      REG htif3 : 1; // half transfer (HT) flag
-      REG teif3 : 1; // transfer error (TE) flag
-      REG gif4 : 1;  // global interrupt flag
-      REG tcif4 : 1; // transfer complete (TC) flag
-      REG htif4 : 1; // half transfer (HT) flag
-      REG teif4 : 1; // transfer error (TE) flag
-      REG gif5 : 1;  // global interrupt flag
-      REG tcif5 : 1; // transfer complete (TC) flag
-      REG htif5 : 1; // half transfer (HT) flag
-      REG teif5 : 1; // transfer error (TE) flag
-      REG gif6 : 1;  // global interrupt flag
-      REG tcif6 : 1; // transfer complete (TC) flag
-      REG htif6 : 1; // half transfer (HT) flag
-      REG teif6 : 1; // transfer error (TE) flag
-      REG gif7 : 1;  // global interrupt flag
-      REG tcif7 : 1; // transfer complete (TC) flag
-      REG htif7 : 1; // half transfer (HT) flag
-      REG teif7 : 1; // transfer error (TE) flag
-      REG rsvd : 4;
+      uint32_t gif1 : 1;  // global interrupt flag
+      uint32_t tcif1 : 1; // transfer complete (TC) flag
+      uint32_t htif1 : 1; // half transfer (HT) flag
+      uint32_t teif1 : 1; // transfer error (TE) flag
+      uint32_t gif2 : 1;  // global interrupt flag
+      uint32_t tcif2 : 1; // transfer complete (TC) flag
+      uint32_t htif2 : 1; // half transfer (HT) flag
+      uint32_t teif2 : 1; // transfer error (TE) flag
+      uint32_t gif3 : 1;  // global interrupt flag
+      uint32_t tcif3 : 1; // transfer complete (TC) flag
+      uint32_t htif3 : 1; // half transfer (HT) flag
+      uint32_t teif3 : 1; // transfer error (TE) flag
+      uint32_t gif4 : 1;  // global interrupt flag
+      uint32_t tcif4 : 1; // transfer complete (TC) flag
+      uint32_t htif4 : 1; // half transfer (HT) flag
+      uint32_t teif4 : 1; // transfer error (TE) flag
+      uint32_t gif5 : 1;  // global interrupt flag
+      uint32_t tcif5 : 1; // transfer complete (TC) flag
+      uint32_t htif5 : 1; // half transfer (HT) flag
+      uint32_t teif5 : 1; // transfer error (TE) flag
+      uint32_t gif6 : 1;  // global interrupt flag
+      uint32_t tcif6 : 1; // transfer complete (TC) flag
+      uint32_t htif6 : 1; // half transfer (HT) flag
+      uint32_t teif6 : 1; // transfer error (TE) flag
+      uint32_t gif7 : 1;  // global interrupt flag
+      uint32_t tcif7 : 1; // transfer complete (TC) flag
+      uint32_t htif7 : 1; // half transfer (HT) flag
+      uint32_t teif7 : 1; // transfer error (TE) flag
+      uint32_t rsvd : 4;
     };
-    REG r;
+    uint32_t r;
   } intClr; // Interrupt Flag Clear Register [RM] 11.6.2 (pg 311)
   struct ChannelRegs {
     struct {
-      REG enable : 1;   // channel enable
-      REG tcie : 1;     // transfer complete interrupt enable
-      REG htie : 1;     // half transfer interrupt enable
-      REG teie : 1;     // transfer error interrupt enable
-      REG dir : 1;      // data xfer direction 0: per->mem, 1: mem->per
-      REG circular : 1; // circular mode
-      REG perInc : 1;   // peripheral increment mode
-      REG memInc : 1;   // memory increment mode
-      REG psize : 2;    // peripheral size 0b00 - 8bits, 0b10 - 32bits
-      REG msize : 2;    // memory size 0b00 - 8bits, 0b10 - 32bits
-      REG priority : 2; // priority level 0b00 - low, 0b11 - high
-      REG mem2mem : 1;  // memory-to-memory mode
-      REG rsvd : 17;
-    } config;  // channel x configuration register [RM] 11.6.3 (pg 312)
-    REG count; // channel x number of data to transfer register
+      uint32_t enable : 1;   // channel enable
+      uint32_t tcie : 1;     // transfer complete interrupt enable
+      uint32_t htie : 1;     // half transfer interrupt enable
+      uint32_t teie : 1;     // transfer error interrupt enable
+      uint32_t dir : 1;      // data xfer direction 0: per->mem, 1: mem->per
+      uint32_t circular : 1; // circular mode
+      uint32_t perInc : 1;   // peripheral increment mode
+      uint32_t memInc : 1;   // memory increment mode
+      uint32_t psize : 2;    // peripheral size 0b00 - 8bits, 0b10 - 32bits
+      uint32_t msize : 2;    // memory size 0b00 - 8bits, 0b10 - 32bits
+      uint32_t priority : 2; // priority level 0b00 - low, 0b11 - high
+      uint32_t mem2mem : 1;  // memory-to-memory mode
+      uint32_t rsvd : 17;
+    } config;       // channel x configuration register [RM] 11.6.3 (pg 312)
+    uint32_t count; // channel x number of data to transfer register
     volatile void *pAddr; // channel x peripheral address register
     volatile void *mAddr; // channel x memory address register
-    REG rsvd;
+    uint32_t rsvd;
   } channel[7];
-  REG rsvd[5];
+  uint32_t rsvd[5];
   union {
     struct {
-      REG c1s : 4;
-      REG c2s : 4;
-      REG c3s : 4;
-      REG c4s : 4;
-      REG c5s : 4;
-      REG c6s : 4;
-      REG c7s : 4;
-      REG rsvd : 4;
+      uint32_t c1s : 4;
+      uint32_t c2s : 4;
+      uint32_t c3s : 4;
+      uint32_t c4s : 4;
+      uint32_t c5s : 4;
+      uint32_t c6s : 4;
+      uint32_t c7s : 4;
+      uint32_t rsvd : 4;
     };
-    REG r;
+    uint32_t r;
   } chanSel; // Channel Selection Register [RM] 11.6.7 (pg 317)
 };
+typedef volatile DMA_Regs_ DMA_Regs;
 inline DMA_Regs *const DMA1_BASE = reinterpret_cast<DMA_Regs *>(0x40020000);
 inline DMA_Regs *const DMA2_BASE = reinterpret_cast<DMA_Regs *>(0x40020400);
 
 /* Select the source for a DMA channel:
   @param dma        Address of DMA registers
   @param chan       DMA channel to modify.  Channels are numbered from 0
-  @param selection  Selects which peripherial request to map to the channel
+  @param selection  Selects which peripheral request to map to the channel
 */
 inline void DMA_SelectChannel(DMA_Regs *dma, DMA_Chan chan, int selection) {
   selection &= 0x0F;
@@ -674,139 +686,154 @@ inline void DMA_ClearInt(DMA_Regs *dma, DMA_Chan chan, DmaInterrupt interrupt) {
 }
 
 // [RM] 40.6 SPI Registers (pg 1330)
-struct SPI_Regs {
+struct SPI_Regs_ {
   struct {
-    REG cpha : 1;       // Clock phase
-    REG cpol : 1;       // Clock polarity
-    REG mstr : 1;       // Master mode
-    REG br : 3;         // Bit rate
-    REG spe : 1;        // SPI enable
-    REG lsb_first : 1;  // Send LSB first
-    REG ssi : 1;        // Internal slave select
-    REG ssm : 1;        // Software slave management
-    REG rx_only : 1;    // Receive mode only
-    REG crcl : 1;       // CRC length
-    REG crc_next : 1;   // CRC transmit next
-    REG crc_ena : 1;    // CRC enable
-    REG bidir_oe : 1;   // Bidirectional output enable
-    REG bidir_mode : 1; // Bidirectional data mode enable
-    REG rsvd : 16;
+    uint32_t cpha : 1;       // Clock phase
+    uint32_t cpol : 1;       // Clock polarity
+    uint32_t mstr : 1;       // Master mode
+    uint32_t br : 3;         // Bit rate
+    uint32_t spe : 1;        // SPI enable
+    uint32_t lsb_first : 1;  // Send LSB first
+    uint32_t ssi : 1;        // Internal slave select
+    uint32_t ssm : 1;        // Software slave management
+    uint32_t rx_only : 1;    // Receive mode only
+    uint32_t crcl : 1;       // CRC length
+    uint32_t crc_next : 1;   // CRC transmit next
+    uint32_t crc_ena : 1;    // CRC enable
+    uint32_t bidir_oe : 1;   // Bidirectional output enable
+    uint32_t bidir_mode : 1; // Bidirectional data mode enable
+    uint32_t rsvd : 16;
   } ctrl1; // Control register 1 (SPIx_CR1) [RM] 40.6.1 (pg 1330)
   struct {
-    REG rx_dma_en : 1; // Receive buffer DMA enable
-    REG tx_dma_en : 1; // Transmit buffer DMA enable
-    REG ssoe : 1;      // SS output enable
-    REG nssp : 1;      // NSS pulse management
-    REG frf : 1;       // Frame format
-    REG err_ie : 1;    // Error interrupt enable
-    REG rxne_ie : 1;   // Recieve buffer not empty int enable
-    REG txe_ie : 1;    // Transmit buffer empty int enable
-    REG ds : 4;        // Data size
-    REG frxth : 1;     // FIFO reception threshold
-    REG ldma_rx : 1;   // Last DMA xfer for receive
-    REG ldma_tx : 1;   // Last DMA xfer for transmit
-    REG rsvd : 17;
-  } ctrl2;     // Control register 2 (SPIx_CR2) [RM] 40.6.2
-  REG status;  // Status register (SPIx_SR) [RM] 40.6.3
-  REG data;    // Data register (SPIx_Dr) [RM] 40.6.4
-  REG crcPoly; // CRC polynomial register (SPIx_CRCPR) [RM] 40.6.5
-  REG rxCRC;   // Rx CRC register (SPIx_RXCRCR) [RM] 40.6.6
-  REG txCRC;   // Tx CRC register (SPIx_TXCRCR) [RM] 40.6.7
+    uint32_t rx_dma_en : 1; // Receive buffer DMA enable
+    uint32_t tx_dma_en : 1; // Transmit buffer DMA enable
+    uint32_t ssoe : 1;      // SS output enable
+    uint32_t nssp : 1;      // NSS pulse management
+    uint32_t frf : 1;       // Frame format
+    uint32_t err_ie : 1;    // Error interrupt enable
+    uint32_t rxne_ie : 1;   // Receive buffer not empty int enable
+    uint32_t txe_ie : 1;    // Transmit buffer empty int enable
+    uint32_t ds : 4;        // Data size
+    uint32_t frxth : 1;     // FIFO reception threshold
+    uint32_t ldma_rx : 1;   // Last DMA xfer for receive
+    uint32_t ldma_tx : 1;   // Last DMA xfer for transmit
+    uint32_t rsvd : 17;
+  } ctrl2;          // Control register 2 (SPIx_CR2) [RM] 40.6.2
+  uint32_t status;  // Status register (SPIx_SR) [RM] 40.6.3
+  uint32_t data;    // Data register (SPIx_Dr) [RM] 40.6.4
+  uint32_t crcPoly; // CRC polynomial register (SPIx_CRCPR) [RM] 40.6.5
+  uint32_t rxCRC;   // Rx CRC register (SPIx_RXCRCR) [RM] 40.6.6
+  uint32_t txCRC;   // Tx CRC register (SPIx_TXCRCR) [RM] 40.6.7
 };
+typedef volatile SPI_Regs_ SPI_Regs;
 inline SPI_Regs *const SPI1_BASE = reinterpret_cast<SPI_Regs *>(0x40013000);
 inline SPI_Regs *const SPI2_BASE = reinterpret_cast<SPI_Regs *>(0x40003800);
 inline SPI_Regs *const SPI3_BASE = reinterpret_cast<SPI_Regs *>(0x40003C00);
 
 // [RM] 37.7 I2C Registers
-struct I2C_Regs {
+struct I2C_Regs_ {
   union {
     struct {
-      REG peripheral_en : 1;   // Set to enable the I2C bus
-      REG tx_interrupts : 1;   // Interrupt when TX empty while channel active
-      REG rx_interrupts : 1;   // Interrupt when RX not empty
-      REG addr_interrupts : 1; // Generate interrupts on address match (slave)
-      REG nack_interrupts : 1; // Generate interrupts on NACK
-      REG stop_interrupts : 1; // Generate interrupts on stop detection (slave)
-      REG tx_complete_interrupts : 1; // Interrupt when transfer complete
-      REG error_interrupts : 1;       // Interrupt on error
-      REG dnf_cntrl : 4;              // Configure digital noise filtering
-      REG anf_off : 1;                // Disable analog noise filtering
-      REG reserved1 : 1;
-      REG dma_tx : 1;        // Enable DMA for TX
-      REG dma_rx : 1;        // Enable DMA for RX
-      REG slave_byte_en : 1; // Enable slave byte control (slave)
-      REG no_stretch : 1;    // Disable Clock stretching (slave)
-      REG wup_en : 1;        // Wake up from Stop Mode
-      REG gc_en : 1;         // General call (slave)
-      REG smd_h_en : 1;      // Use SMBus default host adress
-      REG smb_d_en : 1;      // Use SMBus default device adress
-      REG alert_en : 1;      // SMBus Alert enable
-      REG pec_en : 1;        // Use SMBus Packet error checking
-      REG reserved2 : 8;
+      uint32_t peripheral_en : 1;   // Set to enable the I2C bus
+      uint32_t tx_interrupts : 1;   // Interrupt when TX empty while channel
+                                    // active
+      uint32_t rx_interrupts : 1;   // Interrupt when RX not empty
+      uint32_t addr_interrupts : 1; // Generate interrupts on address
+                                    // match (slave)
+      uint32_t nack_interrupts : 1; // Generate interrupts on NACK
+      uint32_t stop_interrupts : 1; // Generate interrupts on stop
+                                    // detection (slave)
+      uint32_t tx_complete_interrupts : 1; // Interrupt when transfer
+                                           // complete
+      uint32_t error_interrupts : 1;       // Interrupt on error
+      uint32_t dnf_cntrl : 4;              // Configure digital noise filtering
+      uint32_t anf_off : 1;                // Disable analog noise filtering
+      uint32_t reserved1 : 1;
+      uint32_t dma_tx : 1;        // Enable DMA for TX
+      uint32_t dma_rx : 1;        // Enable DMA for RX
+      uint32_t slave_byte_en : 1; // Enable slave byte control (slave)
+      uint32_t no_stretch : 1;    // Disable Clock stretching (slave)
+      uint32_t wup_en : 1;        // Wake up from Stop Mode
+      uint32_t gc_en : 1;         // General call (slave)
+      uint32_t smd_h_en : 1;      // Use SMBus default host address
+      uint32_t smb_d_en : 1;      // Use SMBus default device address
+      uint32_t alert_en : 1;      // SMBus Alert enable
+      uint32_t pec_en : 1;        // Use SMBus Packet error checking
+      uint32_t reserved2 : 8;
     };
-    REG r;
+    uint32_t r;
   } ctrl1; // Control register 1 [RM] 37.7.1
   union {
     struct {
-      REG slave_addr_lsb : 1; // lsb of 10 bits slave adress (master)
-      REG slave_addr_7b : 7;  // middle 7b bits of slave adress (master)
-      REG slave_addr_msb : 2; // msb of 10 bits slave adress (master)
-      REG transfer_dir : 1;   // 0 = write, 1 = read (master)
-      REG address_10b : 1;    // Set to enable 10 bits address header (master)
-      REG read_10b_head : 1;  // Clear to send complete read sequence (master)
-      REG start : 1;          // Set to generate START condition
-      REG stop : 1;    // Set to generate STOP after byte transfer (master)
-      REG nack : 1;    // Generate NACK after byte reception (slave)
-      REG n_bytes : 8; // Set to the number of bytes to send
-      REG reload : 1;  // Set to allow several consecutive transfers
-      REG autoend : 1; // Set to automatically send stop condition
-      REG pecbyte : 1; // Set to send SMBus packet error checking byte
-      REG reserved : 5;
+      uint32_t slave_addr_lsb : 1; // lsb of 10 bits slave address
+                                   // (master)
+      uint32_t slave_addr_7b : 7;  // middle 7b bits of slave address
+                                   // (master)
+      uint32_t slave_addr_msb : 2; // msb of 10 bits slave address
+                                   // (master)
+      uint32_t transfer_dir : 1;   // 0 = write, 1 = read (master)
+      uint32_t address_10b : 1;    // Set to enable 10 bits address header
+                                   // (master)
+      uint32_t read_10b_head : 1;  // Clear to send complete read sequence
+                                   // (master)
+      uint32_t start : 1;          // Set to generate START condition
+      uint32_t stop : 1;           // Set to generate STOP after byte transfer
+                                   // (master)
+      uint32_t nack : 1;           // Generate NACK after byte reception (slave)
+      uint32_t n_bytes : 8;        // Set to the number of bytes to send
+      uint32_t reload : 1;         // Set to allow several consecutive transfers
+      uint32_t autoend : 1;        // Set to automatically send stop condition
+      uint32_t pecbyte : 1;        // Set to send SMBus packet error checking
+                                   // byte
+      uint32_t reserved : 5;
     };
-    REG r;
-  } ctrl2;     // Control register 2 [RM] 37.7.2
-  REG addr[2]; // Own address (1-2) register [RM] 37.7.{3,4} (slave)
+    uint32_t r;
+  } ctrl2;          // Control register 2 [RM] 37.7.2
+  uint32_t addr[2]; // Own address (1-2) register [RM] 37.7.{3,4} (slave)
   union {
     struct {
-      REG scl_low : 8;   // Duration of SCL Low state (cycles)
-      REG scl_high : 8;  // Duration of SCL High state (cycles)
-      REG sda_hold : 4;  // Delay between SCL falling edge and SDA edge (cycles)
-      REG scl_delay : 4; // Delay between SDA edge and SCL rising edge (cycles)
-      REG reserved : 4;
-      REG prescaler : 4; // Prescaler
+      uint32_t scl_low : 8;   // Duration of SCL Low state (cycles)
+      uint32_t scl_high : 8;  // Duration of SCL High state (cycles)
+      uint32_t sda_hold : 4;  // Delay between SCL falling edge and SDA
+                              // edge (cycles)
+      uint32_t scl_delay : 4; // Delay between SDA edge and SCL rising
+                              // edge (cycles)
+      uint32_t reserved : 4;
+      uint32_t prescaler : 4; // Prescaler
     };
-    REG r;
-  } timing;    // Timing register [RM] 37.7.5
-  REG timeout; // Timout register [RM] 37.7.6
+    uint32_t r;
+  } timing;         // Timing register [RM] 37.7.5
+  uint32_t timeout; // Timout register [RM] 37.7.6
   union {
     struct {
-      REG tx_empty : 1;
-      REG tx_interrupt : 1;
-      REG rx_not_empty : 1;
-      REG address_match : 1;
-      REG nack : 1;
-      REG stop : 1;
-      REG transfer_complete : 1;
-      REG transfer_reload : 1;
-      REG bus_error : 1;
-      REG arbitration_loss : 1;
-      REG overrun : 1;
-      REG packet_check_error : 1;
-      REG timeout : 1;
-      REG alert : 1;
-      REG reserved1 : 1;
-      REG busy : 1;
-      REG transfer_dir : 1;
-      REG address_code : 7;
-      REG reserved : 8;
+      uint32_t tx_empty : 1;
+      uint32_t tx_interrupt : 1;
+      uint32_t rx_not_empty : 1;
+      uint32_t address_match : 1;
+      uint32_t nack : 1;
+      uint32_t stop : 1;
+      uint32_t transfer_complete : 1;
+      uint32_t transfer_reload : 1;
+      uint32_t bus_error : 1;
+      uint32_t arbitration_loss : 1;
+      uint32_t overrun : 1;
+      uint32_t packet_check_error : 1;
+      uint32_t timeout : 1;
+      uint32_t alert : 1;
+      uint32_t reserved1 : 1;
+      uint32_t busy : 1;
+      uint32_t transfer_dir : 1;
+      uint32_t address_code : 7;
+      uint32_t reserved : 8;
     };
-    REG r;
-  } status;   // Interrupt & status register [RM] 37.7.7
-  REG intClr; // Interrupt clear register [RM] 37.7.8
-  REG pec;    // PEC register [RM] 37.7.9
-  REG rxData; // Receive data register [RM] 37.7.10
-  REG txData; // Transmit data register [RM] 37.7.11
+    uint32_t r;
+  } status;        // Interrupt & status register [RM] 37.7.7
+  uint32_t intClr; // Interrupt clear register [RM] 37.7.8
+  uint32_t pec;    // PEC register [RM] 37.7.9
+  uint32_t rxData; // Receive data register [RM] 37.7.10
+  uint32_t txData; // Transmit data register [RM] 37.7.11
 };
+typedef volatile I2C_Regs_ I2C_Regs;
 inline I2C_Regs *const I2C1_BASE = reinterpret_cast<I2C_Regs *>(0x40005400);
 inline I2C_Regs *const I2C2_BASE = reinterpret_cast<I2C_Regs *>(0x40005800);
 inline I2C_Regs *const I2C3_BASE = reinterpret_cast<I2C_Regs *>(0x40005c00);
@@ -814,43 +841,46 @@ inline I2C_Regs *const I2C4_BASE = reinterpret_cast<I2C_Regs *>(0x40008400);
 
 // Watchdog timer
 // [RM] 32.4 Watchdog Registers (pg 1016)
-struct Watchdog_Regs {
-  REG key;      // Key register [RM] 32.4.1
-  REG prescale; // Prescale register [RM] 32.4.2
-  REG reload;   // Reload register [RM] 32.4.3
-  REG status;   // Status register [RM] 32.4.4
-  REG window;   // Winow register [RM] 32.4.5
+struct Watchdog_Regs_ {
+  uint32_t key;      // Key register [RM] 32.4.1
+  uint32_t prescale; // Prescale register [RM] 32.4.2
+  uint32_t reload;   // Reload register [RM] 32.4.3
+  uint32_t status;   // Status register [RM] 32.4.4
+  uint32_t window;   // Window register [RM] 32.4.5
 };
+typedef volatile Watchdog_Regs_ Watchdog_Regs;
 inline Watchdog_Regs *const WATCHDOG_BASE =
     reinterpret_cast<Watchdog_Regs *>(0x40003000);
 
 // CRC calculation unit
 // [RM] 14.4 CRC Registers (pg 341)
-struct CRC_Regs {
-  REG data;    // Data register [RM] 14.4.1
-  REG scratch; // Independent data register [RM] 14.4.2
-  REG ctrl;    // Control register [RM] 14.4.3
-  REG rsvd;
-  REG init; // Initial CRC value [RM] 14.4.4
-  REG poly; // CRC polynomial [RM] 14.4.5
+struct CRC_Regs_ {
+  uint32_t data;    // Data register [RM] 14.4.1
+  uint32_t scratch; // Independent data register [RM] 14.4.2
+  uint32_t ctrl;    // Control register [RM] 14.4.3
+  uint32_t rsvd;
+  uint32_t init; // Initial CRC value [RM] 14.4.4
+  uint32_t poly; // CRC polynomial [RM] 14.4.5
 };
+typedef volatile CRC_Regs_ CRC_Regs;
 inline CRC_Regs *const CRC_BASE = reinterpret_cast<CRC_Regs *>(0x40023000);
 
 // General Purpose I/O
 // [RM] 8.4 GPIO Registers (pg 267)
-struct GPIO_Regs {
-  REG mode;     // Mode register [RM] 8.4.1
-  REG outType;  // Output type register [RM] 8.4.2
-  REG outSpeed; // Output speed register [RM] 8.4.3
-  REG pullUpDn; // Pull-up/pull-down register [RM] 8.4.4
-  REG inDat;    // Input data register [RM] 8.4.5
-  REG outDat;   // Output data register [RM] 8.4.6
-  SREG set;     // Bit set register [RM] 8.4.7
-  SREG clr;     // Bit reset register [RM] 8.4.7
-  REG lock;     // Configuration lock register [RM] 8.4.8
-  REG alt[2];   // Alternate function low/high register [RM] 8.4.{9,10}
-  REG reset;    // Reset register [RM] 8.4.11
+struct GPIO_Regs_ {
+  uint32_t mode;     // Mode register [RM] 8.4.1
+  uint32_t outType;  // Output type register [RM] 8.4.2
+  uint32_t outSpeed; // Output speed register [RM] 8.4.3
+  uint32_t pullUpDn; // Pull-up/pull-down register [RM] 8.4.4
+  uint32_t inDat;    // Input data register [RM] 8.4.5
+  uint32_t outDat;   // Output data register [RM] 8.4.6
+  uint16_t set;      // Bit set register [RM] 8.4.7
+  uint16_t clr;      // Bit reset register [RM] 8.4.7
+  uint32_t lock;     // Configuration lock register [RM] 8.4.8
+  uint32_t alt[2];   // Alternate function low/high register [RM] 8.4.{9,10}
+  uint32_t reset;    // Reset register [RM] 8.4.11
 };
+typedef volatile GPIO_Regs_ GPIO_Regs;
 inline GPIO_Regs *const GPIO_A_BASE = reinterpret_cast<GPIO_Regs *>(0x48000000);
 inline GPIO_Regs *const GPIO_B_BASE = reinterpret_cast<GPIO_Regs *>(0x48000400);
 inline GPIO_Regs *const GPIO_C_BASE = reinterpret_cast<GPIO_Regs *>(0x48000800);

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ limitations under the License.
 // a pinch valve would, which is why it's used for that purpose.
 //
 // The PSOL we're using is made by SMC pneumatics and is model number
-// PVQ31-6G-40-01.  You can find it described in the series catelog
+// PVQ31-6G-40-01.  You can find it described in the series catalog
 // available here: https://www.smcpneumatics.com/pdfs/PVQ.pdf
 //
 // On our board the solenoid output is connected to pin PA11 which
@@ -54,9 +54,8 @@ void HalApi::InitPSOL() {
   EnableClock(TIMER1_BASE);
 
   // Connect PA11 to timer 1
-  // The STM32 datasheet has a table (table 17) which shows
-  // which functions can be connected to each pin.  For
-  // PA11 we select function 1 to connect it to timer 1.
+  // [DS] table 17 shows which functions can be connected to each pin.
+  // For PA11 we select function 1 to connect it to timer 1.
   GPIO_PinAltFunc(GPIO_A_BASE, 11, 1);
 
   TimerRegs *tmr = TIMER1_BASE;
@@ -78,8 +77,7 @@ void HalApi::InitPSOL() {
   tmr->ccEnable = 0x1000;
 
   // For timer 1 we need to disable the main output enable
-  // (MOE) feature by setting bit 15 of the deadtime register.
-  // See section 26.3.16 of the reference manual.
+  // (MOE) feature by setting bit 15 of the deadtime register. [RM] 26.3.16
   tmr->deadTime = 0x8000;
 
   // Start with 0% duty cycle

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ limitations under the License.
 #include "stepper.h"
 #include "hal.h"
 #include "hal_stm32.h"
-#include <math.h>
-#include <string.h>
+#include <cmath>
+#include <cstring>
 
 // Static data members
 StepMotor StepMotor::motor_[StepMotor::kMaxMotors];
@@ -158,7 +158,7 @@ StepMtrErr StepMotor::GetParam(StepMtrParam param, uint32_t *value) {
  * handler.
  *
  * One positive is that you can daisy chain multiple stepper drivers
- * and commuicate with them all at once.  If you have N drivers then
+ * and communicate with them all at once.  If you have N drivers then
  * you would send N bytes all at once and bring the CS line high
  * between sets of N bytes.  The bits flow through the chain of
  * stepper drivers all connected together and the data is latched
@@ -187,7 +187,7 @@ void HalApi::StepperMotorInit() {
   // Configure the CS and reset pins as outputs.
   // pulled high.  I don't really use the reset pin,
   // I just want it to be high so I don't reset the
-  // part inadvertantly
+  // part inadvertently
   CS_High();
   GPIO_SetPin(GPIO_A_BASE, 9);
   GPIO_PinMode(GPIO_B_BASE, 6, GPIO_PinMode::OUT);
@@ -241,7 +241,7 @@ void HalApi::StepperMotorInit() {
   dma->channel[C3].config.htie = 0;
   dma->channel[C3].config.teie = 0;
   dma->channel[C3].config.dir =
-      static_cast<REG>(DmaChannelDir::PERIPHERAL_TO_MEM);
+      static_cast<uint32_t>(DmaChannelDir::PERIPHERAL_TO_MEM);
   dma->channel[C3].config.circular = 0;
   dma->channel[C3].config.perInc = 0;
   dma->channel[C3].config.memInc = 1;
@@ -255,7 +255,7 @@ void HalApi::StepperMotorInit() {
   dma->channel[C4].config.htie = 0;
   dma->channel[C4].config.teie = 0;
   dma->channel[C4].config.dir =
-      static_cast<REG>(DmaChannelDir::MEM_TO_PERIPHERAL);
+      static_cast<uint32_t>(DmaChannelDir::MEM_TO_PERIPHERAL);
   dma->channel[C4].config.circular = 0;
   dma->channel[C4].config.perInc = 0;
   dma->channel[C4].config.memInc = 1;
@@ -370,7 +370,7 @@ StepMtrErr StepMotor::GetMaxSpeed(float *ret) {
 //
 // NOTE - Setting a non-zero minimum speed doesn't mean
 // the motor can't stop, this is the minimum speed for
-// a move.  When you start a move, rathern than increase
+// a move.  When you start a move, rather than increase
 // linearly from 0, the stepper will jump to this speed
 // immediately, then ramp up from there.
 // This can help with vibration.
@@ -914,11 +914,11 @@ void StepMotor::ProbeChips() {
          sizeof(probe_buff));
   SendInitCmd(probe_buff, sizeof(probe_buff));
 
-  // The first N bytes of the returned array should be 0 and the rest should be
-  // the reset command.
+  // The first N bytes of the returned array should be 0 and the rest should
+  // be the reset command.
   total_motors_ = 0;
-  for (int i = 0; i < sizeof(probe_buff); i++) {
-    if (probe_buff[i] == 0x00)
+  for (unsigned char i : probe_buff) {
+    if (i == 0x00)
       total_motors_++;
     else
       break;

--- a/software/controller/lib/hal/uart_dma.h
+++ b/software/controller/lib/hal/uart_dma.h
@@ -1,3 +1,19 @@
+/* Copyright 2020-2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 #ifndef __UART_DMA
 #define __UART_DMA
 #include "hal_stm32_regs.h"
@@ -62,15 +78,15 @@ public:
 
   void init(int baud);
   // Returns true if DMA TX is in progress
-  bool isTxInProgress();
+  bool isTxInProgress() const;
   // Returns true if DMA RX is in progress
-  bool isRxInProgress();
+  bool isRxInProgress() const;
 
   // Sets up UART3 to transfer [length] characters from [buf]
   // Returns false if DMA transmission is in progress, does not
   // interrupt previous transmission.
   // Returns true if no transmission is in progress
-  bool startTX(const char *buf, uint32_t length);
+  bool startTX(char *buf, uint32_t length);
 
   uint32_t getRxBytesLeft();
 
@@ -83,7 +99,7 @@ public:
   // setup. Returns true if no reception is in progress and new reception
   // was setup.
 
-  bool startRX(const char *buf, uint32_t length, uint32_t timeout);
+  bool startRX(char *buf, uint32_t length, uint32_t timeout);
   void stopRX();
   void charMatchEnable();
 

--- a/software/controller/test/checksum/checksum_test.cpp
+++ b/software/controller/test/checksum/checksum_test.cpp
@@ -21,11 +21,15 @@ TEST(Checksum, KnownValues) {
 
 TEST(Checksum32, KnownValues) {
   EXPECT_EQ((uint32_t)0, soft_crc32(NULL, 0));
-  EXPECT_EQ((uint32_t)0, soft_crc32("", 0));
-  EXPECT_EQ((uint32_t)0xC808931C, soft_crc32("a", 1));
-  EXPECT_EQ((uint32_t)0x47A393F8, soft_crc32("abcde", 5));
-  EXPECT_EQ((uint32_t)0x9DBDD91C, soft_crc32("abcdef", 6));
-  EXPECT_EQ((uint32_t)0x321FBEF4, soft_crc32("abcdefgh", 8));
+  EXPECT_EQ((uint32_t)0, soft_crc32(reinterpret_cast<const uint8_t *>(""), 0));
+  EXPECT_EQ((uint32_t)0xC808931C,
+            soft_crc32(reinterpret_cast<const uint8_t *>("a"), 1));
+  EXPECT_EQ((uint32_t)0x47A393F8,
+            soft_crc32(reinterpret_cast<const uint8_t *>("abcde"), 5));
+  EXPECT_EQ((uint32_t)0x9DBDD91C,
+            soft_crc32(reinterpret_cast<const uint8_t *>("abcdef"), 6));
+  EXPECT_EQ((uint32_t)0x321FBEF4,
+            soft_crc32(reinterpret_cast<const uint8_t *>("abcdefgh"), 8));
 }
 
 TEST(Checksum, CheckBytes) {
@@ -92,7 +96,7 @@ TEST(Checksum, BitFlips) {
 TEST(Checksum32, BitFlips) {
   srand(0);
 
-  char data[32];
+  uint8_t data[32];
   memset(&data, '\0', sizeof(data));
 
   // Start lastChecksum at -1 because our first test will be checksum'ing the

--- a/software/controller/test/nvparams/nvparams_test.cpp
+++ b/software/controller/test/nvparams/nvparams_test.cpp
@@ -63,7 +63,7 @@ static void CompareParams(int16_t address, const Structure &ref) {
 }
 
 uint32_t ParamsCRC(Structure *params) {
-  char *ptr = reinterpret_cast<char *>(params);
+  uint8_t *ptr = reinterpret_cast<uint8_t *>(params);
   return soft_crc32(ptr + 4, sizeof(Structure) - 4);
 }
 
@@ -82,8 +82,8 @@ TEST(NVparams, FirstInitEver) {
   SCOPED_TRACE("Flip side check");
   CompareParams(static_cast<uint16_t>(Address::kFlip), ref_params);
 
-  // Increment count, then compute crc, this should get us in the state of flop
-  // and current params
+  // Increment count, then compute crc, this should get us in the state of
+  // flop and current params
   ref_params.count++;
   ref_params.crc = ParamsCRC(&ref_params);
   SCOPED_TRACE("Flop side check");
@@ -95,7 +95,8 @@ TEST(NVparams, FirstInitEver) {
 
 TEST(NVparams, Update) {
   Structure ref_params;
-  // We are reusing the resulting nv_params and eeprom state from previous test
+  // We are reusing the resulting nv_params and eeprom state from previous
+  // test
   nv_params.Get(0, &ref_params, sizeof(Structure));
   ref_params.last_settings.mode = VentMode::VentMode_PRESSURE_CONTROL;
 
@@ -425,7 +426,8 @@ TEST(NVparams, InitBothValid) {
   SCOPED_TRACE("nv_param_ check after Init");
   CompareParams(-1, valid_params);
 
-  // update those values in flip_params, the rest was kept in its previous state
+  // update those values in flip_params, the rest was kept in its previous
+  // state
   flip_params.count = valid_params.count;
   flip_params.power_cycles = valid_params.power_cycles;
   flip_params.crc = valid_params.crc;


### PR DESCRIPTION
Add a few more references to the reference manual and datasheet in the HAL code.

Do some housekeeping. Mostly fixing spelling in comments. Made some types more consistent.  Also replaced the `typedef *REG`'s with their standard types and moved the `volatile` keyword into `typedefs` on the structs.

Planning to make a couple more passes through the HAL, but figured it would be good to checkpoint since I don't have hardware to test on.

I can run `pio test -e native` and the tests pass, and I can do a `pio run -e stm32` and everything compiles (fails to link, but that was present before - #1032)