### PR TITLE
Explicitly install pio native platform for controller tests to run properly in CI

### DIFF
--- a/.circleci/controller_tests_Dockerfile
+++ b/.circleci/controller_tests_Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
     apt-get install build-essential python3-pip lcov git curl libtinfo5 -y && \
     pip3 install -U pip && \
     pip3 install platformio codecov && \
-    platformio update
+    platformio update && \
+    platformio platform install native
 
 WORKDIR /root/Ventilator
 COPY . ./


### PR DESCRIPTION
# Description

Explicitly install platformio "native" platform to get around a bug introduced in platformio 5.1.1 (see #1089 for a link to the pio issue)
Fixes #1089 : controller tests now pass on CI

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [ ] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [ ] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [ ] I performed a clean build and verified that there were no warnings
- [ ] I ran our static analysis tools and verified there were no warnings
- [ ] Any dependent changes have been merged and published in downstream modules
