### PR TITLE
Replace trace specific debugvars by trace subcommands

### DIFF
--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -122,6 +122,7 @@ if [ "$1" == "--test" ]; then
   INTEGRATION_TEST_H=stepper_test.h TEST_PARAM_1=0 TEST_PARAM_2=90.0f pio run -e integration-test
   INTEGRATION_TEST_H=pinch_valve_test.h TEST_PARAM_1=0 pio run -e integration-test
   INTEGRATION_TEST_H=psol_test.h pio run -e integration-test
+  INTEGRATION_TEST_H=eeprom_test.h pio run -e integration-test
 
   # Make sure controller builds for target platform.
   pio run

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -84,6 +84,16 @@ public:
 // does:
 //  kFlushTrace - Used to disable the trace and flush the trace buffer
 //  kDownloadTrace - Used to read data from the buffer
+//  kStartTrace - Used to start recording in the trace buffer
+//  kGetTraceVar followed by var index (1 byte) - Used to get trace variables ID
+//  kSetTraceVar followed by var index (1 byte) and variable ID (2 bytes) - Used
+//    to set traced variable id
+//  kGetTracePeriod - Used to get the trace period
+//  kSetTracePeriod followed by desired trace period (4 bytes) - Used to set the
+//    trace period
+//  kCountTraceSamples - Used to get the number of samples
+//    currently in the trace buffer
+
 class TraceHandler : public Handler {
 public:
   explicit TraceHandler(Trace *trace) : trace_(trace){};

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -91,6 +91,8 @@ public:
 
 private:
   ErrorCode ReadTraceBuffer(Context *context);
+  ErrorCode SetTraceVar(Context *context);
+  ErrorCode GetTraceVar(Context *context);
   Trace *trace_{nullptr};
 };
 

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -82,22 +82,33 @@ public:
 //
 // Data passed to the command is a single byte which defines what the command
 // does:
-//  kFlushTrace - Used to disable the trace and flush the trace buffer
-//  kDownloadTrace - Used to read data from the buffer
-//  kStartTrace - Used to start recording in the trace buffer
-//  kGetTraceVar followed by var index (1 byte) - Used to get trace variables ID
-//  kSetTraceVar followed by var index (1 byte) and variable ID (2 bytes) - Used
-//    to set traced variable id
-//  kGetTracePeriod - Used to get the trace period
-//  kSetTracePeriod followed by desired trace period (4 bytes) - Used to set the
+//  kFlush - Used to disable the trace and flush the trace buffer
+//  kDownload - Used to read data from the buffer
+//  kStart - Used to start recording in the trace buffer
+//  kGetVarId followed by var index (1 byte) - Used to get trace variables ID
+//  kSetVarId followed by var index (1 byte) and variable ID (2 bytes) - Used to
+//    set traced variable id
+//  kGetPeriod - Used to get the trace period
+//  kSetPeriod followed by desired trace period (4 bytes) - Used to set the
 //    trace period
-//  kCountTraceSamples - Used to get the number of samples
-//    currently in the trace buffer
+//  kCountSamples - Used to get the number of samples currently in the trace
+//    buffer
 
 class TraceHandler : public Handler {
 public:
   explicit TraceHandler(Trace *trace) : trace_(trace){};
   ErrorCode Process(Context *context) override;
+
+  enum class Subcommand {
+    kFlush = 0x00,    // disable and flush the trace buffer
+    kDownload = 0x01, // download data from the trace buffer
+    kStart = 0x02,    // start tracing data
+    kGetVarId = 0x03, // get traced variable id
+    kSetVarId = 0x04, // set traced variable id
+    kGetPeriod = 0x05,
+    kSetPeriod = 0x06,
+    kCountSamples = 0x07, // get number of samples in the trace buffer
+  };
 
 private:
   ErrorCode ReadTraceBuffer(Context *context);
@@ -112,7 +123,7 @@ private:
 // which defines what the command does and the structure of its data.
 //
 // Sub-commands:
-//  kVarInfo - Used to read info about a variable.  The debug interface calls
+//  kGetInfo - Used to read info about a variable.  The debug interface calls
 //             this repeatedly on startup to enumerate the variables currently
 //             supported by the code.  This way new debug variables can be added
 //             on the fly without modifying the Python code to match.
@@ -122,14 +133,20 @@ private:
 //             the variable.
 //             See the code below for details of the output format
 //
-//  kGetVar - Read the variables value.
+//  kGet - Read the variables value.
 //
-//  kSetVar - Set the variables value.
+//  kSet - Set the variables value.
 //
 class VarHandler : public Handler {
 public:
   VarHandler() = default;
   ErrorCode Process(Context *context) override;
+
+  enum class Subcommand {
+    kGetInfo = 0x00, // get variable info (name, type, help string)
+    kGet = 0x01,     // get variable value
+    kSet = 0x02,     // set variable value
+  };
 
 private:
   // Return info about one of the variables. The 16-bit variable ID is passed
@@ -150,15 +167,20 @@ private:
 // which defines what the command does and the structure of its data.
 //
 // Sub-commands:
-//  kEepromRead, followed by a 16 bits address and a 16 bits length :
-//                Used to read length data bytes at given address in EEPROM
+//  kRead, followed by a 16 bits address and a 16 bits length :
+//          Used to read length data bytes at given address in EEPROM
 //
-//  kEepromWrite, followed by a 16 bits address and some data bytes :
-//                Used to write given data at given address
+//  kWrite, followed by a 16 bits address and some data bytes :
+//          Used to write given data at given address
 class EepromHandler : public Handler {
 public:
   explicit EepromHandler(I2Ceeprom *eeprom) : eeprom_(eeprom){};
   ErrorCode Process(Context *context) override;
+
+  enum class Subcommand {
+    kRead = 0x00,
+    kWrite = 0x01,
+  };
 
 private:
   ErrorCode Read(uint16_t address, Context *context);

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -99,7 +99,7 @@ public:
   explicit TraceHandler(Trace *trace) : trace_(trace){};
   ErrorCode Process(Context *context) override;
 
-  enum class Subcommand {
+  enum class Subcommand : uint8_t {
     kFlush = 0x00,    // disable and flush the trace buffer
     kDownload = 0x01, // download data from the trace buffer
     kStart = 0x02,    // start tracing data
@@ -142,7 +142,7 @@ public:
   VarHandler() = default;
   ErrorCode Process(Context *context) override;
 
-  enum class Subcommand {
+  enum class Subcommand : uint8_t {
     kGetInfo = 0x00, // get variable info (name, type, help string)
     kGet = 0x01,     // get variable value
     kSet = 0x02,     // set variable value
@@ -177,7 +177,7 @@ public:
   explicit EepromHandler(I2Ceeprom *eeprom) : eeprom_(eeprom){};
   ErrorCode Process(Context *context) override;
 
-  enum class Subcommand {
+  enum class Subcommand : uint8_t {
     kRead = 0x00,
     kWrite = 0x01,
   };

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -84,22 +84,6 @@ public:
   }
 };
 
-enum class Subcommand {
-  kFlushTrace = 0x00,        // disable and flush the trace buffer
-  kDownloadTrace = 0x01,     // download the trace buffer
-  kStartTrace = 0x02,        // start tracing data
-  kGetTraceVar = 0x03,       // get traced variable id
-  kSetTraceVar = 0x04,       // set traced variable id
-  kGetTracePeriod = 0x05,    // get trace period
-  kSetTracePeriod = 0x06,    // set trace period
-  kCountTraceSamples = 0x07, // get number of samples in the trace buffer
-  kVarInfo = 0x00,           // get variable info (name, type, help string)
-  kGetVar = 0x01,            // get variable value
-  kSetVar = 0x02,            // set variable value
-  kEepromRead = 0x00,        // read value in EEPROM
-  kEepromWrite = 0x01,       // write value in EEPROM
-};
-
 } // namespace Command
 
 } // namespace Debug

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -90,7 +90,7 @@ enum class Subcommand {
   kStartTrace = 0x02,        // start tracing data
   kGetTraceVar = 0x03,       // get traced variable id
   kSetTraceVar = 0x04,       // set traced variable id
-  kGetTracePeriod = 0x05,    // set trace period
+  kGetTracePeriod = 0x05,    // get trace period
   kSetTracePeriod = 0x06,    // set trace period
   kCountTraceSamples = 0x07, // get number of samples in the trace buffer
   kVarInfo = 0x00,           // get variable info (name, type, help string)

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -85,13 +85,19 @@ public:
 };
 
 enum class Subcommand {
-  kFlushTrace = 0x00,    // disable and flush the trace
-  kDownloadTrace = 0x01, // download the trace buffer
-  kVarInfo = 0x00,       // get variable info (name, type, help string)
-  kGetVar = 0x01,        // get variable value
-  kSetVar = 0x02,        // set variable value
-  kEepromRead = 0x00,    // read value in EEPROM
-  kEepromWrite = 0x01,   // write value in EEPROM
+  kFlushTrace = 0x00,        // disable and flush the trace buffer
+  kDownloadTrace = 0x01,     // download the trace buffer
+  kStartTrace = 0x02,        // start tracing data
+  kGetTraceVar = 0x03,       // get traced variable id
+  kSetTraceVar = 0x04,       // set traced variable id
+  kGetTracePeriod = 0x05,    // set trace period
+  kSetTracePeriod = 0x06,    // set trace period
+  kCountTraceSamples = 0x07, // get number of samples in the trace buffer
+  kVarInfo = 0x00,           // get variable info (name, type, help string)
+  kGetVar = 0x01,            // get variable value
+  kSetVar = 0x02,            // set variable value
+  kEepromRead = 0x00,        // read value in EEPROM
+  kEepromWrite = 0x01,       // write value in EEPROM
 };
 
 } // namespace Command

--- a/software/controller/lib/debug/eeprom_cmd.cpp
+++ b/software/controller/lib/debug/eeprom_cmd.cpp
@@ -27,10 +27,10 @@ ErrorCode EepromHandler::Process(Context *context) {
 
   // Process subcommand
   switch (context->request[0]) {
-  case static_cast<uint8_t>(Subcommand::kEepromRead):
+  case static_cast<uint8_t>(Subcommand::kRead):
     return Read(address, context);
 
-  case static_cast<uint8_t>(Subcommand::kEepromWrite):
+  case static_cast<uint8_t>(Subcommand::kWrite):
     return Write(address, context);
 
   default:

--- a/software/controller/lib/debug/eeprom_cmd.cpp
+++ b/software/controller/lib/debug/eeprom_cmd.cpp
@@ -25,12 +25,14 @@ ErrorCode EepromHandler::Process(Context *context) {
   // Whatever the subcommand, bytes 1 and 2 are the address
   uint16_t address = u8_to_u16(&context->request[1]);
 
+  Subcommand subcommand{context->request[0]};
+
   // Process subcommand
-  switch (context->request[0]) {
-  case static_cast<uint8_t>(Subcommand::kRead):
+  switch (subcommand) {
+  case Subcommand::kRead:
     return Read(address, context);
 
-  case static_cast<uint8_t>(Subcommand::kWrite):
+  case Subcommand::kWrite:
     return Write(address, context);
 
   default:

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -1,0 +1,99 @@
+/* Copyright 2020-2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "trace.h"
+
+namespace Debug {
+
+// (Re-)Start the trace
+void Trace::Start() {
+  if (!running_) {
+    trace_buffer_.Flush();
+  }
+  running_ = true;
+}
+
+// Sample all trace variables every "period" calls
+void Trace::MaybeSample() {
+  if (!running_)
+    return;
+
+  if (cycles_count_ == 0) {
+    if (!SampleAllVars()) {
+      // Trace buffer is full, stop tracing.
+      Stop();
+    }
+  }
+
+  ++cycles_count_;
+  if (cycles_count_ >= period_)
+    cycles_count_ = 0;
+}
+
+bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
+  if (index >= kMaxTraceVars) {
+    return false;
+  }
+  traced_vars_[index] = DebugVar::FindVar(id);
+  // like in the SetTraceVarId<int index> template, we need to flush the buffer
+  // when the set of traced variables change.
+  trace_buffer_.Flush();
+  return true;
+}
+
+int16_t Trace::GetTracedVarId(uint8_t index) {
+  if (index >= kMaxTraceVars) {
+    return -1;
+  }
+  return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
+}
+
+[[nodiscard]] bool
+Trace::GetNextTraceRecord(std::array<uint32_t, kMaxTraceVars> *record,
+                          size_t *count) {
+  // Grab one sample with interrupts disabled.
+  // There's a chance the trace is still running, so we could get interrupted
+  // by the high priority thread that adds to the buffer.
+  // I want to make sure I read a full sample without being interrupted.
+  *count = 0;
+  BlockInterrupts block;
+  for (auto *var : traced_vars_) {
+    if (!var)
+      continue;
+    std::optional<uint32_t> dat = trace_buffer_.Get();
+    if (!dat)
+      return false;
+    (*record)[(*count)++] = *dat;
+  }
+  return true;
+}
+
+bool Trace::SampleAllVars() {
+  // If there are no enabled trace variables, or if there isn't enough space
+  // in the buffer for a full sample, then signal to stop the trace.
+  if (trace_buffer_.FreeCount() < GetNumActiveVars()) {
+    return false;
+  }
+  // Sample each enabled variable and store the result to the buffer.
+  for (auto *var : traced_vars_) {
+    if (!var)
+      continue;
+    // Can't fail as we've already checked for sufficient space above.
+    (void)trace_buffer_.Put(var->GetValue());
+  }
+  return true;
+}
+
+} // namespace Debug

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -95,8 +95,24 @@ public:
     trace_buffer_.Flush();
   }
 
+  bool SetTracedVarId(uint8_t index, uint16_t id) {
+    if (index >= kMaxTraceVars) {
+      return false;
+    }
+    traced_vars_[index] = DebugVar::FindVar(id);
+    trace_buffer_.Flush();
+    return true;
+  }
+
   template <int index> int32_t GetTracedVarId() {
     static_assert(index >= 0 && index < kMaxTraceVars);
+    return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
+  }
+
+  int16_t GetTracedVarId(uint8_t index) {
+    if (index >= kMaxTraceVars) {
+      return -1;
+    }
     return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
   }
 

--- a/software/controller/lib/debug/trace_cmd.cpp
+++ b/software/controller/lib/debug/trace_cmd.cpp
@@ -25,11 +25,12 @@ ErrorCode TraceHandler::Process(Context *context) {
   if (context->request_length < 1)
     return ErrorCode::kMissingData;
 
-  switch (context->request[0]) {
+  Subcommand subcommand{context->request[0]};
 
+  switch (subcommand) {
   // Sub-command kFlushTrace is used to flush the trace buffer
   // It also disables the trace
-  case static_cast<uint8_t>(Subcommand::kFlush): {
+  case Subcommand::kFlush: {
     trace_->Stop();
     context->response_length = 0;
     *(context->processed) = true;
@@ -37,22 +38,22 @@ ErrorCode TraceHandler::Process(Context *context) {
   }
 
   // Sub-command kDownloadTrace is used to read data from the buffer
-  case static_cast<uint8_t>(Subcommand::kDownload):
+  case Subcommand::kDownload:
     return ReadTraceBuffer(context);
 
-  case static_cast<uint8_t>(Subcommand::kStart):
+  case Subcommand::kStart:
     trace_->Start();
     context->response_length = 0;
     *(context->processed) = true;
     return ErrorCode::kNone;
 
-  case static_cast<uint8_t>(Subcommand::kGetVarId):
+  case Subcommand::kGetVarId:
     return GetTraceVar(context);
 
-  case static_cast<uint8_t>(Subcommand::kSetVarId):
+  case Subcommand::kSetVarId:
     return SetTraceVar(context);
 
-  case static_cast<uint8_t>(Subcommand::kGetPeriod):
+  case Subcommand::kGetPeriod:
     // response (trace period) is 32 bits (4 bytes) long
     if (context->max_response_length < 4)
       return ErrorCode::kNoMemory;
@@ -61,7 +62,7 @@ ErrorCode TraceHandler::Process(Context *context) {
     *(context->processed) = true;
     return ErrorCode::kNone;
 
-  case static_cast<uint8_t>(Subcommand::kSetPeriod):
+  case Subcommand::kSetPeriod:
     // trace period is a 32 bits int, meaning the request (including subcommand)
     // is 5 bytes long
     if (context->request_length < 5)
@@ -71,7 +72,7 @@ ErrorCode TraceHandler::Process(Context *context) {
     *(context->processed) = true;
     return ErrorCode::kNone;
 
-  case static_cast<uint8_t>(Subcommand::kCountSamples):
+  case Subcommand::kCountSamples:
     // response (num samples) is 4 bytes long, make sure I have enough room
     if (context->max_response_length < 4)
       return ErrorCode::kNoMemory;

--- a/software/controller/lib/debug/trace_cmd.cpp
+++ b/software/controller/lib/debug/trace_cmd.cpp
@@ -29,7 +29,7 @@ ErrorCode TraceHandler::Process(Context *context) {
 
   // Sub-command kFlushTrace is used to flush the trace buffer
   // It also disables the trace
-  case static_cast<uint8_t>(Subcommand::kFlushTrace): {
+  case static_cast<uint8_t>(Subcommand::kFlush): {
     trace_->Stop();
     context->response_length = 0;
     *(context->processed) = true;
@@ -37,22 +37,22 @@ ErrorCode TraceHandler::Process(Context *context) {
   }
 
   // Sub-command kDownloadTrace is used to read data from the buffer
-  case static_cast<uint8_t>(Subcommand::kDownloadTrace):
+  case static_cast<uint8_t>(Subcommand::kDownload):
     return ReadTraceBuffer(context);
 
-  case static_cast<uint8_t>(Subcommand::kStartTrace):
+  case static_cast<uint8_t>(Subcommand::kStart):
     trace_->Start();
     context->response_length = 0;
     *(context->processed) = true;
     return ErrorCode::kNone;
 
-  case static_cast<uint8_t>(Subcommand::kGetTraceVar):
+  case static_cast<uint8_t>(Subcommand::kGetVarId):
     return GetTraceVar(context);
 
-  case static_cast<uint8_t>(Subcommand::kSetTraceVar):
+  case static_cast<uint8_t>(Subcommand::kSetVarId):
     return SetTraceVar(context);
 
-  case static_cast<uint8_t>(Subcommand::kGetTracePeriod):
+  case static_cast<uint8_t>(Subcommand::kGetPeriod):
     // response (trace period) is 32 bits (4 bytes) long
     if (context->max_response_length < 4)
       return ErrorCode::kNoMemory;
@@ -61,7 +61,7 @@ ErrorCode TraceHandler::Process(Context *context) {
     *(context->processed) = true;
     return ErrorCode::kNone;
 
-  case static_cast<uint8_t>(Subcommand::kSetTracePeriod):
+  case static_cast<uint8_t>(Subcommand::kSetPeriod):
     // trace period is a 32 bits int, meaning the request (including subcommand)
     // is 5 bytes long
     if (context->request_length < 5)
@@ -71,7 +71,7 @@ ErrorCode TraceHandler::Process(Context *context) {
     *(context->processed) = true;
     return ErrorCode::kNone;
 
-  case static_cast<uint8_t>(Subcommand::kCountTraceSamples):
+  case static_cast<uint8_t>(Subcommand::kCountSamples):
     // response (num samples) is 4 bytes long, make sure I have enough room
     if (context->max_response_length < 4)
       return ErrorCode::kNoMemory;

--- a/software/controller/lib/debug/trace_cmd.cpp
+++ b/software/controller/lib/debug/trace_cmd.cpp
@@ -40,6 +40,47 @@ ErrorCode TraceHandler::Process(Context *context) {
   case static_cast<uint8_t>(Subcommand::kDownloadTrace):
     return ReadTraceBuffer(context);
 
+  case static_cast<uint8_t>(Subcommand::kStartTrace):
+    trace_->Start();
+    context->response_length = 0;
+    *(context->processed) = true;
+    return ErrorCode::kNone;
+
+  case static_cast<uint8_t>(Subcommand::kGetTraceVar):
+    return GetTraceVar(context);
+
+  case static_cast<uint8_t>(Subcommand::kSetTraceVar):
+    return SetTraceVar(context);
+
+  case static_cast<uint8_t>(Subcommand::kGetTracePeriod):
+    // response (trace period) is 32 bits (4 bytes) long
+    if (context->max_response_length < 4)
+      return ErrorCode::kNoMemory;
+    u32_to_u8(trace_->GetPeriod(), context->response);
+    context->response_length = 4;
+    *(context->processed) = true;
+    return ErrorCode::kNone;
+
+  case static_cast<uint8_t>(Subcommand::kSetTracePeriod):
+    // trace period is a 32 bits int, meaning the request (including subcommand)
+    // is 5 bytes long
+    if (context->request_length < 5)
+      return ErrorCode::kMissingData;
+    trace_->SetPeriod(u8_to_u32(&(context->request[1])));
+    context->response_length = 0;
+    *(context->processed) = true;
+    return ErrorCode::kNone;
+
+  case static_cast<uint8_t>(Subcommand::kCountTraceSamples):
+    // response (num samples) is 4 bytes long, make sure I have enough room
+    if (context->max_response_length < 4)
+      return ErrorCode::kNoMemory;
+    u32_to_u8(static_cast<uint32_t>(trace_->GetNumSamples()),
+              context->response);
+    context->response_length = 4;
+    *(context->processed) = true;
+    return ErrorCode::kNone;
+
   default:
     return ErrorCode::kInvalidData;
   }
@@ -90,6 +131,40 @@ ErrorCode TraceHandler::ReadTraceBuffer(Context *context) {
 
   context->response_length =
       static_cast<uint32_t>(samples_count * var_count * sizeof(uint32_t));
+  *(context->processed) = true;
+  return ErrorCode::kNone;
+}
+
+ErrorCode TraceHandler::SetTraceVar(Context *context) {
+  // 3 extra bytes are required to provide variable index and variable ID
+  if (context->request_length < 4)
+    return ErrorCode::kMissingData;
+  // extract index and var_id from request
+  uint8_t index = context->request[1];
+  uint16_t var_id = u8_to_u16(&context->request[2]);
+  if (!trace_->SetTracedVarId(index, var_id)) {
+    return ErrorCode::kInvalidData;
+  }
+  // no response is required, only the error code
+  context->response_length = 0;
+  *(context->processed) = true;
+  return ErrorCode::kNone;
+}
+
+ErrorCode TraceHandler::GetTraceVar(Context *context) {
+  // 1 extra byte is required to provide variable index
+  if (context->request_length < 2)
+    return ErrorCode::kMissingData;
+
+  uint8_t index = context->request[1];
+
+  // response (var ID) is 16 bits (2 bytes) long
+  if (context->max_response_length < 2)
+    return ErrorCode::kNoMemory;
+  context->response_length = 2;
+
+  u16_to_u8(static_cast<uint16_t>(trace_->GetTracedVarId(index)),
+            context->response);
   *(context->processed) = true;
   return ErrorCode::kNone;
 }

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -30,13 +30,13 @@ ErrorCode VarHandler::Process(Context *context) {
   switch (context->request[0]) {
 
   // Return info about one of the variables.
-  case static_cast<uint8_t>(Subcommand::kVarInfo):
+  case static_cast<uint8_t>(Subcommand::kGetInfo):
     return GetVarInfo(context);
 
-  case static_cast<uint8_t>(Subcommand::kGetVar):
+  case static_cast<uint8_t>(Subcommand::kGet):
     return GetVar(context);
 
-  case static_cast<uint8_t>(Subcommand::kSetVar):
+  case static_cast<uint8_t>(Subcommand::kSet):
     return SetVar(context);
 
   default:

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -27,16 +27,17 @@ ErrorCode VarHandler::Process(Context *context) {
   if (context->request_length < 1)
     return ErrorCode::kMissingData;
 
-  switch (context->request[0]) {
+  Subcommand subcommand{context->request[0]};
 
+  switch (subcommand) {
   // Return info about one of the variables.
-  case static_cast<uint8_t>(Subcommand::kGetInfo):
+  case Subcommand::kGetInfo:
     return GetVarInfo(context);
 
-  case static_cast<uint8_t>(Subcommand::kGet):
+  case Subcommand::kGet:
     return GetVar(context);
 
-  case static_cast<uint8_t>(Subcommand::kSet):
+  case Subcommand::kSet:
     return SetVar(context);
 
   default:

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -55,46 +55,6 @@ static I2Ceeprom eeprom = I2Ceeprom(0x50, 64, 32768, &i2c1);
 
 // Global variables for the debug interface
 static Debug::Trace trace;
-// These variables are used to control the trace function
-// TODO: add subcommands to manipulate the trace and replace those debugvars
-static FnDebugVar varTraceCtrl(
-    VarType::UINT32, "trace_ctrl", "Used to start/stop the trace function",
-    "0x%08x", [] { return static_cast<uint32_t>(trace.GetStatus()); },
-    [](uint32_t value) {
-      if (value == 1)
-        trace.Start();
-      else
-        trace.Stop();
-    });
-
-static FnDebugVar varTracePeriod(
-    VarType::UINT32, "trace_period",
-    "Period that data will be captured.  Loop cycle units", "%u",
-    [] { return trace.GetPeriod(); },
-    [](uint32_t value) { trace.SetPeriod(value); });
-
-static FnDebugVar varTraceSamp(
-    VarType::UINT32, "trace_samples", "Number of trace samples saved so far",
-    "%u", [] { return static_cast<uint32_t>(trace.GetNumSamples()); },
-    [](uint32_t value) { /*ignored*/ });
-
-static FnDebugVar vartrace_var1(
-    VarType::INT32, "trace_var1", "Variable to be saved to the trace buffer",
-    "%d", [] { return trace.GetTracedVarId<0>(); },
-    [](int32_t value) { trace.SetTracedVarId<0>(value); });
-static FnDebugVar vartrace_var2(
-    VarType::INT32, "trace_var2", "Variable to be saved to the trace buffer",
-    "%d", [] { return trace.GetTracedVarId<1>(); },
-    [](int32_t value) { trace.SetTracedVarId<1>(value); });
-static FnDebugVar vartrace_var3(
-    VarType::INT32, "trace_var3", "Variable to be saved to the trace buffer",
-    "%d", [] { return trace.GetTracedVarId<2>(); },
-    [](int32_t value) { trace.SetTracedVarId<2>(value); });
-static FnDebugVar vartrace_var4(
-    VarType::INT32, "trace_var4", "Variable to be saved to the trace buffer",
-    "%d", [] { return trace.GetTracedVarId<3>(); },
-    [](int32_t value) { trace.SetTracedVarId<3>(value); });
-
 // Create a handler for each of the known commands that the Debug Handler can
 // link to.  This is a bit tedious but I can't find a simpler way.
 static Debug::Command::ModeHandler mode_command;

--- a/software/controller/test/debug/eeprom_cmd_test.cpp
+++ b/software/controller/test/debug/eeprom_cmd_test.cpp
@@ -34,7 +34,7 @@ TEST(EepromHandler, ValidRead) {
   for (uint16_t read_length = 1; read_length <= kMaxRequestSize;
        ++read_length) {
     std::array<uint8_t, 6> read_command = {
-        static_cast<uint8_t>(Subcommand::kEepromRead)};
+        static_cast<uint8_t>(EepromHandler::Subcommand::kRead)};
     // set command length
     u16_to_u8(read_length, &read_command[3]);
     for (uint16_t offset = 0; offset < kMemorySize + 1 - read_length;
@@ -74,7 +74,7 @@ TEST(EepromHandler, ValidWrite) {
   for (uint16_t write_length = 1; write_length <= kMaxWriteSize;
        ++write_length) {
     std::array<uint8_t, kMaxWriteSize + 3> write_command = {
-        static_cast<uint8_t>(Subcommand::kEepromWrite)};
+        static_cast<uint8_t>(EepromHandler::Subcommand::kWrite)};
     for (uint16_t offset = 0; offset < kMemorySize + 1 - write_length;
          ++offset) {
       // set command address

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -60,7 +60,8 @@ TEST(TraceHandler, Flush) {
   EXPECT_EQ(trace.GetNumSamples(), 1);
   EXPECT_TRUE(trace.GetStatus());
 
-  std::array flush_command = {static_cast<uint8_t>(Subcommand::kFlushTrace)};
+  std::array flush_command = {
+      static_cast<uint8_t>(TraceHandler::Subcommand::kFlush)};
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
   Context flush_context = {.request = flush_command.data(),
@@ -87,7 +88,7 @@ TEST(TraceHandler, Read) {
       VarType::UINT32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UINT32, "x", "", "", [&] { return i * 10; },
+      VarType::UINT32, "y", "", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler
@@ -95,7 +96,8 @@ TEST(TraceHandler, Read) {
   TraceHandler trace_handler = TraceHandler(&trace);
 
   // read with no vars ==> nothing to report
-  std::array read_command = {static_cast<uint8_t>(Subcommand::kDownloadTrace)};
+  std::array read_command = {
+      static_cast<uint8_t>(TraceHandler::Subcommand::kDownload)};
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
   Context read_context = {.request = read_command.data(),
@@ -112,7 +114,8 @@ TEST(TraceHandler, Read) {
   trace.SetTracedVarId<3>(var_y.GetId());
 
   // start the trace (using debug command)
-  std::array start_command = {static_cast<uint8_t>(Subcommand::kStartTrace)};
+  std::array start_command = {
+      static_cast<uint8_t>(TraceHandler::Subcommand::kStart)};
   processed = false;
   Context start_context = {.request = start_command.data(),
                            .request_length = std::size(start_command),
@@ -139,7 +142,7 @@ TEST(TraceHandler, Read) {
 
   // Take advantage of having a full buffer to test CountSamples command
   std::array num_samples_command = {
-      static_cast<uint8_t>(Subcommand::kCountTraceSamples)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::kCountSamples)};
   processed = false;
   Context num_samples_context = {.request = num_samples_command.data(),
                                  .request_length =
@@ -178,13 +181,8 @@ TEST(TraceHandler, Read) {
 
 TEST(TraceHandler, SettersAndGetters) {
   // define debug variables
-  uint32_t i = 0;
-  FnDebugVar var_x(
-      VarType::UINT32, "x", "", "", [&] { return i; },
-      [&](uint32_t value) { (void)value; });
-  FnDebugVar var_y(
-      VarType::UINT32, "x", "", "", [&] { return i * 10; },
-      [&](uint32_t value) { (void)value; });
+  DebugUInt32 var_x("x");
+  DebugUInt32 var_y("y");
 
   // define trace and trace handler
   Trace trace;
@@ -192,7 +190,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Set trace var ID for var 1
   std::array<uint8_t, 4> set_var1_command = {
-      static_cast<uint8_t>(Subcommand::kSetTraceVar), 1, 0, 0};
+      static_cast<uint8_t>(TraceHandler::Subcommand::kSetVarId), 1, 0, 0};
   u16_to_u8(var_y.GetId(), &set_var1_command[2]);
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
@@ -210,7 +208,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace var ID for var 1
   std::array<uint8_t, 2> get_var1_command = {
-      static_cast<uint8_t>(Subcommand::kGetTraceVar), 1};
+      static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId), 1};
   processed = false;
   Context get_var1_context = {.request = get_var1_command.data(),
                               .request_length = std::size(get_var1_command),
@@ -226,7 +224,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace var ID for var 2 (un-associated)
   std::array<uint8_t, 2> get_var2_command = {
-      static_cast<uint8_t>(Subcommand::kGetTraceVar), 2};
+      static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId), 2};
   processed = false;
   Context get_var2_context = {.request = get_var2_command.data(),
                               .request_length = std::size(get_var2_command),
@@ -242,7 +240,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace var ID for var kMaxTraceVars (out of bounds)
   std::array<uint8_t, 2> get_var_max_command = {
-      static_cast<uint8_t>(Subcommand::kGetTraceVar),
+      static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId),
       static_cast<uint8_t>(kMaxTraceVars)};
   processed = false;
   Context get_var_max_context = {.request = get_var_max_command.data(),
@@ -259,7 +257,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Set trace period
   std::array<uint8_t, 5> set_period_command = {
-      static_cast<uint8_t>(Subcommand::kSetTracePeriod)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::kSetPeriod)};
   u32_to_u8(2, &set_period_command[1]);
   processed = false;
   Context set_period_context = {.request = set_period_command.data(),
@@ -276,7 +274,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace period
   std::array get_period_command = {
-      static_cast<uint8_t>(Subcommand::kGetTracePeriod)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::kGetPeriod)};
   processed = false;
   Context get_period_context = {.request = get_period_command.data(),
                                 .request_length = std::size(get_period_command),
@@ -293,13 +291,8 @@ TEST(TraceHandler, SettersAndGetters) {
 
 TEST(TraceHandler, Errors) {
   // define some debug variables
-  uint32_t i = 0;
-  FnDebugVar var_x(
-      VarType::UINT32, "x", "", "", [&] { return i; },
-      [&](uint32_t value) { (void)value; });
-  FnDebugVar var_y(
-      VarType::UINT32, "x", "", "", [&] { return i * 10; },
-      [&](uint32_t value) { (void)value; });
+  DebugUInt32 var_x("x");
+  DebugUInt32 var_y("y");
 
   // define trace and trace handler
   Trace trace;
@@ -312,21 +305,22 @@ TEST(TraceHandler, Errors) {
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
       {{}, ErrorCode::kMissingData},  // Missing subcommand
       {{8}, ErrorCode::kInvalidData}, // Invalid subcommand
-      {{static_cast<uint8_t>(Subcommand::kDownloadTrace)},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kDownload)},
        ErrorCode::kNoMemory},
-      {{static_cast<uint8_t>(Subcommand::kSetTraceVar), 1, 1},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kSetVarId), 1, 1},
        ErrorCode::kMissingData},
-      {{static_cast<uint8_t>(Subcommand::kSetTraceVar), kMaxTraceVars, 1, 0},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kSetVarId),
+        kMaxTraceVars, 1, 0},
        ErrorCode::kInvalidData},
-      {{static_cast<uint8_t>(Subcommand::kGetTraceVar)},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId)},
        ErrorCode::kMissingData},
-      {{static_cast<uint8_t>(Subcommand::kGetTraceVar), 1},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId), 1},
        ErrorCode::kNoMemory},
-      {{static_cast<uint8_t>(Subcommand::kSetTracePeriod), 1, 1, 1},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kSetPeriod), 1, 1, 1},
        ErrorCode::kMissingData},
-      {{static_cast<uint8_t>(Subcommand::kGetTracePeriod)},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kGetPeriod)},
        ErrorCode::kNoMemory},
-      {{static_cast<uint8_t>(Subcommand::kCountTraceSamples)},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::kCountSamples)},
        ErrorCode::kNoMemory},
   };
   std::array<uint8_t, kResponseSize> response;

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -21,10 +21,10 @@ limitations under the License.
 namespace Debug::Command {
 
 static constexpr size_t kResponseSize{100};
-// check response helper function
-void CheckResponse(std::array<uint8_t, kResponseSize> response,
-                   uint32_t response_length, size_t sample_size,
-                   uint32_t initial_value) {
+// helper function that checks the buffer output
+void CheckBufferOutput(std::array<uint8_t, kResponseSize> response,
+                       uint32_t response_length, size_t sample_size,
+                       uint32_t initial_value) {
   for (int i = 0; i < response_length / sample_size; ++i) {
     uint8_t expected_value[sample_size];
     u32_to_u8(static_cast<uint32_t>(i + initial_value), &expected_value[0]);
@@ -111,7 +111,20 @@ TEST(TraceHandler, Read) {
   trace.SetTracedVarId<1>(var_x.GetId());
   trace.SetTracedVarId<3>(var_y.GetId());
 
-  trace.Start();
+  // start the trace (using debug command)
+  std::array start_command = {static_cast<uint8_t>(Subcommand::kStartTrace)};
+  processed = false;
+  Context start_context = {.request = start_command.data(),
+                           .request_length = std::size(start_command),
+                           .response = response.data(),
+                           .max_response_length = kResponseSize,
+                           .response_length = 0,
+                           .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&start_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(start_context.response_length, 0);
+  EXPECT_EQ(trace.GetStatus(), 1);
+
   // trace with no samples (tracing active) ==> nothing to report
   EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
   EXPECT_EQ(read_context.response_length, 0);
@@ -123,6 +136,23 @@ TEST(TraceHandler, Read) {
   for (i = 0; i < kResponseSize / sample_size + kExtraSamples; ++i) {
     trace.MaybeSample();
   }
+
+  // Take advantage of having a full buffer to test CountSamples command
+  std::array num_samples_command = {
+      static_cast<uint8_t>(Subcommand::kCountTraceSamples)};
+  processed = false;
+  Context num_samples_context = {.request = num_samples_command.data(),
+                                 .request_length =
+                                     std::size(num_samples_command),
+                                 .response = response.data(),
+                                 .max_response_length = kResponseSize,
+                                 .response_length = 0,
+                                 .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&num_samples_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(num_samples_context.response_length, 4);
+  EXPECT_EQ(trace.GetNumSamples(), u8_to_u32(response.data()));
+
   // issue a new read command
   EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
   // we are only returning entire samples
@@ -130,7 +160,7 @@ TEST(TraceHandler, Read) {
             kResponseSize - kResponseSize % sample_size);
   size_t read_samples = read_context.response_length / sample_size;
   // check response
-  CheckResponse(response, read_context.response_length, sample_size, 0);
+  CheckBufferOutput(response, read_context.response_length, sample_size, 0);
 
   // reset response pointer and response_length before issuing a new read
   read_context.response = response.data();
@@ -138,12 +168,127 @@ TEST(TraceHandler, Read) {
   EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
   EXPECT_EQ(read_context.response_length, kExtraSamples * sample_size);
   // check response
-  CheckResponse(response, read_context.response_length, sample_size,
-                static_cast<uint32_t>(read_samples));
+  CheckBufferOutput(response, read_context.response_length, sample_size,
+                    static_cast<uint32_t>(read_samples));
 
   // expect trace to still be running but with no samples in buffer
   EXPECT_TRUE(trace.GetStatus());
   EXPECT_EQ(trace.GetNumSamples(), 0);
+}
+
+TEST(TraceHandler, SettersAndGetters) {
+  // define debug variables
+  uint32_t i = 0;
+  FnDebugVar var_x(
+      VarType::UINT32, "x", "", "", [&] { return i; },
+      [&](uint32_t value) { (void)value; });
+  FnDebugVar var_y(
+      VarType::UINT32, "x", "", "", [&] { return i * 10; },
+      [&](uint32_t value) { (void)value; });
+
+  // define trace and trace handler
+  Trace trace;
+  TraceHandler trace_handler = TraceHandler(&trace);
+
+  // Set trace var ID for var 1
+  std::array<uint8_t, 4> set_var1_command = {
+      static_cast<uint8_t>(Subcommand::kSetTraceVar), 1, 0, 0};
+  u16_to_u8(var_y.GetId(), &set_var1_command[2]);
+  std::array<uint8_t, kResponseSize> response;
+  bool processed{false};
+  Context set_var1_context = {.request = set_var1_command.data(),
+                              .request_length = std::size(set_var1_command),
+                              .response = response.data(),
+                              .max_response_length = kResponseSize,
+                              .response_length = 0,
+                              .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&set_var1_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(set_var1_context.response_length, 0);
+  // check that the trace now points to desired var
+  EXPECT_EQ(u8_to_u16(&set_var1_command[2]), trace.GetTracedVarId<1>());
+
+  // Get trace var ID for var 1
+  std::array<uint8_t, 2> get_var1_command = {
+      static_cast<uint8_t>(Subcommand::kGetTraceVar), 1};
+  processed = false;
+  Context get_var1_context = {.request = get_var1_command.data(),
+                              .request_length = std::size(get_var1_command),
+                              .response = response.data(),
+                              .max_response_length = kResponseSize,
+                              .response_length = 0,
+                              .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_var1_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(get_var1_context.response_length, 2);
+
+  EXPECT_EQ(trace.GetTracedVarId<1>(), u8_to_u16(response.data()));
+
+  // Get trace var ID for var 2 (un-associated)
+  std::array<uint8_t, 2> get_var2_command = {
+      static_cast<uint8_t>(Subcommand::kGetTraceVar), 2};
+  processed = false;
+  Context get_var2_context = {.request = get_var2_command.data(),
+                              .request_length = std::size(get_var2_command),
+                              .response = response.data(),
+                              .max_response_length = kResponseSize,
+                              .response_length = 0,
+                              .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_var2_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(get_var2_context.response_length, 2);
+
+  EXPECT_EQ(uint16_t(-1), u8_to_u16(response.data()));
+
+  // Get trace var ID for var kMaxTraceVars (out of bounds)
+  std::array<uint8_t, 2> get_var_max_command = {
+      static_cast<uint8_t>(Subcommand::kGetTraceVar),
+      static_cast<uint8_t>(kMaxTraceVars)};
+  processed = false;
+  Context get_var_max_context = {.request = get_var_max_command.data(),
+                                 .request_length =
+                                     std::size(get_var_max_command),
+                                 .response = response.data(),
+                                 .max_response_length = kResponseSize,
+                                 .response_length = 0,
+                                 .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_var_max_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(get_var_max_context.response_length, 2);
+  EXPECT_EQ(uint16_t(-1), u8_to_u16(response.data()));
+
+  // Set trace period
+  std::array<uint8_t, 5> set_period_command = {
+      static_cast<uint8_t>(Subcommand::kSetTracePeriod)};
+  u32_to_u8(2, &set_period_command[1]);
+  processed = false;
+  Context set_period_context = {.request = set_period_command.data(),
+                                .request_length = std::size(set_period_command),
+                                .response = response.data(),
+                                .max_response_length = kResponseSize,
+                                .response_length = 0,
+                                .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&set_period_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(set_period_context.response_length, 0);
+
+  EXPECT_EQ(trace.GetPeriod(), u8_to_u32(&set_period_command[1]));
+
+  // Get trace period
+  std::array get_period_command = {
+      static_cast<uint8_t>(Subcommand::kGetTracePeriod)};
+  processed = false;
+  Context get_period_context = {.request = get_period_command.data(),
+                                .request_length = std::size(get_period_command),
+                                .response = response.data(),
+                                .max_response_length = kResponseSize,
+                                .response_length = 0,
+                                .processed = &processed};
+  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_period_context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(get_period_context.response_length, 4);
+
+  EXPECT_EQ(trace.GetPeriod(), u8_to_u32(get_period_context.response));
 }
 
 TEST(TraceHandler, Errors) {
@@ -164,14 +309,25 @@ TEST(TraceHandler, Errors) {
   trace.SetTracedVarId<3>(var_y.GetId());
   trace.Start();
 
-  // note we are sampling 2 variables that are 4 bytes each
-  uint32_t num_vars = trace.GetNumActiveVars();
-  size_t sample_size = num_vars * sizeof(uint32_t);
-
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
       {{}, ErrorCode::kMissingData},  // Missing subcommand
-      {{3}, ErrorCode::kInvalidData}, // Invalid subcommand
-      {{1}, ErrorCode::kNoMemory},
+      {{8}, ErrorCode::kInvalidData}, // Invalid subcommand
+      {{static_cast<uint8_t>(Subcommand::kDownloadTrace)},
+       ErrorCode::kNoMemory},
+      {{static_cast<uint8_t>(Subcommand::kSetTraceVar), 1, 1},
+       ErrorCode::kMissingData},
+      {{static_cast<uint8_t>(Subcommand::kSetTraceVar), kMaxTraceVars, 1, 0},
+       ErrorCode::kInvalidData},
+      {{static_cast<uint8_t>(Subcommand::kGetTraceVar)},
+       ErrorCode::kMissingData},
+      {{static_cast<uint8_t>(Subcommand::kGetTraceVar), 1},
+       ErrorCode::kNoMemory},
+      {{static_cast<uint8_t>(Subcommand::kSetTracePeriod), 1, 1, 1},
+       ErrorCode::kMissingData},
+      {{static_cast<uint8_t>(Subcommand::kGetTracePeriod)},
+       ErrorCode::kNoMemory},
+      {{static_cast<uint8_t>(Subcommand::kCountTraceSamples)},
+       ErrorCode::kNoMemory},
   };
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
@@ -180,9 +336,8 @@ TEST(TraceHandler, Errors) {
                        .request_length = static_cast<uint32_t>(request.size()),
                        .response = response.data(),
                        .max_response_length =
-                           static_cast<uint32_t>(sample_size - 1),
-                       // To provoke the No Memory error once all other
-                       // checks have passed
+                           1, // To provoke the No Memory error once all other
+                              // checks have passed
                        .response_length = 0,
                        .processed = &processed};
     EXPECT_EQ(error, trace_handler.Process(&context));

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -47,7 +47,8 @@ TEST(VarHandler, GetVarInfo) {
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
-      static_cast<uint8_t>(Subcommand::kVarInfo), id[0], id[1], // Var id
+      static_cast<uint8_t>(VarHandler::Subcommand::kGetInfo), id[0],
+      id[1], // Var id
   };
   std::array<uint8_t, 50> response;
   bool processed{false};
@@ -73,7 +74,8 @@ TEST(VarHandler, GetVar) {
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
-      static_cast<uint8_t>(Subcommand::kGetVar), id[0], id[1], // Var id
+      static_cast<uint8_t>(VarHandler::Subcommand::kGet), id[0],
+      id[1], // Var id
   };
   std::array<uint8_t, 4> response;
   bool processed{false};
@@ -105,7 +107,7 @@ TEST(VarHandler, SetVar) {
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
-      static_cast<uint8_t>(Subcommand::kSetVar),
+      static_cast<uint8_t>(VarHandler::Subcommand::kSet),
       id[0],
       id[1], // Var id
       new_bytes[0],

--- a/software/utils/controller_debug.md
+++ b/software/utils/controller_debug.md
@@ -59,14 +59,25 @@ To exit console mode, enter control-C
 **poke**
 These commands allow memory locations to be read (peek) or written (poke).  They are primarily useful when developing hardware drivers as part of the HAL and should generally be used with caution.
 
+**eeprom**
+This command allows the user to `read` and `write` in non-volatile memory.
+To read the user provides the data's address and number of bytes to read:
+```
+eeprom read 4096 52
+```
+To write the user provides the data's address and the bytes to write:
+```
+eeprom write 128 255 255 255 255 255 255 255
+```
+
 **trace**
 One of the most useful features of the debug utilities is the trace buffer.  The trace buffer is a large block of RAM into which debug variables can be saved periodically.  That data can then be download using the trace command and either saved to a file or displayed graphically.
 
-To use the trace, several debug variables must be set to configure it.
-- trace_var1 … trace_var4.  These four variables define what will be saved to the trace buffer.  The value you set them to is the name of another debug variable that you wish to save.  Up to 4 debug variables can be stored in the trace at any time using these four variables.
-- trace_period.  This sets the period (in units of loop cycles) at which the debug variables will be stored to the trace buffer.  Setting trace_period to 1 will cause the data to be stored every cycle.  Setting it to 2 will cause the data to be stored every other cycle, etc.
-- trace_ctrl.  This is used to start and stop the trace feature.  Setting this variable to 1 starts the collection of trace data.  Setting it to 0 stops the collection of trace data.  If the trace buffer fills up, then this will be automatically set to 0 by the controller software.
-- trace_samples.  This variable can be read to see how many samples of trace data have been collected.
+To start the trace, one needs to provide a list of traced vars and (optionnaly) a trace period:
+```
+trace start [--period <period>] <var_name1 ... var_name4>
+```
+where period is given in loop cycles
 
 Once the trace is set up and started, the collected data can be graphed using the command:
 ```
@@ -78,9 +89,7 @@ trace download <filename>
 ```
 For example, to capture patient pressure every loop cycle, the following commands would be used:
 ```
-set trace_var1 pressure
-set trace_period 1
-set trace_ctrl 1
+trace start pressure
 ```
 pause for a few seconds while the data is captured, then
 ```

--- a/software/utils/controller_debug.py
+++ b/software/utils/controller_debug.py
@@ -50,6 +50,12 @@ SUBCMD_VAR_SET = 2
 
 SUBCMD_TRACE_FLUSH = 0
 SUBCMD_TRACE_GETDATA = 1
+SUBCMD_TRACE_START = 2
+SUBCMD_TRACE_GET_VARID = 3
+SUBCMD_TRACE_SET_VARID = 4
+SUBCMD_TRACE_GET_PERIOD = 5
+SUBCMD_TRACE_SET_PERIOD = 6
+SUBCMD_TRACE_GET_NUM_SAMPLES = 7
 
 SUBCMD_EEPROM_READ = 0
 SUBCMD_EEPROM_WRITE = 1
@@ -478,11 +484,10 @@ trace start [--period p] [var1 ... ]
   Starts collecting trace data.
 
   You can specify the names of up to TRACE_VAR_CT debug variables to trace.  If
-  you don't specify any, we use the values in trace_var1, ....
+  you don't specify any, we use the last known values.
 
   --period controls the sample period in units of one trip through the
-  controller's high-priority loop.  If you don't specify a period, we use
-  whatever is in the trace_period debug variable.
+  controller's high-priority loop.  If you don't specify a period, we use 1.
 
 trace graph [--dest=<filename>] [--title=<title>] [--nointeractive]
             [--scale=<field>/scale --scale=<field>*scale]
@@ -505,23 +510,12 @@ trace download [--separator=<str>] [--dest=<filename>]
   option is given, then the specified string will separate each column of data.
   The default separator is a few spaces.
 
-The tracing API also exposes the following debug vars, controlled via the
-standard `get` and `set` commands.  You probably don't need to touch these.
+trace current
+  This returns the current state of the trace:
+    - traced variables
+    - trace period
+    - number of samples in the trace buffer
 
-trace_var1, ..., trace_var{TRACE_VAR_CT}
-  Names of the variables to trace.  Can be set explicitly, or via `trace
-  start`.
-
-trace_period
-  Interval between two samples in the trace.  A value of N means we sample once
-  every N times through the controller's high priority loop.
-
-trace_ctrl
-  This variable is used to start the trace.  Just set it to 1 to start.
-  It will be cleared when the trace buffer is full.
-
-trace_samples
-  This variable gives the number of samples stored in the buffer currently.
 """
         cl = shlex.split(line)
         if len(cl) < 1:
@@ -542,18 +536,22 @@ trace_samples
                 print(f"Can't trace more than {TRACE_VAR_CT} variables at once.")
                 return
             if args.period:
-                SetVar("trace_period", args.period)
+                period = Split32(args.period)
+                SendCmd(OP_TRACE, [SUBCMD_TRACE_SET_PERIOD] + period)
+            else:
+                SendCmd(OP_TRACE, [SUBCMD_TRACE_SET_PERIOD] + Split32(1))
             if args.var:
                 # Unset existing trace vars, so we only get what was asked for.
-                var = args.var + [""] * (TRACE_VAR_CT - len(args.var))
-                for (i, var) in enumerate(var):
-                    SetVar(f"trace_var{i + 1}", var)
+                var_names = args.var + [""] * (TRACE_VAR_CT - len(args.var))
+                for (i, var_name) in enumerate(var_names):
+                    var_id = -1
+                    if var_name in varDict:
+                        var_id = varDict[var_name].id
+                    var = Split16(var_id)
+                    SendCmd(OP_TRACE, [SUBCMD_TRACE_SET_VARID, i] + var)
 
             SendCmd(OP_TRACE, [SUBCMD_TRACE_FLUSH])
-
-            # The transition from 0 to 1 resets and starts the trace
-            SetVar("trace_ctrl", 0)
-            SetVar("trace_ctrl", 1)
+            SendCmd(OP_TRACE, [SUBCMD_TRACE_START])
 
         elif cl[0] == "download":
             parser = CmdArgumentParser(prog="trace download")
@@ -578,6 +576,17 @@ trace_samples
 
         elif cl[0] == "graph":
             TraceGraph(cl[1:])
+
+        elif cl[0] == "current":
+            print("Traced variables:")
+            for var in TraceActiveVars():
+                print(" - %s" % var.name)
+            dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_PERIOD])
+            period = Build32(dat)[0]
+            print("Trace period: %i" % period)
+            dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_NUM_SAMPLES])
+            samples = Build32(dat)[0]
+            print("Samples in buffer: %i" % samples)
 
         else:
             print("Unknown trace sub-command %s" % cl[0])
@@ -706,14 +715,6 @@ def GetVar(name, raw=False, fmt=None):
     if fmt == None:
         fmt = V.fmt
 
-    # I'll convert trace variable values to variable names
-    if name.startswith("trace_var"):
-        if val < 0:
-            return "none"
-        tv = FindVarByID(val)
-        if tv != None:
-            return tv.name
-
     return fmt % val
 
 
@@ -722,14 +723,6 @@ def SetVar(name, value):
         raise Error("Unknown variable %s" % name)
 
     V = varDict[name]
-
-    # If this is a trace variable, the passed value
-    # should be a variable name
-    if name.startswith("trace_var"):
-        if value == "" or value == "none":
-            value = "-1"
-        elif value in varDict:
-            value = "%d" % varDict[value].id
 
     if V.type == VAR_INT32:
         if not isinstance(value, int):
@@ -751,14 +744,12 @@ def SetVar(name, value):
 def TraceActiveVars():
     """Return a list of active trace variables"""
     ret = []
-    for i in range(10):
-        name = "trace_var%d" % (i + 1)
-        if not name in varDict:
-            break
-        vid = GetVar(name, raw=True)
-        V = FindVarByID(vid)
-        if V:
-            ret.append(V)
+    for i in range(TRACE_VAR_CT):
+        dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_VARID, i])
+        var_id = Build16(dat)[0]
+        var = FindVarByID(var_id)
+        if var:
+            ret.append(var)
     return ret
 
 
@@ -774,7 +765,9 @@ def TraceDownload():
     if len(traceVars) < 1:
         return None
 
-    ct = GetVar("trace_samples", raw=True) * len(traceVars)
+    # get samples count
+    dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_NUM_SAMPLES])
+    ct = Build32(dat)[0] * len(traceVars)
 
     data = []
     while len(data) < 4 * ct:
@@ -801,7 +794,9 @@ def TraceDownload():
         for i, val in enumerate(sample):
             ret[i].append(traceVars[i].ConvertInt(val))
 
-    per = GetVar("trace_period", raw=True)
+    # get trace period
+    dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_PERIOD])
+    per = Build32(dat)[0]
     if per < 1:
         per = 1
 

--- a/software/utils/controller_debug_scripts/pinch_valve_cal.py
+++ b/software/utils/controller_debug_scripts/pinch_valve_cal.py
@@ -18,12 +18,6 @@ def main():
     print()
 
     print("Reading minimal flow value from sensor...")
-    SetVar("trace_var1", "flow_inhale")
-    SetVar("trace_var2", "none")
-    SetVar("trace_var3", "none")
-    SetVar("trace_var4", "none")
-    SetVar("trace_ctrl", 0)
-    SetVar("trace_period", 1)
     zero = GetTraceMean()
     print(zero)
 
@@ -71,10 +65,14 @@ def main():
 
 
 def GetTraceMean(samps=300):
-    SetVar("trace_ctrl", 0)
-    SetVar("trace_ctrl", 1)
-    while int(GetVar("trace_samples")) < samps:
-        pass
+    run("trace flush")
+    run("trace start flow_inhale")
+
+    dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_NUM_SAMPLES])
+    ct = Build32(dat)[0]
+    while ct < samps:
+        dat = SendCmd(OP_TRACE, [SUBCMD_TRACE_GET_NUM_SAMPLES])
+        ct = Build32(dat)[0]
 
     dat = TraceDownload()
     return mean(dat[1])


### PR DESCRIPTION
# Description

Simplify init of the debug interface by not requiring to handle the trace buffer with debug vars, and use specific trace subcommands instead
Tested on my pizza with (among others):
```
$ ./controller_debug.py
] trace start --period 10 pressure net_flow
] trace current
Traced variables:
 - pressure
 - net_flow
Trace period: 10
Samples in buffer: 47
] trace graph 
```
Which graphs the desired variables, like it did before those change.

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules