### PR TITLE
Fix Github action for gh-pages - wrong pip install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           && pip3 install sphinx-rtd-theme
           && pip3 install breathe
           && pip3 install sphinx-sitemap
-          && pip3 install sphinxcontrib-traceability
+          && pip3 install mlx.traceability
       - name: Checkout repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
# Description

`gh-pages` failing because I changed the pip module used for traceability and forgot to update the Github action.

# General checklist:

- [X] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [n/a] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [n/a] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [n/a] All new content is linked, easily discoverable, does not require too many clicks
- [n/a] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers
