### PR TITLE
Uflow tapping and mounting instructions

### DIFF
--- a/manufacturing/internals/PSOL/README.md
+++ b/manufacturing/internals/PSOL/README.md
@@ -15,10 +15,10 @@ BEFORE purchasing any parts.**
 | Item  | Quantity | Manufacturer   | Part #              | Price (USD)  | Sources[*][ppg]| Notes |
 | ----- |---------:| -------------- | ------------------- | ------------:|:--------------:| ----- |
 |**A1** | 1        | SMC Pneumatics | PVQ31-6G-40-01N     | 96.10        | [Sm][a1smc]    | Proportional solenoid |
-|**A2** | 2        | McMaster-Carr  | 5121K391            | 5.58 / 10    | [C][a2mcmc]    | 1/8 NPT x 1/4" ID barbed adapter **with `[A1]` only** |
-|**A3** |(1)       | Uflow          | IBV19M              | 87.00        | [U][a3uflow]   | Proportional solenoid **alternate for `[A1]`** |
-|**A4** |(2)       | McMaster-Carr  | 1786N249            | 8.16         | [C][a4mcmc]    | 1/8 BSPT x 1/4 NTP brass threaded pipe fitting **with `[A3]` only** |
-|**A5** |(2)       | McMaster-Carr  | 5121K451            | 5.78 / 10    | [C][a5mcmc]    | 1/4 NPT x 1/4" ID barbed adapter **with [A3] only** |
+|**A2** | 2        | McMaster-Carr  | 5121K391            | 5.58 / 10    | [C][a2mcmc]    | 1/8 NPT x 1/4" ID barbed adapter, **only with `[A1]`** |
+|**A3** |(1)       | Uflow          | IBV19M              | 87.00        | [U][a3uflow]   | Proportional solenoid, **alternate for `[A1]`** |
+|**A4** |(2)       | McMaster-Carr  | 1786N249            | 8.16         | [C][a4mcmc]    | 1/8 BSPT x 1/4 NTP brass threaded pipe fitting,  **only with `[A3]`** |
+|**A5** |(2)       | McMaster-Carr  | 5121K451            | 5.78 / 10    | [C][a5mcmc]    | 1/4 NPT x 1/4" ID barbed adapter, **only with `[A3]`** |
 |**A6** | 2        | McMaster-Carr  | 92095A182           | 8.38 / 100   | [C][a6mcmc]    | M3 screws, 10mm: for mounting to tray |
 |**A7** | 2        | McMaster-Carr  | 91116A120           | 2.77 / 100   | [C][a7mcmc]    | M3 washers, 9mm OD: for mounting to tray |
 
@@ -34,9 +34,31 @@ BEFORE purchasing any parts.**
 
 **Note: Please see general advice in the [manufacturing methods guide](../../methods).**
 
-Note that mounting the Uflow solenoid may require tapping of M3 threads in the aluminium manifold.
+Sub-assembly steps will differ depending on which proportional solenoid is used.
 
-**ATTENTION: tools for tapping not listed here.**
+### Uflow IBV19M
+
+Follow this section only if you are using the Uflow IBV19M `[A3]` solenoid.
+
+You will need to create two M3 holes in opposite corners of the aluminium manifold as pictured:
+![](images/uflow_tapped.jpg)
+
+You will first want to drill 2.5mm holes about 5mm deep. Do so with the PSOL secured in a drill press at 90 degrees,
+and with depth stop set precisely so as not to bore a hole into the pneumatics channel thus creating a leak.  If you do
+not have a 2.5mm drill bit, the closest SAE bits are 3/32" or 7/64".
+
+Next you will have to tap M3x0.5 threads into those holes. Do so slowly, by hand. You can probably use the bottoming
+tap from a kit like [this](https://www.amazon.com/uxcell-Metric-Straight-Flutes-Bottoming/dp/B00VGEG5GM). However, for
+a professional tapping experience, [this kit](https://www.mcmaster.com/2608A13/) would be preferable, which  includes
+both the drill bits and the proper taps.
+
+You will need to drill 3.2mm holes in the appropriate positions on the pneumatics tray acrylic sheet, as those
+provided in CAD drawings are positioned for the SMC solenoid.
+
+You will also need to install the BSPT pipe adapters `[A4]` and the NPT tubing adapters `[A5]`. Remember to use
+PTFE tape on the threads.
+
+### General mounting instructions
 
 Mounts to acrylic with 2x:
 * M3x10 screws

--- a/manufacturing/internals/PSOL/README.md
+++ b/manufacturing/internals/PSOL/README.md
@@ -41,11 +41,17 @@ Sub-assembly steps will differ depending on which proportional solenoid is used.
 Follow this section only if you are using the Uflow IBV19M `[A3]` solenoid.
 
 You will need to create two M3 holes in opposite corners of the aluminium manifold as pictured:
-![](images/uflow_tapped.jpg)
 
-You will first want to drill 2.5mm holes about 5mm deep. Do so with the PSOL secured in a drill press at 90 degrees,
-and with depth stop set precisely so as not to bore a hole into the pneumatics channel thus creating a leak.  If you do
-not have a 2.5mm drill bit, the closest SAE bits are 3/32" or 7/64".
+| Marked | Tapped |
+|:-------------------------:|:-------------------------:|
+| ![](images/uflow_tapping_1.jpg) | ![](images/uflow_tapping_2.jpg) |
+
+You will first want to drill 2.5mm holes about 5mm deep. Mark out the positions with a scribe and punch holes to help
+guide the drill.
+
+Drill with the PSOL secured in a drill press at 90 degrees, and with depth stop set precisely so as not to bore a hole
+into the pneumatics channel thus creating a leak. If you do not have a 2.5mm drill bit, the closest SAE bits are
+3/32" or 7/64".
 
 Next you will have to tap M3x0.5 threads into those holes. Do so slowly, by hand. You can probably use the bottoming
 tap from a kit like [this](https://www.amazon.com/uxcell-Metric-Straight-Flutes-Bottoming/dp/B00VGEG5GM). However, for
@@ -66,4 +72,4 @@ Mounts to acrylic with 2x:
 
 PSOL sub-assembly CAD: [.iam](PSOL.iam)
 
->**TODO: make subassembly of Uflow PSOL and add more details**
+>**TODO: make CAD subassembly of Uflow PSOL and add more details**

--- a/manufacturing/internals/PSOL/images/uflow_tapped.jpg
+++ b/manufacturing/internals/PSOL/images/uflow_tapped.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6a7120651cb3dc8723e38f66646a37e2593722fcb328678db1bae25f3a02dc0
-size 101351

--- a/manufacturing/internals/PSOL/images/uflow_tapped.jpg
+++ b/manufacturing/internals/PSOL/images/uflow_tapped.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6a7120651cb3dc8723e38f66646a37e2593722fcb328678db1bae25f3a02dc0
+size 101351

--- a/manufacturing/internals/PSOL/images/uflow_tapping_1.jpg
+++ b/manufacturing/internals/PSOL/images/uflow_tapping_1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e59d6d1c6da2ec48bfdf3826ffd5b4b339aa761892cec8c413399e99961c49e
+size 188805

--- a/manufacturing/internals/PSOL/images/uflow_tapping_2.jpg
+++ b/manufacturing/internals/PSOL/images/uflow_tapping_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3494dd7bea8d1384d8647c5e6a544d5a989d70403a5cf1c3b8f3559fd055d819
+size 260398


### PR DESCRIPTION
Added instructions for how to modify the UFlow PSOL for mounting using M3 screws. This may later have to be split off into a separate page when we have CAD of this configuration, but again as a stopgap measure at least this provides the essential information so that if someone reads this, they should not find themselves at a loss.

Updates #1055 