### PR TITLE
Stub out the functions necessary to get ./test.sh running again

### DIFF
--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -68,6 +68,8 @@ void I2C1_ER_ISR() { i2c1.I2CErrorHandler(); };
 void DMA2_CH6_ISR() { i2c1.DMAIntHandler(DMA_Chan::C6); };
 
 void DMA2_CH7_ISR() { i2c1.DMAIntHandler(DMA_Chan::C7); };
+#else
+I2C::Channel i2c1;
 #endif // BARE_STM32
 
 bool I2C::Channel::SendRequest(const Request &request) {

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -271,6 +271,8 @@ private:
 
 #ifdef BARE_STM32
 extern I2C::STM32Channel i2c1;
+#else
+extern I2C::Channel i2c1;
 #endif
 
 #endif // I2C_H

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include "hal.h"
+
 #if defined(BARE_STM32)
 
 // This file implements the interface to the Proportional Solenoid
@@ -30,7 +32,6 @@ limitations under the License.
 // can be driven by timer 1 channel 4.  We'll use that timer channel
 // to control the solenoid
 
-#include "hal.h"
 #include "hal_stm32.h"
 #include "vars.h"
 #include <algorithm>
@@ -112,4 +113,6 @@ void HalApi::PSOL_Value(float val) {
   tmr->compare[3] = static_cast<int>(duty);
 }
 
+#else
+void HalApi::PSOL_Value(float val) {}
 #endif

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -13,19 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#if defined(BARE_STM32)
-
 #include "stepper.h"
 #include "hal.h"
+
+StepMotor StepMotor::motor_[StepMotor::kMaxMotors];
+int StepMotor::total_motors_;
+
+#if defined(BARE_STM32)
+
 #include "hal_stm32.h"
 #include <cmath>
 #include <cstring>
 
 // Static data members
-StepMotor StepMotor::motor_[StepMotor::kMaxMotors];
 uint8_t StepMotor::dma_buff_[StepMotor::kMaxMotors];
 StepCommState StepMotor::coms_state_ = StepCommState::IDLE;
-int StepMotor::total_motors_;
 
 // This array holds the length of each parameter in units of
 // bytes, rounded up to the nearest byte.  This info is based
@@ -84,8 +86,6 @@ static const int ustep_per_step_ = 128;
 // These functions raise and lower the chip select pin
 inline void CS_High() { GPIO_SetPin(GPIO_B_BASE, 6); }
 inline void CS_Low() { GPIO_ClrPin(GPIO_B_BASE, 6); }
-
-StepMotor::StepMotor() = default;
 
 StepMtrErr StepMotor::SetParam(StepMtrParam param, uint32_t value) {
   uint8_t p = static_cast<uint8_t>(param);
@@ -930,4 +930,20 @@ void StepMotor::ProbeChips() {
     total_motors_ = 0;
 }
 
+#else
+StepMtrErr StepMotor::HardDisable() { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::SetAmpAll(float amp) { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::SetMaxSpeed(float dps) { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::SetAccel(float acc) { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::MoveRel(float deg) { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::ClearPosition() { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::GotoPos(float deg) { return StepMtrErr::OK; }
+
+StepMtrErr StepMotor::HardStop() { return StepMtrErr::OK; }
 #endif

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -171,7 +171,7 @@ class StepMotor {
   static int total_motors_;
 
 public:
-  StepMotor();
+  StepMotor() = default;
 
   // Called from HAL at startup
   static void OneTimeInit();

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -9,6 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 [platformio]
 boards_dir = platformio/build_config
+default_envs = stm32
 
 # Scope for variables that we reference below, but which don't have meaning to
 # platformio.

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -8,11 +8,6 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 [platformio]
-include_dir = include
-src_dir = .
-test_dir = test
-lib_dir = lib
-default_envs = stm32
 boards_dir = platformio/build_config
 
 # Scope for variables that we reference below, but which don't have meaning to

--- a/software/controller/src/pure_virtual.cpp
+++ b/software/controller/src/pure_virtual.cpp
@@ -27,4 +27,6 @@ limitations under the License.
 // header in the putative library from each file with a pure virtual function.
 // We'd probably also need to remove the dependency on hal, so this could be
 // used from libraries that don't link with hal.
+#ifdef BARE_STM32
 extern "C" void __cxa_pure_virtual() { Hal.reset_device(); }
+#endif

--- a/software/controller/src_test/main.cpp
+++ b/software/controller/src_test/main.cpp
@@ -1,6 +1,5 @@
 #include "debug.h"
 #include "hal.h"
-#include "hal_stm32.h"
 #include "uart_dma.h"
 #include <string.h>
 

--- a/software/controller/test/psol/psol_test.cpp
+++ b/software/controller/test/psol/psol_test.cpp
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
 #include "hal.h"
+#include "gtest/gtest.h"
 
 // Not really a test, just silencing code coverage warning for native build
 TEST(PSol, TestStubs) { PSOL_Value(0.0); }

--- a/software/controller/test/psol/psol_test.cpp
+++ b/software/controller/test/psol/psol_test.cpp
@@ -14,7 +14,7 @@ limitations under the License.
 */
 
 #include "gtest/gtest.h"
-#include <hal.h>
+#include "hal.h"
 
 // Not really a test, just silencing code coverage warning for native build
 TEST(PSol, TestStubs) { PSOL_Value(0.0); }

--- a/software/controller/test/psol/psol_test.cpp
+++ b/software/controller/test/psol/psol_test.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "gtest/gtest.h"
+#include <hal.h>
+
+// Not really a test, just silencing code coverage warning for native build
+TEST(PSol, TestStubs) { PSOL_Value(0.0); }

--- a/software/controller/test/stepper/stepper_test.cpp
+++ b/software/controller/test/stepper/stepper_test.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "gtest/gtest.h"
+#include <stepper.h>
+
+// Not really tests, just silencing code coverage warning for native build
+TEST(Stepper, TestStubs) {
+  StepMotor step_motor;
+  EXPECT_EQ(StepMtrErr::OK, step_motor.HardDisable());
+  EXPECT_EQ(StepMtrErr::OK, step_motor.SetAmpAll(0.0));
+  EXPECT_EQ(StepMtrErr::OK, step_motor.SetMaxSpeed(0.0));
+  EXPECT_EQ(StepMtrErr::OK, step_motor.SetAccel(0.0));
+  EXPECT_EQ(StepMtrErr::OK, step_motor.MoveRel(0.0));
+  EXPECT_EQ(StepMtrErr::OK, step_motor.ClearPosition());
+  EXPECT_EQ(StepMtrErr::OK, step_motor.GotoPos(0.0));
+  EXPECT_EQ(StepMtrErr::OK, step_motor.HardStop());
+}

--- a/software/controller/test/stepper/stepper_test.cpp
+++ b/software/controller/test/stepper/stepper_test.cpp
@@ -14,7 +14,7 @@ limitations under the License.
 */
 
 #include "gtest/gtest.h"
-#include <stepper.h>
+#include "stepper.h"
 
 // Not really tests, just silencing code coverage warning for native build
 TEST(Stepper, TestStubs) {

--- a/software/controller/test/stepper/stepper_test.cpp
+++ b/software/controller/test/stepper/stepper_test.cpp
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
 #include "stepper.h"
+#include "gtest/gtest.h"
 
 // Not really tests, just silencing code coverage warning for native build
 TEST(Stepper, TestStubs) {


### PR DESCRIPTION
Fixes #1032 

`./test.sh` is now running. It fails `pio check -e `clang-tidy`, but that error was there in `master`.

I was getting a multiple definition of `main`, I think because it was linking the stm32 startup code.

## Testing
`pio test -e native` - PASSES
`pio run -e stm32` - BUILD PASSES
`pio run -e integration-test - BUILD PASSES
`pio run -e stm32-test - BUILD FAILS (errors linking `dmaUART)

The `stm32-test` environment is marked experimental DMA so it was probably failing to build before. Logged as issue #1046