### PR TITLE
Adding PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes #(issue)
+
+Updates #(issue)
+
+# General checklist:
+
+- [ ] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
+- [ ] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
+- [ ] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
+- [ ] All new content is linked, easily discoverable, does not require too many clicks
+- [ ] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
+- [ ] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
+- [ ] I have tagged relevant reviewers
+
+## Code checklist:
+
+- [ ] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
+- [ ] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
+- [ ] I performed a clean build and verified that there were no warnings
+- [ ] I ran our static analysis tools and verified there were no warnings
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
The goal is to have a template that would work for all teams, including software, electrical, mechanical -- even regulatory and QA.

Some of the items are super obvious, to help out github newbies.

The first section should be general and apply to all. The there is a software-only section. We may have other specialized sections later on, but I thought it best to not have multiple templates, since we want to all be sort of on the same page with how we operate.

There may be some mention like "mind the requirements" later on, or something else if we have RDM, but we can add those once the relevant stuff is in repo and the expectation becomes reasonable.

Fixes #1013 