### PR TITLE
add platformio manual native install instruction to controller README

### DIFF
--- a/software/controller/README.md
+++ b/software/controller/README.md
@@ -64,10 +64,10 @@ but platformio will just say all checks have passed without giving an error if i
 
 ## Building and testing
 
-After installing platformio, you should be able to build and test as follows.
+After installing platformio, you should be able to build and test as follows:
 
 ```
-$ ./test.sh
+$ ./controller.sh --test
 # This will run a few commands, such as "platformio run" and
 # "platformio test -e native".
 ```
@@ -81,6 +81,12 @@ e.g. if things don't build for you in `master`, try:
 
 ```
 $ rm -rf .pio/
+```
+
+If you encounter an error such as `Error: Unknown development platform 'native'`, try running
+
+```
+$ platformio platform install native
 ```
 
 ## Running on the controller


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

There is currently a bug in platformio so an extra step is required to run the controller tests on native. Updating the controller README to reflect this. 

Fixes #(issue)
1089

Updates #(issue)

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [ ] Any dependent changes have been merged and published in downstream modules
