### PR TITLE
Migrate controller to googlestyle and add clang-tidy rules

### DIFF
--- a/software/.clang-tidy
+++ b/software/.clang-tidy
@@ -53,16 +53,10 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.GlobalConstantCase
     value:           CamelCase
-  - key:             readability-identifier-naming.GlobalConstantPrefix
-    value:           k
   - key:             readability-identifier-naming.StaticConstantCase
     value:           CamelCase
-  - key:             readability-identifier-naming.StaticConstantPrefix
-    value:           k
   - key:             readability-identifier-naming.StaticVariableCase
     value:           CamelCase
-  - key:             readability-identifier-naming.StaticVariablePrefix
-    value:           k
   - key:             readability-identifier-naming.MemberCase
     value:           lower_case
 # We only require the "_" suffix for private and protected members in order to
@@ -88,8 +82,7 @@ CheckOptions:
     value:           UPPER_CASE
   - key:             readability-identifier-naming.IgnoreMainLikeFunctions
     value:           1
-# TODO: add function naming rules (CamelCase?).
-# Because we want to be able to use a different convention (snake_case) for accessors
-# and some globals (mostly in commons/ folder), this is not enforced for now.
-# We could add a //NOLINTNEXTLINE() to all of those, but this seems overkill (especially for accessors).
+# TODO: add function naming rules (snake_case?).
+# Because we want to be able to use acronyms, we don't want to enforce this
+# We could add a //NOLINTNEXTLINE() to all of those, but this seems overkill.
 ...

--- a/software/.clang-tidy
+++ b/software/.clang-tidy
@@ -51,8 +51,6 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.EnumConstantCase
     value:           CamelCase
-  - key:             readability-identifier-naming.EnumConstantPrefix
-    value:           k
   - key:             readability-identifier-naming.GlobalConstantCase
     value:           CamelCase
   - key:             readability-identifier-naming.GlobalConstantPrefix

--- a/software/.clang-tidy
+++ b/software/.clang-tidy
@@ -37,5 +37,61 @@ Checks: >
 #WarningsAsErrors: '*'
 # This is OK because clang-tidy still displays the warnings
 
-# TODO: Add naming style checks (readability-identifier-naming).
+# Naming style checks (readability-identifier-naming).
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.TypeAliasCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.TypedefCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.NamespaceCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumConstantPrefix
+    value:           k
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.GlobalConstantPrefix
+    value:           k
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StaticConstantPrefix
+    value:           k
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StaticVariablePrefix
+    value:           k
+  - key:             readability-identifier-naming.MemberCase
+    value:           lower_case
+# We only require the "_" suffix for private and protected members in order to
+# allow struct members (which are public) to not use the suffix
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           _
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           _
+# static class members also require the suffix
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           _
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+  - key:             readability-identifier-naming.MacroDefinitionCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1
+# TODO: add function naming rules (CamelCase?).
+# Because we want to be able to use a different convention (snake_case) for accessors
+# and some globals (mostly in commons/ folder), this is not enforced for now.
+# We could add a //NOLINTNEXTLINE() to all of those, but this seems overkill (especially for accessors).
 ...

--- a/software/common/libs/binary_utils/binary_utils.h
+++ b/software/common/libs/binary_utils/binary_utils.h
@@ -20,17 +20,17 @@ limitations under the License.
 // Some simple data conversion functions.
 // These assume little endian byte format
 inline uint16_t u8_to_u16(const uint8_t *dat) {
-  uint16_t L = dat[0];
-  uint16_t H = dat[1];
-  return static_cast<uint16_t>(L | (H << 8));
+  uint16_t l = dat[0];
+  uint16_t h = dat[1];
+  return static_cast<uint16_t>(l | (h << 8));
 }
 
 inline uint32_t u8_to_u32(const uint8_t *dat) {
-  uint32_t A = dat[0];
-  uint32_t B = dat[1];
-  uint32_t C = dat[2];
-  uint32_t D = dat[3];
-  return static_cast<uint32_t>(A | (B << 8) | (C << 16) | (D << 24));
+  uint32_t a = dat[0];
+  uint32_t b = dat[1];
+  uint32_t c = dat[2];
+  uint32_t d = dat[3];
+  return static_cast<uint32_t>(a | (b << 8) | (c << 16) | (d << 24));
 }
 
 inline void u16_to_u8(uint16_t val, uint8_t *buff) {

--- a/software/common/libs/checksum/checksum.cpp
+++ b/software/common/libs/checksum/checksum.cpp
@@ -35,7 +35,7 @@ uint16_t ChecksumFletcher16(const char *data, uint8_t count,
 // Table generated using
 // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
 uint32_t CRC32Single(uint32_t crc, uint8_t data) {
-  static constexpr uint32_t kCRCTable[16] = {
+  static constexpr uint32_t CRCTable[16] = {
       // Nibble lookup table for 0x741B8CD7 polynomial
       0x00000000, 0x741B8CD7, 0xE83719AE, 0x9C2C9579, 0xA475BF8B, 0xD06E335C,
       0x4C42A625, 0x38592AF2, 0x3CF0F3C1, 0x48EB7F16, 0xD4C7EA6F, 0xA0DC66B8,
@@ -46,15 +46,15 @@ uint32_t CRC32Single(uint32_t crc, uint8_t data) {
   // Process 32-bits, 4 at a time, or 8 rounds
 
   crc = (crc << 4) ^
-        kCRCTable[crc >> 28]; // Assumes 32-bit reg, masking index to 4-bits
+        CRCTable[crc >> 28]; // Assumes 32-bit reg, masking index to 4-bits
   crc =
-      (crc << 4) ^ kCRCTable[crc >> 28]; //  0x04C11DB7 Polynomial used in STM32
-  crc = (crc << 4) ^ kCRCTable[crc >> 28];
-  crc = (crc << 4) ^ kCRCTable[crc >> 28];
-  crc = (crc << 4) ^ kCRCTable[crc >> 28];
-  crc = (crc << 4) ^ kCRCTable[crc >> 28];
-  crc = (crc << 4) ^ kCRCTable[crc >> 28];
-  crc = (crc << 4) ^ kCRCTable[crc >> 28];
+      (crc << 4) ^ CRCTable[crc >> 28]; //  0x04C11DB7 Polynomial used in STM32
+  crc = (crc << 4) ^ CRCTable[crc >> 28];
+  crc = (crc << 4) ^ CRCTable[crc >> 28];
+  crc = (crc << 4) ^ CRCTable[crc >> 28];
+  crc = (crc << 4) ^ CRCTable[crc >> 28];
+  crc = (crc << 4) ^ CRCTable[crc >> 28];
+  crc = (crc << 4) ^ CRCTable[crc >> 28];
 
   return crc;
 }

--- a/software/common/libs/checksum/checksum.cpp
+++ b/software/common/libs/checksum/checksum.cpp
@@ -16,8 +16,8 @@ limitations under the License.
 #include "checksum.h"
 #include <stdint.h>
 
-uint16_t checksum_fletcher16(const char *data, uint8_t count,
-                             uint16_t state /*=0*/) {
+uint16_t ChecksumFletcher16(const char *data, uint8_t count,
+                            uint16_t state /*=0*/) {
   uint8_t s1 = static_cast<uint8_t>(state & 0xff);
   uint8_t s2 = static_cast<uint8_t>((state >> 8) & 0xff);
   for (uint8_t index = 0; index < count; ++index) {
@@ -34,8 +34,8 @@ uint16_t checksum_fletcher16(const char *data, uint8_t count,
 // 2002.] https://users.ece.cmu.edu/~koopman/crc/
 // Table generated using
 // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
-uint32_t crc32_single(uint32_t crc, uint8_t data) {
-  static const uint32_t crcTable[16] = {
+uint32_t CRC32Single(uint32_t crc, uint8_t data) {
+  static constexpr uint32_t kCRCTable[16] = {
       // Nibble lookup table for 0x741B8CD7 polynomial
       0x00000000, 0x741B8CD7, 0xE83719AE, 0x9C2C9579, 0xA475BF8B, 0xD06E335C,
       0x4C42A625, 0x38592AF2, 0x3CF0F3C1, 0x48EB7F16, 0xD4C7EA6F, 0xA0DC66B8,
@@ -46,27 +46,27 @@ uint32_t crc32_single(uint32_t crc, uint8_t data) {
   // Process 32-bits, 4 at a time, or 8 rounds
 
   crc = (crc << 4) ^
-        crcTable[crc >> 28]; // Assumes 32-bit reg, masking index to 4-bits
+        kCRCTable[crc >> 28]; // Assumes 32-bit reg, masking index to 4-bits
   crc =
-      (crc << 4) ^ crcTable[crc >> 28]; //  0x04C11DB7 Polynomial used in STM32
-  crc = (crc << 4) ^ crcTable[crc >> 28];
-  crc = (crc << 4) ^ crcTable[crc >> 28];
-  crc = (crc << 4) ^ crcTable[crc >> 28];
-  crc = (crc << 4) ^ crcTable[crc >> 28];
-  crc = (crc << 4) ^ crcTable[crc >> 28];
-  crc = (crc << 4) ^ crcTable[crc >> 28];
+      (crc << 4) ^ kCRCTable[crc >> 28]; //  0x04C11DB7 Polynomial used in STM32
+  crc = (crc << 4) ^ kCRCTable[crc >> 28];
+  crc = (crc << 4) ^ kCRCTable[crc >> 28];
+  crc = (crc << 4) ^ kCRCTable[crc >> 28];
+  crc = (crc << 4) ^ kCRCTable[crc >> 28];
+  crc = (crc << 4) ^ kCRCTable[crc >> 28];
+  crc = (crc << 4) ^ kCRCTable[crc >> 28];
 
   return crc;
 }
 
-uint32_t soft_crc32(const uint8_t *data, uint32_t count) {
+uint32_t SoftCRC32(const uint8_t *data, uint32_t count) {
   if (0 == count) {
     return 0;
   }
 
   uint32_t crc = 0xFFFFFFFF;
   while (count--) {
-    crc = crc32_single(crc, *data++);
+    crc = CRC32Single(crc, *data++);
   }
   return crc;
 }

--- a/software/common/libs/checksum/checksum.h
+++ b/software/common/libs/checksum/checksum.h
@@ -24,27 +24,27 @@ limitations under the License.
 // function if you want to checksum one "logical message" which isn't in a
 // single buffer.
 //
-//   uint16_t state = checksum_fletcher16(data0, data0_len);
-//   state = checksum_fletcher16(data1, data1_len, state);
-//   uint16_t result = checksum_fletcher16(data2, data2_len, state);
+//   uint16_t state = ChecksumFletcher16(data0, data0_len);
+//   state = ChecksumFletcher16(data1, data1_len, state);
+//   uint16_t result = ChecksumFletcher16(data2, data2_len, state);
 //
-uint16_t checksum_fletcher16(const char *data, uint8_t count,
-                             uint16_t state = 0);
+uint16_t ChecksumFletcher16(const char *data, uint8_t count,
+                            uint16_t state = 0);
 
 // The polynomial 0x741B8CD7 has Hamming distance 6 up to 16360 bits
 // and Hamming distance 4 up to 114663 bits.
 //[Philip Koopman, 32-Bit Cyclic Redundancy Codes for Internet Applications
 // 2002.] https://users.ece.cmu.edu/~koopman/crc/
-constexpr uint32_t CRC32_POLYNOMIAL = 0x741B8CD7;
+constexpr uint32_t kCrc32Polynomial = 0x741B8CD7;
 
-uint32_t soft_crc32(const uint8_t *data, uint32_t count);
+uint32_t SoftCRC32(const uint8_t *data, uint32_t count);
 
 // Computes check bytes for a fletcher16 checksum.
 //
-// Given a packet p and checksum(p) == c, check_bytes_fletcher16(c) returns two
+// Given a packet p and checksum(p) == c, CheckBytesFletcher16(c) returns two
 // bytes [b1 b2] such that checksum(p | b1 | b2) == 0, where `|` represents
 // concatenation.
-inline uint16_t check_bytes_fletcher16(uint16_t checksum) {
+inline uint16_t CheckBytesFletcher16(uint16_t checksum) {
   uint8_t f0 = static_cast<uint8_t>(checksum & 0xff);
   uint8_t f1 = static_cast<uint8_t>((checksum >> 8) & 0xff);
   uint8_t c0 = static_cast<uint8_t>(0xff - ((f0 + f1) % 0xff));
@@ -56,8 +56,8 @@ inline uint16_t check_bytes_fletcher16(uint16_t checksum) {
 //
 // When creating packets, we append "check bytes" so that the whole packet
 // (including the check bytes) has a checksum of 0.
-inline bool checksum_check(const char *packet, uint8_t packet_len) {
-  return checksum_fletcher16(packet, packet_len) == 0;
+inline bool ChecksumCheck(const char *packet, uint8_t packet_len) {
+  return ChecksumFletcher16(packet, packet_len) == 0;
 }
 
 #endif // CHECKSUM_H

--- a/software/common/libs/checksum/checksum.h
+++ b/software/common/libs/checksum/checksum.h
@@ -35,7 +35,7 @@ uint16_t ChecksumFletcher16(const char *data, uint8_t count,
 // and Hamming distance 4 up to 114663 bits.
 //[Philip Koopman, 32-Bit Cyclic Redundancy Codes for Internet Applications
 // 2002.] https://users.ece.cmu.edu/~koopman/crc/
-constexpr uint32_t kCrc32Polynomial = 0x741B8CD7;
+constexpr uint32_t Crc32Polynomial = 0x741B8CD7;
 
 uint32_t SoftCRC32(const uint8_t *data, uint32_t count);
 

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -191,14 +191,14 @@ protected:
 class Pressure : public UnitsDetail::ArithScalar<Pressure, float> {
 public:
   [[nodiscard]] constexpr float kPa() const { return val_; }
-  [[nodiscard]] constexpr float cmH2O() const { return val_ * kKPacmH2O; }
-  [[nodiscard]] constexpr float atm() const { return val_ / kAtmToKPa; }
+  [[nodiscard]] constexpr float cmH2O() const { return val_ * KPaToCmH2O; }
+  [[nodiscard]] constexpr float atm() const { return val_ / AtmToKPa; }
 
 private:
   // https://www.google.com/search?q=kpa+to+cmh2o
-  static constexpr float kKPacmH2O{10.1972f};
+  static constexpr float KPaToCmH2O{10.1972f};
   // https://www.google.com/search?q=atm+to+kPa
-  static constexpr float kAtmToKPa{101.325f};
+  static constexpr float AtmToKPa{101.325f};
 
   constexpr friend Pressure kPa(float kpa);
   constexpr friend Pressure cmH2O(float cm_h2o);
@@ -209,11 +209,9 @@ private:
 
 constexpr Pressure kPa(float kpa) { return Pressure(kpa); }
 constexpr Pressure cmH2O(float cm_h2o) {
-  return Pressure(cm_h2o / Pressure::kKPacmH2O);
+  return Pressure(cm_h2o / Pressure::KPaToCmH2O);
 }
-constexpr Pressure atm(float atm) {
-  return Pressure(atm * Pressure::kAtmToKPa);
-}
+constexpr Pressure atm(float atm) { return Pressure(atm * Pressure::AtmToKPa); }
 
 // Represents a length.
 //

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -54,10 +54,13 @@ limitations under the License.
 //
 //   Pressure         kPa(float)
 //   Pressure         cmH2O(float)
+//   Pressure         atm(float)
 //   Length           meters(float)
 //   Length           millimeters(float)
 //   VolumetricFlow   cubic_m_per_sec(float)
 //   VolumetricFlow   ml_per_min(float)
+//   VolumetricFlow   liters_per_sec(float)
+//   VolumetricFlow   ml_per_sec(float)
 //   Volume           cubic_m(float)
 //   Volume           ml(float)
 //   Voltage          volts(float)
@@ -65,6 +68,7 @@ limitations under the License.
 //   Duration         milliseconds(int64_t)
 //   Duration         milliseconds(float)
 //   Duration         microseconds(int64_t)
+//   Duration         minutes(float)
 //   Time             microsSinceStartup(int64_t)
 //
 // Values support addition and subtraction.  The laws for Duration and Time are
@@ -80,7 +84,7 @@ limitations under the License.
 //
 // [1] https://en.wikipedia.org/wiki/Physical_quantity
 
-namespace units_detail {
+namespace UnitsDetail {
 
 // Represents a value of some physical quantity Q, e.g. length, pressure, time.
 //
@@ -172,7 +176,7 @@ protected:
   using Scalar<Q, ValTy>::Scalar;
 };
 
-} // namespace units_detail
+} // namespace UnitsDetail
 
 // Represents pressure, e.g. air pressure.
 //
@@ -184,15 +188,15 @@ protected:
 //  - atm (atmospheres)
 //
 // Native unit (implementation detail): kPa
-class Pressure : public units_detail::ArithScalar<Pressure, float> {
+class Pressure : public UnitsDetail::ArithScalar<Pressure, float> {
 public:
   [[nodiscard]] constexpr float kPa() const { return val_; }
-  [[nodiscard]] constexpr float cmH2O() const { return val_ * kKPaToCmH2O; }
+  [[nodiscard]] constexpr float cmH2O() const { return val_ * kKPacmH2O; }
   [[nodiscard]] constexpr float atm() const { return val_ / kAtmToKPa; }
 
 private:
   // https://www.google.com/search?q=kpa+to+cmh2o
-  static constexpr float kKPaToCmH2O{10.1972f};
+  static constexpr float kKPacmH2O{10.1972f};
   // https://www.google.com/search?q=atm+to+kPa
   static constexpr float kAtmToKPa{101.325f};
 
@@ -200,12 +204,12 @@ private:
   constexpr friend Pressure cmH2O(float cm_h2o);
   constexpr friend Pressure atm(float atm);
 
-  using units_detail::ArithScalar<Pressure, float>::ArithScalar;
+  using UnitsDetail::ArithScalar<Pressure, float>::ArithScalar;
 };
 
 constexpr Pressure kPa(float kpa) { return Pressure(kpa); }
 constexpr Pressure cmH2O(float cm_h2o) {
-  return Pressure(cm_h2o / Pressure::kKPaToCmH2O);
+  return Pressure(cm_h2o / Pressure::kKPacmH2O);
 }
 constexpr Pressure atm(float atm) {
   return Pressure(atm * Pressure::kAtmToKPa);
@@ -220,7 +224,7 @@ constexpr Pressure atm(float atm) {
 //   - millimeters
 //
 // Native unit (implementation detail): meters
-class Length : public units_detail::ArithScalar<Length, float> {
+class Length : public UnitsDetail::ArithScalar<Length, float> {
 public:
   [[nodiscard]] constexpr float meters() const { return val_; }
   [[nodiscard]] constexpr float millimeters() const { return val_ * 1000; }
@@ -229,7 +233,7 @@ private:
   constexpr friend Length meters(float meters);
   constexpr friend Length millimeters(float mm);
 
-  using units_detail::ArithScalar<Length, float>::ArithScalar;
+  using UnitsDetail::ArithScalar<Length, float>::ArithScalar;
 };
 
 constexpr Length meters(float meters) { return Length(meters); }
@@ -250,7 +254,7 @@ constexpr Length millimeters(float mm) { return Length(mm / 1000); }
 //
 // Dividing a Volume by a Duration (see below) gives you a VolumetricFlow.
 // Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
-class VolumetricFlow : public units_detail::ArithScalar<VolumetricFlow, float> {
+class VolumetricFlow : public UnitsDetail::ArithScalar<VolumetricFlow, float> {
 public:
   [[nodiscard]] constexpr float cubic_m_per_sec() const { return val_; }
   [[nodiscard]] constexpr float ml_per_min() const {
@@ -265,9 +269,9 @@ private:
   constexpr friend VolumetricFlow cubic_m_per_sec(float m3ps);
   constexpr friend VolumetricFlow ml_per_min(float ml_per_min);
   constexpr friend VolumetricFlow liters_per_sec(float lps);
-  constexpr friend VolumetricFlow ml_per_sec(float mmps);
+  constexpr friend VolumetricFlow ml_per_sec(float mlps);
 
-  using units_detail::ArithScalar<VolumetricFlow, float>::ArithScalar;
+  using UnitsDetail::ArithScalar<VolumetricFlow, float>::ArithScalar;
 };
 
 constexpr VolumetricFlow cubic_m_per_sec(float m3ps) {
@@ -279,8 +283,8 @@ constexpr VolumetricFlow ml_per_min(float ml_per_min) {
 constexpr VolumetricFlow liters_per_sec(float lps) {
   return VolumetricFlow(lps / (1000.0f));
 }
-constexpr VolumetricFlow ml_per_sec(float mmps) {
-  return VolumetricFlow(mmps / (1.0e6f));
+constexpr VolumetricFlow ml_per_sec(float mlps) {
+  return VolumetricFlow(mlps / (1.0e6f));
 }
 
 // Represents volume.
@@ -296,7 +300,7 @@ constexpr VolumetricFlow ml_per_sec(float mmps) {
 //
 // Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
 // Dividing a Volume by a Duration gives you a VolumetricFlow.
-class Volume : public units_detail::ArithScalar<Volume, float> {
+class Volume : public UnitsDetail::ArithScalar<Volume, float> {
 public:
   [[nodiscard]] constexpr float cubic_m() const { return val_; }
   [[nodiscard]] constexpr float ml() const { return val_ * 1000.0f * 1000.0f; }
@@ -305,7 +309,7 @@ private:
   constexpr friend Volume cubic_m(float m3);
   constexpr friend Volume ml(float ml);
 
-  using units_detail::ArithScalar<Volume, float>::ArithScalar;
+  using UnitsDetail::ArithScalar<Volume, float>::ArithScalar;
 };
 
 constexpr Volume cubic_m(float m3) { return Volume(m3); }
@@ -316,14 +320,14 @@ constexpr Volume ml(float ml) { return Volume(ml / (1000.0f * 1000.0f)); }
 // Precision: float.
 //
 // Units: Volts
-class Voltage : public units_detail::ArithScalar<Voltage, float> {
+class Voltage : public UnitsDetail::ArithScalar<Voltage, float> {
 public:
   [[nodiscard]] constexpr float volts() const { return val_; }
 
 private:
   constexpr friend Voltage volts(float v);
 
-  using units_detail::ArithScalar<Voltage, float>::ArithScalar;
+  using UnitsDetail::ArithScalar<Voltage, float>::ArithScalar;
 };
 
 constexpr Voltage volts(float v) { return Voltage(v); }
@@ -370,7 +374,7 @@ class Time;
 // This is unfortunate, but the alternative (not offering a
 // milliseconds(int64_t) factory) is worse, because converting an int64
 // milliseconds to float may lose useful precision.
-class Duration : public units_detail::ArithScalar<Duration, int64_t> {
+class Duration : public UnitsDetail::ArithScalar<Duration, int64_t> {
 public:
   [[nodiscard]] constexpr int64_t microseconds() const { return val_; }
   [[nodiscard]] constexpr float milliseconds() const {
@@ -389,7 +393,7 @@ public:
 private:
   constexpr friend Duration microseconds(int64_t micros);
 
-  using units_detail::ArithScalar<Duration, int64_t>::ArithScalar;
+  using UnitsDetail::ArithScalar<Duration, int64_t>::ArithScalar;
 };
 
 constexpr Duration microseconds(int64_t micros) { return Duration(micros); }
@@ -420,7 +424,7 @@ constexpr Duration minutes(float mins) { return seconds(mins * 60); }
 //  - microseconds
 //
 // Native unit (implementation detail): uint64_t microseconds
-class Time : public units_detail::Scalar<Time, uint64_t> {
+class Time : public UnitsDetail::Scalar<Time, uint64_t> {
 public:
   [[nodiscard]] uint64_t microsSinceStartup() const { return val_; }
 
@@ -434,7 +438,7 @@ public:
 private:
   constexpr friend Time microsSinceStartup(uint64_t micros);
 
-  using units_detail::Scalar<Time, uint64_t>::Scalar;
+  using UnitsDetail::Scalar<Time, uint64_t>::Scalar;
 };
 
 constexpr Time microsSinceStartup(uint64_t micros) { return Time(micros); }

--- a/software/controller/integration_tests/blower_test.h
+++ b/software/controller/integration_tests/blower_test.h
@@ -11,31 +11,31 @@
 #include "hal.h"
 
 // test parameters
-static constexpr Duration kDelay{milliseconds(10)};
-static constexpr float kFanMin{TEST_PARAM_1};
-static constexpr float kFanMax{TEST_PARAM_2};
-static constexpr float kInitialStep{0.002f};
+static constexpr Duration Delay{milliseconds(10)};
+static constexpr float FanMin{TEST_PARAM_1};
+static constexpr float FanMax{TEST_PARAM_2};
+static constexpr float InitialStep{0.002f};
 
 void RunTest() {
   hal.Init();
 
-  float fan_power = kFanMin;
-  float step = kInitialStep;
+  float fan_power = FanMin;
+  float step = InitialStep;
 
   while (true) {
     hal.AnalogWrite(PwmPin::Blower, fan_power);
-    hal.Delay(kDelay);
+    hal.Delay(Delay);
 
     hal.WatchdogHandler();
 
     fan_power += step;
-    if (fan_power >= kFanMax) {
+    if (fan_power >= FanMax) {
       // switch to ramp-down state
-      fan_power = kFanMax;
+      fan_power = FanMax;
       step = -step;
-    } else if (fan_power <= kFanMin) {
+    } else if (fan_power <= FanMin) {
       // switch to ramp-up state
-      fan_power = kFanMin;
+      fan_power = FanMin;
       step = -step;
     }
   }

--- a/software/controller/integration_tests/blower_test.h
+++ b/software/controller/integration_tests/blower_test.h
@@ -23,7 +23,7 @@ void RunTest() {
   float step = kInitialStep;
 
   while (true) {
-    hal.AnalogWrite(PwmPin::kBlower, fan_power);
+    hal.AnalogWrite(PwmPin::Blower, fan_power);
     hal.Delay(kDelay);
 
     hal.WatchdogHandler();

--- a/software/controller/integration_tests/blower_test.h
+++ b/software/controller/integration_tests/blower_test.h
@@ -11,31 +11,31 @@
 #include "hal.h"
 
 // test parameters
-static constexpr int64_t delay_ms{10};
-static constexpr float fan_min{TEST_PARAM_1};
-static constexpr float fan_max{TEST_PARAM_2};
-static constexpr float initial_step{0.002f};
+static constexpr Duration kDelay{milliseconds(10)};
+static constexpr float kFanMin{TEST_PARAM_1};
+static constexpr float kFanMax{TEST_PARAM_2};
+static constexpr float kInitialStep{0.002f};
 
-void run_test() {
-  Hal.init();
+void RunTest() {
+  hal.Init();
 
-  float fan_power = fan_min;
-  float step = initial_step;
+  float fan_power = kFanMin;
+  float step = kInitialStep;
 
   while (true) {
-    Hal.analogWrite(PwmPin::BLOWER, fan_power);
-    Hal.delay(milliseconds(delay_ms));
+    hal.AnalogWrite(PwmPin::kBlower, fan_power);
+    hal.Delay(kDelay);
 
-    Hal.watchdog_handler();
+    hal.WatchdogHandler();
 
     fan_power += step;
-    if (fan_power >= fan_max) {
+    if (fan_power >= kFanMax) {
       // switch to ramp-down state
-      fan_power = fan_max;
+      fan_power = kFanMax;
       step = -step;
-    } else if (fan_power <= fan_min) {
+    } else if (fan_power <= kFanMin) {
       // switch to ramp-up state
-      fan_power = fan_min;
+      fan_power = kFanMin;
       step = -step;
     }
   }

--- a/software/controller/integration_tests/buzzer_test.h
+++ b/software/controller/integration_tests/buzzer_test.h
@@ -11,38 +11,38 @@
 #include "hal.h"
 
 // test parameters
-static constexpr int64_t delay_ms{1000};
-static constexpr float volume_min{TEST_PARAM_1};
-static constexpr float volume_max{TEST_PARAM_2};
-static constexpr float initial_step{0.1f};
+static constexpr Duration kDelay{milliseconds(1000)};
+static constexpr float kMinVolume{TEST_PARAM_1};
+static constexpr float kMaxVolume{TEST_PARAM_2};
+static constexpr float kInitialStep{0.1f};
 
-void run_test() {
-  Hal.init();
+void RunTest() {
+  hal.Init();
 
-  float volume = volume_min;
-  float step = initial_step;
+  float volume = kMinVolume;
+  float step = kInitialStep;
 
   bool buzzer_on{false};
 
   while (true) {
     if (buzzer_on) {
-      Hal.BuzzerOn(volume);
+      hal.BuzzerOn(volume);
     } else {
-      Hal.BuzzerOff();
+      hal.BuzzerOff();
     }
 
-    Hal.delay(milliseconds(delay_ms));
+    hal.Delay(kDelay);
 
     buzzer_on = !buzzer_on;
     if (buzzer_on) {
       volume += step;
-      if (volume >= volume_max) {
+      if (volume >= kMaxVolume) {
         // switch to ramp-down state
-        volume = volume_max;
+        volume = kMaxVolume;
         step = -step;
-      } else if (volume <= volume_min) {
+      } else if (volume <= kMinVolume) {
         // switch to ramp-up state
-        volume = volume_min;
+        volume = kMinVolume;
         step = -step;
       }
     }

--- a/software/controller/integration_tests/buzzer_test.h
+++ b/software/controller/integration_tests/buzzer_test.h
@@ -11,16 +11,16 @@
 #include "hal.h"
 
 // test parameters
-static constexpr Duration kDelay{milliseconds(1000)};
-static constexpr float kMinVolume{TEST_PARAM_1};
-static constexpr float kMaxVolume{TEST_PARAM_2};
-static constexpr float kInitialStep{0.1f};
+static constexpr Duration Delay{milliseconds(1000)};
+static constexpr float MinVolume{TEST_PARAM_1};
+static constexpr float MaxVolume{TEST_PARAM_2};
+static constexpr float InitialStep{0.1f};
 
 void RunTest() {
   hal.Init();
 
-  float volume = kMinVolume;
-  float step = kInitialStep;
+  float volume = MinVolume;
+  float step = InitialStep;
 
   bool buzzer_on{false};
 
@@ -31,18 +31,18 @@ void RunTest() {
       hal.BuzzerOff();
     }
 
-    hal.Delay(kDelay);
+    hal.Delay(Delay);
 
     buzzer_on = !buzzer_on;
     if (buzzer_on) {
       volume += step;
-      if (volume >= kMaxVolume) {
+      if (volume >= MaxVolume) {
         // switch to ramp-down state
-        volume = kMaxVolume;
+        volume = MaxVolume;
         step = -step;
-      } else if (volume <= kMinVolume) {
+      } else if (volume <= MinVolume) {
         // switch to ramp-up state
-        volume = kMinVolume;
+        volume = MinVolume;
         step = -step;
       }
     }

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -77,14 +77,12 @@ static Debug::Command::VarHandler var_command;
 static Debug::Command::TraceHandler trace_command(&trace);
 static Debug::Command::EepromHandler eeprom_command(&eeprom);
 
-static Debug::Interface debug(&trace, 12, Debug::Command::Code::kMode,
-                              &mode_command, Debug::Command::Code::kPeek,
-                              &peek_command, Debug::Command::Code::kPoke,
-                              &poke_command, Debug::Command::Code::kVariable,
-                              &var_command, Debug::Command::Code::kTrace,
-                              &trace_command,
-                              Debug::Command::Code::kEepromAccess,
-                              &eeprom_command);
+static Debug::Interface
+    debug(&trace, 12, Debug::Command::Code::Mode, &mode_command,
+          Debug::Command::Code::Peek, &peek_command, Debug::Command::Code::Poke,
+          &poke_command, Debug::Command::Code::Variable, &var_command,
+          Debug::Command::Code::Trace, &trace_command,
+          Debug::Command::Code::EepromAccess, &eeprom_command);
 
 void RunTest() {
   hal.Init();

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -59,9 +59,9 @@ static DebugUInt32 dbg_addr_after("eeprom_after",
 static DebugUInt32 dbg_test_result("result", "result of the test", 0);
 
 // test parameters
-static constexpr uint16_t kAddress{TEST_PARAM_1};
-static constexpr uint8_t kData{TEST_PARAM_2};
-static constexpr uint16_t kLength{TEST_PARAM_3};
+static constexpr uint16_t Address{TEST_PARAM_1};
+static constexpr uint8_t Data{TEST_PARAM_2};
+static constexpr uint16_t Length{TEST_PARAM_3};
 
 // declaration of EEPROM
 static I2Ceeprom eeprom = I2Ceeprom(0x50, 64, 32768, &i2c1);
@@ -86,21 +86,21 @@ static Debug::Interface
 
 void RunTest() {
   hal.Init();
-  uint8_t eeprom_before[kLength];
-  uint8_t write_data[kLength];
-  uint8_t eeprom_after[kLength];
+  uint8_t eeprom_before[Length];
+  uint8_t write_data[Length];
+  uint8_t eeprom_after[Length];
   bool second_read_finished{false};
 
-  for (int i = 0; i < kLength; ++i) {
-    write_data[i] = kData;
+  for (int i = 0; i < Length; ++i) {
+    write_data[i] = Data;
   }
 
   hal.BuzzerOn(0.1f);
-  eeprom.ReadBytes(kAddress, kLength, &eeprom_before, nullptr);
+  eeprom.ReadBytes(Address, Length, &eeprom_before, nullptr);
 
-  eeprom.WriteBytes(kAddress, kLength, &write_data, nullptr);
+  eeprom.WriteBytes(Address, Length, &write_data, nullptr);
 
-  eeprom.ReadBytes(kAddress, kLength, &eeprom_after, &second_read_finished);
+  eeprom.ReadBytes(Address, Length, &eeprom_after, &second_read_finished);
 
   dbg_addr_before.Set(reinterpret_cast<uint32_t>(&eeprom_before));
   dbg_write_data.Set(reinterpret_cast<uint32_t>(&write_data));
@@ -114,7 +114,7 @@ void RunTest() {
   };
 
   bool failed = false;
-  for (int i = 0; i < kLength; i++) {
+  for (int i = 0; i < Length; i++) {
     if (eeprom_after[i] != write_data[i]) {
       failed = true;
       break;
@@ -126,7 +126,7 @@ void RunTest() {
   // Put the memory back in its initial state (note that if the initial read
   // failed, or the write method is broken, this will also fail and the eeprom
   // will end up in an undefined state).
-  eeprom.WriteBytes(kAddress, kLength, &eeprom_before, nullptr);
+  eeprom.WriteBytes(Address, Length, &eeprom_before, nullptr);
 
   // loop here to allow the above write to be processed, the buzzer to be
   // stopped after some time, and to process debug interface commands.

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -59,9 +59,9 @@ static DebugUInt32 dbg_addr_after("eeprom_after",
 static DebugUInt32 dbg_test_result("result", "result of the test", 0);
 
 // test parameters
-static constexpr uint16_t address{TEST_PARAM_1};
-static constexpr uint8_t data{TEST_PARAM_2};
-static constexpr uint16_t length{TEST_PARAM_3};
+static constexpr uint16_t kAddress{TEST_PARAM_1};
+static constexpr uint8_t kData{TEST_PARAM_2};
+static constexpr uint16_t kLength{TEST_PARAM_3};
 
 // declaration of EEPROM
 static I2Ceeprom eeprom = I2Ceeprom(0x50, 64, 32768, &i2c1);
@@ -86,23 +86,23 @@ static Debug::Interface debug(&trace, 12, Debug::Command::Code::kMode,
                               Debug::Command::Code::kEepromAccess,
                               &eeprom_command);
 
-void run_test() {
-  Hal.init();
-  uint8_t eeprom_before[length];
-  uint8_t write_data[length];
-  uint8_t eeprom_after[length];
+void RunTest() {
+  hal.Init();
+  uint8_t eeprom_before[kLength];
+  uint8_t write_data[kLength];
+  uint8_t eeprom_after[kLength];
   bool second_read_finished{false};
 
-  for (int i = 0; i < length; ++i) {
-    write_data[i] = data;
+  for (int i = 0; i < kLength; ++i) {
+    write_data[i] = kData;
   }
 
-  Hal.BuzzerOn(0.1f);
-  eeprom.ReadBytes(address, length, &eeprom_before, nullptr);
+  hal.BuzzerOn(0.1f);
+  eeprom.ReadBytes(kAddress, kLength, &eeprom_before, nullptr);
 
-  eeprom.WriteBytes(address, length, &write_data, nullptr);
+  eeprom.WriteBytes(kAddress, kLength, &write_data, nullptr);
 
-  eeprom.ReadBytes(address, length, &eeprom_after, &second_read_finished);
+  eeprom.ReadBytes(kAddress, kLength, &eeprom_after, &second_read_finished);
 
   dbg_addr_before.Set(reinterpret_cast<uint32_t>(&eeprom_before));
   dbg_write_data.Set(reinterpret_cast<uint32_t>(&write_data));
@@ -112,11 +112,11 @@ void run_test() {
   // (through DMA and/or hardware interrupts), with a 500 ms timeout: our I2C
   // bus is 400 kb/s, each of these operations should take less than 100 ms,
   // unless they are too big for our design anyway.
-  while (!second_read_finished && Hal.now() < microsSinceStartup(500000)) {
+  while (!second_read_finished && hal.Now() < microsSinceStartup(500000)) {
   };
 
   bool failed = false;
-  for (int i = 0; i < length; i++) {
+  for (int i = 0; i < kLength; i++) {
     if (eeprom_after[i] != write_data[i]) {
       failed = true;
       break;
@@ -128,15 +128,15 @@ void run_test() {
   // Put the memory back in its initial state (note that if the initial read
   // failed, or the write method is broken, this will also fail and the eeprom
   // will end up in an undefined state).
-  eeprom.WriteBytes(address, length, &eeprom_before, nullptr);
+  eeprom.WriteBytes(kAddress, kLength, &eeprom_before, nullptr);
 
   // loop here to allow the above write to be processed, the buzzer to be
   // stopped after some time, and to process debug interface commands.
   while (true) {
 
     // stop the buzzer after 1 second if the test is a success
-    if (!failed && Hal.now() > microsSinceStartup(1000000)) {
-      Hal.BuzzerOff();
+    if (!failed && hal.Now() > microsSinceStartup(1000000)) {
+      hal.BuzzerOff();
     }
 
     debug.Poll();

--- a/software/controller/integration_tests/idle_test.h
+++ b/software/controller/integration_tests/idle_test.h
@@ -12,12 +12,12 @@
 #include "hal.h"
 
 // test parameters
-static constexpr Duration kDelay{milliseconds(10)};
+static constexpr Duration Delay{milliseconds(10)};
 
 void RunTest() {
   hal.Init();
 
   while (true) {
-    hal.Delay(kDelay);
+    hal.Delay(Delay);
   }
 }

--- a/software/controller/integration_tests/idle_test.h
+++ b/software/controller/integration_tests/idle_test.h
@@ -12,12 +12,12 @@
 #include "hal.h"
 
 // test parameters
-static constexpr int64_t delay_ms{10};
+static constexpr Duration kDelay{milliseconds(10)};
 
-void run_test() {
-  Hal.init();
+void RunTest() {
+  hal.Init();
 
   while (true) {
-    Hal.delay(milliseconds(delay_ms));
+    hal.Delay(kDelay);
   }
 }

--- a/software/controller/integration_tests/main.cpp
+++ b/software/controller/integration_tests/main.cpp
@@ -2,4 +2,4 @@
 
 #include INTEGRATION_TEST_H
 
-int main() { run_test(); }
+int main() { RunTest(); }

--- a/software/controller/integration_tests/pinch_valve_test.h
+++ b/software/controller/integration_tests/pinch_valve_test.h
@@ -13,20 +13,20 @@
 #include "pinch_valve.h"
 
 // test parameters
-static constexpr int motor_index{TEST_PARAM_1};
-static constexpr int64_t delay_ms{1000};
+static constexpr int kMotorIndex{TEST_PARAM_1};
+static constexpr Duration kDelay{milliseconds(1000)};
 
-void run_test() {
-  Hal.init();
-  PinchValve pinch_valve(motor_index);
+void RunTest() {
+  hal.Init();
+  PinchValve pinch_valve(kMotorIndex);
   pinch_valve.Home();
 
   bool valve_open{false};
   while (true) {
     pinch_valve.SetOutput(valve_open ? 1.0f : 0.0f);
-    Hal.delay(milliseconds(delay_ms));
+    hal.Delay(kDelay);
 
-    Hal.watchdog_handler();
+    hal.WatchdogHandler();
 
     valve_open = !valve_open;
   }

--- a/software/controller/integration_tests/pinch_valve_test.h
+++ b/software/controller/integration_tests/pinch_valve_test.h
@@ -13,18 +13,18 @@
 #include "pinch_valve.h"
 
 // test parameters
-static constexpr int kMotorIndex{TEST_PARAM_1};
-static constexpr Duration kDelay{milliseconds(1000)};
+static constexpr int MotorIndex{TEST_PARAM_1};
+static constexpr Duration Delay{milliseconds(1000)};
 
 void RunTest() {
   hal.Init();
-  PinchValve pinch_valve(kMotorIndex);
+  PinchValve pinch_valve(MotorIndex);
   pinch_valve.Home();
 
   bool valve_open{false};
   while (true) {
     pinch_valve.SetOutput(valve_open ? 1.0f : 0.0f);
-    hal.Delay(kDelay);
+    hal.Delay(Delay);
 
     hal.WatchdogHandler();
 

--- a/software/controller/integration_tests/psol_test.h
+++ b/software/controller/integration_tests/psol_test.h
@@ -11,31 +11,31 @@
 #include "hal.h"
 
 // test parameters
-static constexpr Duration kDelay{milliseconds(10)};
-static constexpr float kPSolMin{TEST_PARAM_1};
-static constexpr float kPSolMax{TEST_PARAM_2};
-static constexpr float kInitialStep{TEST_PARAM_3};
+static constexpr Duration Delay{milliseconds(10)};
+static constexpr float PSolMin{TEST_PARAM_1};
+static constexpr float PSolMax{TEST_PARAM_2};
+static constexpr float InitialStep{TEST_PARAM_3};
 
 void RunTest() {
   hal.Init();
 
-  float psol_position = kPSolMin;
-  float step = kInitialStep;
+  float psol_position = PSolMin;
+  float step = InitialStep;
 
   while (true) {
     hal.PSolValue(psol_position);
-    hal.Delay(kDelay);
+    hal.Delay(Delay);
 
     hal.WatchdogHandler();
 
     psol_position += step;
-    if (psol_position >= kPSolMax) {
+    if (psol_position >= PSolMax) {
       // switch to ramp-down state
-      psol_position = kPSolMax;
+      psol_position = PSolMax;
       step = -step;
-    } else if (psol_position <= kPSolMin) {
+    } else if (psol_position <= PSolMin) {
       // switch to ramp-up state
-      psol_position = kPSolMin;
+      psol_position = PSolMin;
       step = -step;
     }
   }

--- a/software/controller/integration_tests/psol_test.h
+++ b/software/controller/integration_tests/psol_test.h
@@ -11,31 +11,31 @@
 #include "hal.h"
 
 // test parameters
-static constexpr int64_t delay_ms{10};
-static constexpr float psol_min{TEST_PARAM_1};
-static constexpr float psol_max{TEST_PARAM_2};
-static constexpr float initial_step{TEST_PARAM_3};
+static constexpr Duration kDelay{milliseconds(10)};
+static constexpr float kPSolMin{TEST_PARAM_1};
+static constexpr float kPSolMax{TEST_PARAM_2};
+static constexpr float kInitialStep{TEST_PARAM_3};
 
-void run_test() {
-  Hal.init();
+void RunTest() {
+  hal.Init();
 
-  float psol_position = psol_min;
-  float step = initial_step;
+  float psol_position = kPSolMin;
+  float step = kInitialStep;
 
   while (true) {
-    Hal.PSOL_Value(psol_position);
-    Hal.delay(milliseconds(delay_ms));
+    hal.PSolValue(psol_position);
+    hal.Delay(kDelay);
 
-    Hal.watchdog_handler();
+    hal.WatchdogHandler();
 
     psol_position += step;
-    if (psol_position >= psol_max) {
+    if (psol_position >= kPSolMax) {
       // switch to ramp-down state
-      psol_position = psol_max;
+      psol_position = kPSolMax;
       step = -step;
-    } else if (psol_position <= psol_min) {
+    } else if (psol_position <= kPSolMin) {
       // switch to ramp-up state
-      psol_position = psol_min;
+      psol_position = kPSolMin;
       step = -step;
     }
   }

--- a/software/controller/integration_tests/pure_virtual.cpp
+++ b/software/controller/integration_tests/pure_virtual.cpp
@@ -27,4 +27,7 @@ limitations under the License.
 // header in the putative library from each file with a pure virtual function.
 // We'd probably also need to remove the dependency on hal, so this could be
 // used from libraries that don't link with hal.
-extern "C" void __cxa_pure_virtual() { Hal.reset_device(); }
+
+// We don't control this function's name, silence the style check
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" void __cxa_pure_virtual() { hal.ResetDevice(); }

--- a/software/controller/integration_tests/stepper_test.h
+++ b/software/controller/integration_tests/stepper_test.h
@@ -14,23 +14,23 @@
 #include <cmath>
 
 // test parameters
-static constexpr int kMotorIndex{TEST_PARAM_1};
-static constexpr float kStepDegrees{TEST_PARAM_2};
-static constexpr Duration kDelay{milliseconds(1000)};
+static constexpr int MotorIndex{TEST_PARAM_1};
+static constexpr float StepDegrees{TEST_PARAM_2};
+static constexpr Duration Delay{milliseconds(1000)};
 
 void RunTest() {
   hal.Init();
 
   // Configure stepper
-  StepMotor *stepper_motor = StepMotor::GetStepper(kMotorIndex);
+  StepMotor *stepper_motor = StepMotor::GetStepper(MotorIndex);
   stepper_motor->SetAmpAll(0.1f);
   stepper_motor->SetMaxSpeed(100.0f);
   stepper_motor->SetAccel(100.0f / 0.1f);
   stepper_motor->ClearPosition();
 
   while (true) {
-    stepper_motor->MoveRel(kStepDegrees);
-    hal.Delay(kDelay);
+    stepper_motor->MoveRel(StepDegrees);
+    hal.Delay(Delay);
 
     hal.WatchdogHandler();
   }

--- a/software/controller/integration_tests/stepper_test.h
+++ b/software/controller/integration_tests/stepper_test.h
@@ -14,24 +14,24 @@
 #include <cmath>
 
 // test parameters
-static constexpr int motor_index{TEST_PARAM_1};
-static constexpr float step_degrees{TEST_PARAM_2};
-static constexpr int64_t delay_ms{1000};
+static constexpr int kMotorIndex{TEST_PARAM_1};
+static constexpr float kStepDegrees{TEST_PARAM_2};
+static constexpr Duration kDelay{milliseconds(1000)};
 
-void run_test() {
-  Hal.init();
+void RunTest() {
+  hal.Init();
 
   // Configure stepper
-  StepMotor *stepper_motor = StepMotor::GetStepper(motor_index);
+  StepMotor *stepper_motor = StepMotor::GetStepper(kMotorIndex);
   stepper_motor->SetAmpAll(0.1f);
   stepper_motor->SetMaxSpeed(100.0f);
   stepper_motor->SetAccel(100.0f / 0.1f);
   stepper_motor->ClearPosition();
 
   while (true) {
-    stepper_motor->MoveRel(step_degrees);
-    Hal.delay(milliseconds(delay_ms));
+    stepper_motor->MoveRel(kStepDegrees);
+    hal.Delay(kDelay);
 
-    Hal.watchdog_handler();
+    hal.WatchdogHandler();
   }
 }

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -26,7 +26,7 @@ static PinchValve exhale_pinch(1);
 
 void ActuatorsExecute(const ActuatorsState &desired_state) {
   // set blower PWM
-  hal.AnalogWrite(PwmPin::kBlower, desired_state.blower_power);
+  hal.AnalogWrite(PwmPin::Blower, desired_state.blower_power);
 
   // Set the blower pinch valve position
   if (desired_state.blower_valve)

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -24,9 +24,9 @@ static PinchValve exhale_pinch(1);
 // Called once at system startup to initialize any
 // actuators that need it
 
-void actuators_execute(const ActuatorsState &desired_state) {
+void ActuatorsExecute(const ActuatorsState &desired_state) {
   // set blower PWM
-  Hal.analogWrite(PwmPin::BLOWER, desired_state.blower_power);
+  hal.AnalogWrite(PwmPin::kBlower, desired_state.blower_power);
 
   // Set the blower pinch valve position
   if (desired_state.blower_valve)
@@ -40,7 +40,7 @@ void actuators_execute(const ActuatorsState &desired_state) {
   else
     exhale_pinch.Disable();
 
-  Hal.PSOL_Value(desired_state.fio2_valve);
+  hal.PSolValue(desired_state.fio2_valve);
 }
 
 // Return true if all actuators are enabled and ready for action

--- a/software/controller/lib/core/actuators.h
+++ b/software/controller/lib/core/actuators.h
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This module is responsible for passing the actuator commands to Hal to
+// This module is responsible for passing the actuator commands to hal to
 // generate the actual electrical signals.
 
 #ifndef ACTUATORS_H
@@ -41,7 +41,7 @@ struct ActuatorsState {
 };
 
 // Causes passed state to be applied to the actuators
-void actuators_execute(const ActuatorsState &desired_state);
+void ActuatorsExecute(const ActuatorsState &desired_state);
 
 // Returns true if the actuators are ready for action or false
 // if they aren't (for example pinch valves are homing).

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -100,7 +100,7 @@ PressureControlFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
     return {
         .pressure_setpoint = expire_pressure_ +
                              (inspire_pressure_ - expire_pressure_) * rise_frac,
-        .flow_direction = FlowDirection::kInspiratory,
+        .flow_direction = FlowDirection::Inspiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath = false,
@@ -108,7 +108,7 @@ PressureControlFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   } else { // expiratory part of the cycle
     return {
         .pressure_setpoint = expire_pressure_,
-        .flow_direction = FlowDirection::kExpiratory,
+        .flow_direction = FlowDirection::Expiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath = (now >= expire_end_),
@@ -136,7 +136,7 @@ PressureAssistFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
     return {
         .pressure_setpoint = expire_pressure_ +
                              (inspire_pressure_ - expire_pressure_) * rise_frac,
-        .flow_direction = FlowDirection::kInspiratory,
+        .flow_direction = FlowDirection::Inspiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath = false,
@@ -144,7 +144,7 @@ PressureAssistFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   } else { // expiratory part of the cycle
     return {
         .pressure_setpoint = expire_pressure_,
-        .flow_direction = FlowDirection::kExpiratory,
+        .flow_direction = FlowDirection::Expiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath =

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -93,14 +93,14 @@ BlowerSystemState
 PressureControlFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   if (now < inspire_end_) {
     // Go from expire_pressure_ to inspire_pressure_ over a duration of
-    // RISE_TIME.  Then for the rest of the inspire time, hold at
+    // kRiseTime.  Then for the rest of the inspire time, hold at
     // inspire_pressure_.
-    static_assert(RISE_TIME > milliseconds(0));
-    float rise_frac = std::min(1.f, (now - start_time_) / RISE_TIME);
+    static_assert(kRiseTime > milliseconds(0));
+    float rise_frac = std::min(1.f, (now - start_time_) / kRiseTime);
     return {
         .pressure_setpoint = expire_pressure_ +
                              (inspire_pressure_ - expire_pressure_) * rise_frac,
-        .flow_direction = FlowDirection::INSPIRATORY,
+        .flow_direction = FlowDirection::kInspiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath = false,
@@ -108,7 +108,7 @@ PressureControlFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   } else { // expiratory part of the cycle
     return {
         .pressure_setpoint = expire_pressure_,
-        .flow_direction = FlowDirection::EXPIRATORY,
+        .flow_direction = FlowDirection::kExpiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath = (now >= expire_end_),
@@ -129,14 +129,14 @@ BlowerSystemState
 PressureAssistFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   if (now < inspire_end_) {
     // Go from expire_pressure_ to inspire_pressure_ over a duration of
-    // RISE_TIME.  Then for the rest of the inspire time, hold at
+    // kRiseTime.  Then for the rest of the inspire time, hold at
     // inspire_pressure_.
-    static_assert(RISE_TIME > milliseconds(0));
-    float rise_frac = std::min(1.f, (now - start_time_) / RISE_TIME);
+    static_assert(kRiseTime > milliseconds(0));
+    float rise_frac = std::min(1.f, (now - start_time_) / kRiseTime);
     return {
         .pressure_setpoint = expire_pressure_ +
                              (inspire_pressure_ - expire_pressure_) * rise_frac,
-        .flow_direction = FlowDirection::INSPIRATORY,
+        .flow_direction = FlowDirection::kInspiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath = false,
@@ -144,7 +144,7 @@ PressureAssistFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   } else { // expiratory part of the cycle
     return {
         .pressure_setpoint = expire_pressure_,
-        .flow_direction = FlowDirection::EXPIRATORY,
+        .flow_direction = FlowDirection::kExpiratory,
         .pip = inspire_pressure_,
         .peep = expire_pressure_,
         .is_end_of_breath =

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -93,10 +93,10 @@ BlowerSystemState
 PressureControlFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   if (now < inspire_end_) {
     // Go from expire_pressure_ to inspire_pressure_ over a duration of
-    // kRiseTime.  Then for the rest of the inspire time, hold at
+    // RiseTime.  Then for the rest of the inspire time, hold at
     // inspire_pressure_.
-    static_assert(kRiseTime > milliseconds(0));
-    float rise_frac = std::min(1.f, (now - start_time_) / kRiseTime);
+    static_assert(RiseTime > milliseconds(0));
+    float rise_frac = std::min(1.f, (now - start_time_) / RiseTime);
     return {
         .pressure_setpoint = expire_pressure_ +
                              (inspire_pressure_ - expire_pressure_) * rise_frac,
@@ -129,10 +129,10 @@ BlowerSystemState
 PressureAssistFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
   if (now < inspire_end_) {
     // Go from expire_pressure_ to inspire_pressure_ over a duration of
-    // kRiseTime.  Then for the rest of the inspire time, hold at
+    // RiseTime.  Then for the rest of the inspire time, hold at
     // inspire_pressure_.
-    static_assert(kRiseTime > milliseconds(0));
-    float rise_frac = std::min(1.f, (now - start_time_) / kRiseTime);
+    static_assert(RiseTime > milliseconds(0));
+    float rise_frac = std::min(1.f, (now - start_time_) / RiseTime);
     return {
         .pressure_setpoint = expire_pressure_ +
                              (inspire_pressure_ - expire_pressure_) * rise_frac,

--- a/software/controller/lib/core/blower_fsm.h
+++ b/software/controller/lib/core/blower_fsm.h
@@ -51,8 +51,8 @@ limitations under the License.
 // https://respiraworks.slack.com/archives/CV4MTUJHF/p1588001011133500
 
 enum class FlowDirection {
-  INSPIRATORY,
-  EXPIRATORY,
+  kInspiratory,
+  kExpiratory,
 };
 
 // Sensor readings etc that are used by BlowerFsm to do e.g. breath detection.
@@ -90,7 +90,7 @@ struct BlowerSystemState {
 
 // Transition from PEEP to PIP pressure over this length of time.  Citation:
 // https://respiraworks.slack.com/archives/C011CJQV4Q7/p1591763842312500?thread_ts=1591759016.310200&cid=C011CJQV4Q7
-inline constexpr Duration RISE_TIME = milliseconds(100);
+inline constexpr Duration kRiseTime = milliseconds(100);
 
 // A "breath finite state machine" where the blower is always off.
 //
@@ -120,7 +120,7 @@ public:
         //
         // Same applies to the is_end_of_breath flag: it doesn't really pertain
         // to the off state but hardcode it to false by convention.
-        .flow_direction = FlowDirection::EXPIRATORY,
+        .flow_direction = FlowDirection::kExpiratory,
         .pip = cmH2O(0.0f),
         .peep = cmH2O(0.0f),
         .is_end_of_breath = false,

--- a/software/controller/lib/core/blower_fsm.h
+++ b/software/controller/lib/core/blower_fsm.h
@@ -90,7 +90,7 @@ struct BlowerSystemState {
 
 // Transition from PEEP to PIP pressure over this length of time.  Citation:
 // https://respiraworks.slack.com/archives/C011CJQV4Q7/p1591763842312500?thread_ts=1591759016.310200&cid=C011CJQV4Q7
-inline constexpr Duration kRiseTime = milliseconds(100);
+inline constexpr Duration RiseTime = milliseconds(100);
 
 // A "breath finite state machine" where the blower is always off.
 //

--- a/software/controller/lib/core/blower_fsm.h
+++ b/software/controller/lib/core/blower_fsm.h
@@ -51,8 +51,8 @@ limitations under the License.
 // https://respiraworks.slack.com/archives/CV4MTUJHF/p1588001011133500
 
 enum class FlowDirection {
-  kInspiratory,
-  kExpiratory,
+  Inspiratory,
+  Expiratory,
 };
 
 // Sensor readings etc that are used by BlowerFsm to do e.g. breath detection.
@@ -120,7 +120,7 @@ public:
         //
         // Same applies to the is_end_of_breath flag: it doesn't really pertain
         // to the off state but hardcode it to false by convention.
-        .flow_direction = FlowDirection::kExpiratory,
+        .flow_direction = FlowDirection::Expiratory,
         .pip = cmH2O(0.0f),
         .peep = cmH2O(0.0f),
         .is_end_of_breath = false,

--- a/software/controller/lib/core/comms.cpp
+++ b/software/controller/lib/core/comms.cpp
@@ -35,18 +35,18 @@ static bool rx_in_progress = false;
 
 // We currently lack proper message framing, so we use a timeout to determine
 // when the GUI is done sending us its message.
-static constexpr Duration kRxTimeout = milliseconds(1);
+static constexpr Duration RxTimeout = milliseconds(1);
 
 // We send a ControllerStatus every TX_INTERVAL_MS.
 
 // In Alpha build we use synchronized communication initiated by GUI cycle
 // controller. Since both ControllerStatus and GuiStatus take roughly 300+
 // bytes, we need at least 1/115200.*10*300=26ms to transmit.
-static constexpr Duration kTxInterval = milliseconds(30);
+static constexpr Duration TxInterval = milliseconds(30);
 
 void CommsInit() {}
 
-static bool IsTimeToProcessPacket() { return hal.Now() - last_rx > kRxTimeout; }
+static bool IsTimeToProcessPacket() { return hal.Now() - last_rx > RxTimeout; }
 
 // NOTE this is work in progress.
 // Proper framing incomming. Afproto will be used to encode data to form that
@@ -68,7 +68,7 @@ static void ProcessTx(const ControllerStatus &controller_status) {
   //  - we can transmit at least one byte now, and
   //  - it's been a while since we last transmitted.
   if (tx_bytes_remaining == 0 &&
-      (last_tx == std::nullopt || hal.Now() - *last_tx > kTxInterval)) {
+      (last_tx == std::nullopt || hal.Now() - *last_tx > TxInterval)) {
     // Serialize current status into output buffer.
     //
     // TODO: Frame the message bytes.

--- a/software/controller/lib/core/comms.h
+++ b/software/controller/lib/core/comms.h
@@ -21,14 +21,14 @@ limitations under the License.
 
 // This module periodically sends messages to the GUI device and receives
 // messages from the GUI.  The only way it communicates with other modules is
-// by modifying the gui_status pointer in comms_handler.
+// by modifying the gui_status pointer in CommsHandler.
 
-void comms_init();
+void CommsInit();
 
 // `controller_status` should be the controller's current status.  It's sent
 // periodically to the GUI.  When we receive a message from the GUI, we update
 // gui_status accordingly.
-void comms_handler(const ControllerStatus &controller_status,
-                   GuiStatus *gui_status);
+void CommsHandler(const ControllerStatus &controller_status,
+                  GuiStatus *gui_status);
 
 #endif // COMMS_H

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <math.h>
 
-static constexpr Duration kLoopPeriod = milliseconds(10);
+static constexpr Duration LoopPeriod = milliseconds(10);
 
 static DebugFloat dbg_forced_blower_power(
     "forced_blower_power",
@@ -43,7 +43,7 @@ static DebugFloat dbg_forced_psol_pos(
 
 // Unchanging outputs - read from external debug program, never modified here.
 static DebugUInt32 dbg_per("loop_period", "Loop period, read-only (usec)",
-                           static_cast<uint32_t>(kLoopPeriod.microseconds()));
+                           static_cast<uint32_t>(LoopPeriod.microseconds()));
 
 // Outputs - read from external debug program, modified here.
 static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint (cmH2O)");
@@ -60,7 +60,7 @@ static DebugFloat dbg_flow_correction("flow_correction",
 static DebugUInt32 dbg_breath_id("breath_id",
                                  "ID of the current breath, read-only", 0);
 
-/*static*/ Duration Controller::GetLoopPeriod() { return kLoopPeriod; }
+/*static*/ Duration Controller::GetLoopPeriod() { return LoopPeriod; }
 
 std::pair<ActuatorsState, ControllerState>
 Controller::Run(Time now, const VentParams &params,

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <math.h>
 
-static constexpr Duration LOOP_PERIOD = milliseconds(10);
+static constexpr Duration kLoopPeriod = milliseconds(10);
 
 static DebugFloat dbg_forced_blower_power(
     "forced_blower_power",
@@ -43,7 +43,7 @@ static DebugFloat dbg_forced_psol_pos(
 
 // Unchanging outputs - read from external debug program, never modified here.
 static DebugUInt32 dbg_per("loop_period", "Loop period, read-only (usec)",
-                           static_cast<uint32_t>(LOOP_PERIOD.microseconds()));
+                           static_cast<uint32_t>(kLoopPeriod.microseconds()));
 
 // Outputs - read from external debug program, modified here.
 static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint (cmH2O)");
@@ -60,7 +60,7 @@ static DebugFloat dbg_flow_correction("flow_correction",
 static DebugUInt32 dbg_breath_id("breath_id",
                                  "ID of the current breath, read-only", 0);
 
-/*static*/ Duration Controller::GetLoopPeriod() { return LOOP_PERIOD; }
+/*static*/ Duration Controller::GetLoopPeriod() { return kLoopPeriod; }
 
 std::pair<ActuatorsState, ControllerState>
 Controller::Run(Time now, const VentParams &params,

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#ifndef CONTROLLER_H_
-#define CONTROLLER_H_
+#ifndef CONTROLLER_H
+#define CONTROLLER_H
 
 #include "actuators.h"
 #include "blower_fsm.h"
@@ -97,12 +97,12 @@ private:
   BlowerFsm fsm_;
   PID blower_valve_pid_ =
       PID(dbg_blower_valve_kp.Get(), dbg_blower_valve_computed_ki.Get(),
-          dbg_blower_valve_kd.Get(), ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, /*output_min=*/0.f,
+          dbg_blower_valve_kd.Get(), ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, /*output_min=*/0.f,
           /*output_max=*/1.0f);
   PID psol_pid_ =
       PID(dbg_psol_kp.Get(), dbg_psol_ki.Get(), dbg_psol_kd.Get(),
-          ProportionalTerm::ON_ERROR, DifferentialTerm::ON_MEASUREMENT,
+          ProportionalTerm::kOnError, DifferentialTerm::kOnMeasurement,
           /*output_min=*/0.f, /*output_max=*/1.0f);
 
   // These objects accumulate flow to calculate volume.
@@ -121,4 +121,4 @@ private:
   bool ventilator_was_on_{false};
 };
 
-#endif // CONTROLLER_H_
+#endif // CONTROLLER_H

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -97,12 +97,12 @@ private:
   BlowerFsm fsm_;
   PID blower_valve_pid_ =
       PID(dbg_blower_valve_kp.Get(), dbg_blower_valve_computed_ki.Get(),
-          dbg_blower_valve_kd.Get(), ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, /*output_min=*/0.f,
+          dbg_blower_valve_kd.Get(), ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, /*output_min=*/0.f,
           /*output_max=*/1.0f);
   PID psol_pid_ =
       PID(dbg_psol_kp.Get(), dbg_psol_ki.Get(), dbg_psol_kd.Get(),
-          ProportionalTerm::kOnError, DifferentialTerm::kOnMeasurement,
+          ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
           /*output_min=*/0.f, /*output_max=*/1.0f);
 
   // These objects accumulate flow to calculate volume.

--- a/software/controller/lib/core/flow_integrator.cpp
+++ b/software/controller/lib/core/flow_integrator.cpp
@@ -16,8 +16,8 @@ limitations under the License.
 #include "flow_integrator.h"
 #include "vars.h"
 
-// TODO: VOLUME_INTEGRAL_INTERVAL was not chosen carefully.
-static constexpr Duration VOLUME_INTEGRAL_INTERVAL = milliseconds(5);
+// TODO: kVVolumeIntegrationInterval was not chosen carefully.
+static constexpr Duration kVVolumeIntegrationInterval = milliseconds(5);
 
 FlowIntegrator::FlowIntegrator() = default;
 
@@ -35,7 +35,7 @@ void FlowIntegrator::AddFlow(Time now, VolumetricFlow uncorrected_flow) {
   }
 
   Duration time_since_last_note = now - *last_flow_measurement_time_;
-  if (time_since_last_note >= VOLUME_INTEGRAL_INTERVAL) {
+  if (time_since_last_note >= kVVolumeIntegrationInterval) {
     volume_ += time_since_last_note * (last_flow_ + flow) / 2.0f;
     last_flow_measurement_time_ = now;
     last_flow_ = flow;

--- a/software/controller/lib/core/flow_integrator.cpp
+++ b/software/controller/lib/core/flow_integrator.cpp
@@ -16,8 +16,8 @@ limitations under the License.
 #include "flow_integrator.h"
 #include "vars.h"
 
-// TODO: kVVolumeIntegrationInterval was not chosen carefully.
-static constexpr Duration kVVolumeIntegrationInterval = milliseconds(5);
+// TODO: VolumeIntegrationInterval was not chosen carefully.
+static constexpr Duration VolumeIntegrationInterval = milliseconds(5);
 
 FlowIntegrator::FlowIntegrator() = default;
 
@@ -35,7 +35,7 @@ void FlowIntegrator::AddFlow(Time now, VolumetricFlow uncorrected_flow) {
   }
 
   Duration time_since_last_note = now - *last_flow_measurement_time_;
-  if (time_since_last_note >= kVVolumeIntegrationInterval) {
+  if (time_since_last_note >= VolumeIntegrationInterval) {
     volume_ += time_since_last_note * (last_flow_ + flow) / 2.0f;
     last_flow_measurement_time_ = now;
     last_flow_ = flow;

--- a/software/controller/lib/core/flow_integrator.h
+++ b/software/controller/lib/core/flow_integrator.h
@@ -73,7 +73,7 @@ private:
   //    observe is equal to true flow plus an error, and that error changes
   //    slowly relative to how quickly we can read the sensor.
   //
-  // flow_correction_ handles this low-frequency error.  It's common to see
+  // flow_correction handles this low-frequency error.  It's common to see
   // this error change by as much as 15ml/s between breaths.
   VolumetricFlow flow_correction_ = cubic_m_per_sec(0);
   // Time of last call to NoteExpectedVolume.

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -42,12 +42,12 @@ static DebugUInt32 dbg_nvparams("nvparams_address", "Address of nv_params", 0);
 namespace NVParams {
 
 // Size of the parameter block including the header
-static constexpr uint32_t kSize{sizeof(Structure)};
+static constexpr uint32_t Size{sizeof(Structure)};
 
 // Calculate the CRC of the params at this address
 static uint32_t CRC(Structure *param) {
   uint8_t *ptr = reinterpret_cast<uint8_t *>(param);
-  return SoftCRC32(ptr + sizeof(uint32_t), kSize - sizeof(uint32_t));
+  return SoftCRC32(ptr + sizeof(uint32_t), Size - sizeof(uint32_t));
 }
 
 // Checks whether a param is valid (through its checksum)
@@ -123,7 +123,7 @@ void Handler::Init(I2Ceeprom *eeprom) {
 bool Handler::Set(uint16_t offset, void *value, uint8_t len) {
   // Make sure the passed pointer is pointing to somewhere
   // in the structure and isn't in the reserved first 6 bytes
-  if ((offset < 6) || ((offset + len) > kSize))
+  if ((offset < 6) || ((offset + len) > Size))
     return false;
 
   // Update the contents in nv_params
@@ -162,7 +162,7 @@ bool Handler::Get(uint16_t offset, void *value, uint8_t len) {
 #ifndef TEST_MODE // in test mode I need to be able to access any byte
   // Make sure the passed pointer is pointing to somewhere
   // in the structure and isn't in the reserved first 6 bytes
-  if ((offset < 6) || ((offset + len) > kSize))
+  if ((offset < 6) || ((offset + len) > Size))
     return false;
 #endif
   memcpy(value, reinterpret_cast<uint8_t *>(&nv_param_) + offset, len);
@@ -172,7 +172,7 @@ bool Handler::Get(uint16_t offset, void *value, uint8_t len) {
 // call this function in order to write variables to nv_params
 void Handler::Update(const Time now, VentParams *params) {
   // We only update cumulated service every so often
-  if (now >= last_update_ + kUpdateInterval) {
+  if (now >= last_update_ + UpdateInterval) {
     uint32_t cumulated = nv_param_.cumulated_service +
                          static_cast<uint32_t>((now - last_update_).seconds());
     Set(offsetof(Structure, cumulated_service), &cumulated, 4);
@@ -213,7 +213,7 @@ void Handler::Update(const Time now, VentParams *params) {
 bool Handler::ReadFullParams(Address address, Structure *param,
                              I2Ceeprom *eeprom) {
   bool read_finished{false};
-  eeprom->ReadBytes(static_cast<uint16_t>(address), kSize, param,
+  eeprom->ReadBytes(static_cast<uint16_t>(address), Size, param,
                     &read_finished);
   Time start_time = hal.Now();
   // Wait until the read is performed, or at most 500 ms: reading 4kB should
@@ -230,7 +230,7 @@ bool Handler::ReadFullParams(Address address, Structure *param,
 }
 
 void Handler::WriteFullParams(Address address) {
-  eeprom_->WriteBytes(static_cast<uint16_t>(address), kSize, &nv_param_,
+  eeprom_->WriteBytes(static_cast<uint16_t>(address), Size, &nv_param_,
                       nullptr);
   // for a write, we don't really need to wait until the request is processed:
   // the I2C queue should ensure nothing is lost.

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -65,28 +65,28 @@ void Handler::Init(I2Ceeprom *eeprom) {
     linked_to_eeprom_ = true;
   }
   // Read flip side
-  if (ReadFullParams(Address::kFlip, &nv_param_, eeprom_)) {
-    nvparam_addr_ = Address::kFlip;
+  if (ReadFullParams(Address::Flip, &nv_param_, eeprom_)) {
+    nvparam_addr_ = Address::Flip;
     // check its validity
     if (IsValid(&nv_param_)) {
       // Still read the flop in case they are both valid (which normally
       // shouldn't happen but could if power is lost at just the right
       // time when writing).
       Structure flop;
-      ReadFullParams(Address::kFlop, &flop, eeprom_);
+      ReadFullParams(Address::Flop, &flop, eeprom_);
       // check its validity
       if (IsValid(&flop)) {
         // Check the counter and keep flop if it is the most recent one
         if (flop.count > nv_param_.count ||
             (flop.count == 0 && nv_param_.count == 0xFF)) {
           nv_param_ = flop;
-          nvparam_addr_ = Address::kFlop;
+          nvparam_addr_ = Address::Flop;
         }
       }
     } else { // flip is invalid ==> check the flop
-      ReadFullParams(Address::kFlop, &nv_param_, eeprom_);
+      ReadFullParams(Address::Flop, &nv_param_, eeprom_);
       if (IsValid(&nv_param_)) {
-        nvparam_addr_ = Address::kFlop;
+        nvparam_addr_ = Address::Flop;
       } else {
         // none of the flip/flop is valid
         // TODO: this should only happen during the very first use of a
@@ -107,8 +107,8 @@ void Handler::Init(I2Ceeprom *eeprom) {
     nv_param_ = Structure();
     nv_param_.crc = CRC(&nv_param_);
     if (linked_to_eeprom_) {
-      WriteFullParams(Address::kFlip);
-      WriteFullParams(Address::kFlop);
+      WriteFullParams(Address::Flip);
+      WriteFullParams(Address::Flop);
     }
   }
   // set write access dbg_vars = nv_params to prevent the first pass in
@@ -134,9 +134,9 @@ bool Handler::Set(uint16_t offset, void *value, uint8_t len) {
 
   if (linked_to_eeprom_) {
     // Update the contents in eeprom (with flip/flop logic)
-    uint16_t new_address{static_cast<uint16_t>(Address::kFlip)};
-    if (nvparam_addr_ == Address::kFlip) {
-      new_address = static_cast<uint16_t>(Address::kFlop);
+    uint16_t new_address{static_cast<uint16_t>(Address::Flip)};
+    if (nvparam_addr_ == Address::Flip) {
+      new_address = static_cast<uint16_t>(Address::Flop);
     }
     // write the changed data and both crc+counter to the new side
     eeprom_->WriteBytes(static_cast<uint16_t>(new_address + offset), len, value,
@@ -149,10 +149,10 @@ bool Handler::Set(uint16_t offset, void *value, uint8_t len) {
         static_cast<uint16_t>(static_cast<uint16_t>(nvparam_addr_) + offset),
         len, value, nullptr);
     // point nvparam_address to the newly-written side
-    if (nvparam_addr_ == Address::kFlip) {
-      nvparam_addr_ = Address::kFlop;
+    if (nvparam_addr_ == Address::Flip) {
+      nvparam_addr_ = Address::Flop;
     } else {
-      nvparam_addr_ = Address::kFlip;
+      nvparam_addr_ = Address::Flip;
     }
   }
   return true;

--- a/software/controller/lib/core/nvparams.h
+++ b/software/controller/lib/core/nvparams.h
@@ -52,8 +52,8 @@ struct Structure {
 static_assert(sizeof(Structure) <= 4096);
 
 enum class Address {
-  kFlip = 0,
-  kFlop = 4096,
+  Flip = 0,
+  Flop = 4096,
 };
 
 // Class that encapsulates NVParams. We need the Structure to be
@@ -71,7 +71,7 @@ public:
 private:
   Structure nv_param_;
   // Address of valid parameter block - defaulted to Flip
-  Address nvparam_addr_{Address::kFlip};
+  Address nvparam_addr_{Address::Flip};
   Time last_update_{microsSinceStartup(0)};
   I2Ceeprom *eeprom_{nullptr};
   // Update cumulated service interval

--- a/software/controller/lib/core/nvparams.h
+++ b/software/controller/lib/core/nvparams.h
@@ -75,7 +75,7 @@ private:
   Time last_update_{microsSinceStartup(0)};
   I2Ceeprom *eeprom_{nullptr};
   // Update cumulated service interval
-  static constexpr Duration kUpdateInterval{seconds(60)};
+  static constexpr Duration UpdateInterval{seconds(60)};
   bool linked_to_eeprom_{false}; // in case of EEPROM failure at startup,
                                  // we can spare ourselves the need to write
                                  // data to the eeprom, even if we will still

--- a/software/controller/lib/core/nvparams.h
+++ b/software/controller/lib/core/nvparams.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef NVPARAM_H_
-#define NVPARAM_H_
+#ifndef NVPARAM_H
+#define NVPARAM_H
 
 #include "eeprom.h"
 #include "network_protocol.pb.h"
@@ -91,11 +91,11 @@ private:
 // structure given its name.
 // Because these are macros, they cannot be part of the NVParams namespace, but
 // should still only be used as member functions of the Handler class.
-#define NVparamsUpdate(member, value)                                          \
+#define NV_PARAMS_UPDATE(member, value)                                        \
   Set(static_cast<uint16_t>(offsetof(Structure, member)), value,               \
       (sizeof(((Structure *)0)->member)))
-#define NVparamsRead(member, value)                                            \
+#define NV_PARAMS_READ(member, value)                                          \
   Get(static_cast<uint16_t>(offsetof(Structure, member)), value,               \
       (sizeof(((Structure *)0)->member)))
 
-#endif // NVPARAM_H_
+#endif // NVPARAM_H

--- a/software/controller/lib/core/pinch_valve.cpp
+++ b/software/controller/lib/core/pinch_valve.cpp
@@ -27,41 +27,41 @@ limitations under the License.
 // be able to come up with a good set of values here that
 // won't need further modification.
 
-// move_dir should be set to either 1 or -1 depending on the
+// kMoveDir should be set to either 1 or -1 depending on the
 // desired direction of motion of the pinch valve.
-static constexpr float move_dir = -1.0f;
+static constexpr float kMoveDir = -1.0f;
 
 // Amplitude of the power level used for homing.
 // 0.1 is 10% of maximum.  There's no need for high
 // power when homing, we're intentionally driving the
 // motor against a hard stop.
-static constexpr float home_amp = 0.1f;
+static constexpr float kHomeAmp = 0.1f;
 
 // Velocity (deg/sec), acceleration (deg/sec/sec)
 // and distance (deg) to move during the home
-static constexpr float home_vel = 60.0f;
-static constexpr float home_accel = home_vel / 0.1f;
-static constexpr float home_dist = 90.0f * move_dir;
+static constexpr float kHomeVel = 60.0f;
+static constexpr float kHomeAccel = kHomeVel / 0.1f;
+static constexpr float kHomeDist = 90.0f * kMoveDir;
 
 // Amount we can move away from the homing end stop before
 // we start to touch the tube (deg)
-static constexpr float home_offset = 30.0f * move_dir;
+static constexpr float kHomeOffset = 30.0f * kMoveDir;
 
 // This is the distance (deg) from the zero position until
 // the tube is completely shut.
-static constexpr float max_move = 50.0f * move_dir;
+static constexpr float kMaxMove = 50.0f * kMoveDir;
 
 // Amplitude of power level for normal operation.
 // Don't go crazy here, you can easily overheat the
 // motor driver chips and stepper motors.
-static constexpr float move_amp = 0.25f;
+static constexpr float kMoveAmp = 0.25f;
 
 // Speed/accel for normal moves.  We want the motor
 // to be quick because the PID loop output will be
 // small move and ideally we want it to finish before
 // the next loop cycle
-static constexpr float move_vel = 2000.0f;
-static constexpr float move_acc = move_vel / 0.05f;
+static constexpr float kMoveVel = 2000.0f;
+static constexpr float kMoveAccel = kMoveVel / 0.05f;
 
 // This table is used to roughly linearize the pinch valve
 // output.  It was built by adjusting the pinch valve and
@@ -71,7 +71,7 @@ static constexpr float move_acc = move_vel / 0.05f;
 // the setting for 0 flow rate (normally 0) and the last entry
 // should be the setting for 100% flow rate.  The minimum
 // length of the table is 2 entries.
-static constexpr float flow_table[] = {0.0000f, 0.0410f, 0.0689f, 0.0987f,
+static constexpr float kFlowTable[] = {0.0000f, 0.0410f, 0.0689f, 0.0987f,
                                        0.1275f, 0.1590f, 0.1932f, 0.2359f,
                                        0.2940f, 0.3988f, 1.0000f};
 
@@ -84,7 +84,7 @@ void PinchValve::Disable() {
   if (!mtr)
     return;
 
-  home_state_ = PinchValveHomeState::DISABLED;
+  home_state_ = PinchValveHomeState::kDisabled;
   mtr->HardDisable();
 }
 
@@ -102,90 +102,90 @@ void PinchValve::Home() {
 
   switch (home_state_) {
 
-  case PinchValveHomeState::DISABLED:
-    home_state_ = PinchValveHomeState::LOWER_AMP;
+  case PinchValveHomeState::kDisabled:
+    home_state_ = PinchValveHomeState::kLowerAmp;
     // fall through
 
   // Limit motor power during homing.
-  case PinchValveHomeState::LOWER_AMP:
-    err = mtr->SetAmpAll(home_amp);
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::SET_HOME_SPEED;
+  case PinchValveHomeState::kLowerAmp:
+    err = mtr->SetAmpAll(kHomeAmp);
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kSetHomeSpeed;
     break;
 
   // Set the move speed/accel to be used during homing
-  case PinchValveHomeState::SET_HOME_SPEED:
-    err = mtr->SetMaxSpeed(home_vel);
-    if (err == StepMtrErr::OK)
-      err = mtr->SetAccel(home_accel);
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::MOVE_TO_STOP;
+  case PinchValveHomeState::kSetHomeSpeed:
+    err = mtr->SetMaxSpeed(kHomeVel);
+    if (err == StepMtrErr::kOk)
+      err = mtr->SetAccel(kHomeAccel);
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kMoveToStop;
     break;
 
   // Start a relative move into the hard stop
-  case PinchValveHomeState::MOVE_TO_STOP:
-    move_start_time_ = Hal.now();
-    err = mtr->MoveRel(home_dist);
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::WAIT_MOVE_STOP;
+  case PinchValveHomeState::kMoveToStop:
+    move_start_time_ = hal.Now();
+    err = mtr->MoveRel(kHomeDist);
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kWaitMoveStop;
     break;
 
   // Wait for the move to hard stop to end
-  case PinchValveHomeState::WAIT_MOVE_STOP: {
-    Duration dt = Hal.now() - move_start_time_;
+  case PinchValveHomeState::kWaitMoveStop: {
+    Duration dt = hal.Now() - move_start_time_;
     if (dt.seconds() >= 3.0f)
-      home_state_ = PinchValveHomeState::SET_NORMAL_AMP;
+      home_state_ = PinchValveHomeState::kSetNormalAmp;
     break;
   }
 
   // Switch to normal power setting
-  case PinchValveHomeState::SET_NORMAL_AMP:
-    err = mtr->SetAmpAll(move_amp);
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::MOVE_OFFSET;
+  case PinchValveHomeState::kSetNormalAmp:
+    err = mtr->SetAmpAll(kMoveAmp);
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kMoveOffset;
     break;
 
   // Make a relative move away from the hard stop.
   // This should cause us to end up with the bearings
   // just touching the tube, but not squeezing it.
-  case PinchValveHomeState::MOVE_OFFSET:
-    move_start_time_ = Hal.now();
-    err = mtr->MoveRel(-home_offset);
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::WAIT_MOVE_OFFSET;
+  case PinchValveHomeState::kMoveOffset:
+    move_start_time_ = hal.Now();
+    err = mtr->MoveRel(-kHomeOffset);
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kWaitMoveOffset;
     break;
 
-  case PinchValveHomeState::WAIT_MOVE_OFFSET: {
-    Duration dt = Hal.now() - move_start_time_;
+  case PinchValveHomeState::kWaitMoveOffset: {
+    Duration dt = hal.Now() - move_start_time_;
     if (dt.seconds() >= 2.0f)
-      home_state_ = PinchValveHomeState::ZERO_POS;
+      home_state_ = PinchValveHomeState::kZeroPos;
     break;
   }
 
   // Set the current position to zero
-  case PinchValveHomeState::ZERO_POS:
+  case PinchValveHomeState::kZeroPos:
     err = mtr->ClearPosition();
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::SET_NORMAL_SPEED;
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kSetNormalSpeed;
     break;
 
   // Switch to normal move speed/accel
-  case PinchValveHomeState::SET_NORMAL_SPEED:
+  case PinchValveHomeState::kSetNormalSpeed:
 
-    err = mtr->SetMaxSpeed(move_vel);
-    if (err == StepMtrErr::OK)
-      err = mtr->SetAccel(move_acc);
-    if (err == StepMtrErr::OK)
-      home_state_ = PinchValveHomeState::HOMED;
+    err = mtr->SetMaxSpeed(kMoveVel);
+    if (err == StepMtrErr::kOk)
+      err = mtr->SetAccel(kMoveAccel);
+    if (err == StepMtrErr::kOk)
+      home_state_ = PinchValveHomeState::kHomed;
 
-  case PinchValveHomeState::HOMED:
+  case PinchValveHomeState::kHomed:
     break;
   }
 }
 
 void PinchValve::SetOutput(float value) {
 
-  if (home_state_ != PinchValveHomeState::HOMED) {
+  if (home_state_ != PinchValveHomeState::kHomed) {
     Home();
     return;
   }
@@ -197,7 +197,7 @@ void PinchValve::SetOutput(float value) {
   value = std::clamp(value, 0.0f, 1.0f);
 
   // Number of intervals defined by the table.
-  float tbl_len = std::size(flow_table) - 1;
+  float tbl_len = std::size(kFlowTable) - 1;
 
   // Convert the input value based on a table
   // used to linearize the pinch valve output
@@ -205,15 +205,15 @@ void PinchValve::SetOutput(float value) {
   float f = value * tbl_len - static_cast<float>(n);
 
   if (n == static_cast<int>(tbl_len))
-    value = flow_table[n];
+    value = kFlowTable[n];
   else
-    value = flow_table[n] + f * (flow_table[n + 1] - flow_table[n]);
+    value = kFlowTable[n] + f * (kFlowTable[n + 1] - kFlowTable[n]);
 
   // Convert the value to an absolute position in deg
   // The motor's zero position is at the home offset
   // which corresponds to fully open (i.e. 100% flow)
-  // The valve is closed at a position of -max_move;
-  float pos = (value - 1.0f) * max_move;
+  // The valve is closed at a position of -kMaxMove;
+  float pos = (value - 1.0f) * kMaxMove;
 
   // Once you put a move in motion you can't change the destination position
   // until the move ends. That means that if the servo loop commands a

--- a/software/controller/lib/core/pinch_valve.cpp
+++ b/software/controller/lib/core/pinch_valve.cpp
@@ -27,41 +27,41 @@ limitations under the License.
 // be able to come up with a good set of values here that
 // won't need further modification.
 
-// kMoveDir should be set to either 1 or -1 depending on the
+// MoveDir should be set to either 1 or -1 depending on the
 // desired direction of motion of the pinch valve.
-static constexpr float kMoveDir = -1.0f;
+static constexpr float MoveDir = -1.0f;
 
 // Amplitude of the power level used for homing.
 // 0.1 is 10% of maximum.  There's no need for high
 // power when homing, we're intentionally driving the
 // motor against a hard stop.
-static constexpr float kHomeAmp = 0.1f;
+static constexpr float HomeAmp = 0.1f;
 
 // Velocity (deg/sec), acceleration (deg/sec/sec)
 // and distance (deg) to move during the home
-static constexpr float kHomeVel = 60.0f;
-static constexpr float kHomeAccel = kHomeVel / 0.1f;
-static constexpr float kHomeDist = 90.0f * kMoveDir;
+static constexpr float HomeVel = 60.0f;
+static constexpr float HomeAccel = HomeVel / 0.1f;
+static constexpr float HomeDist = 90.0f * MoveDir;
 
 // Amount we can move away from the homing end stop before
 // we start to touch the tube (deg)
-static constexpr float kHomeOffset = 30.0f * kMoveDir;
+static constexpr float HomeOffset = 30.0f * MoveDir;
 
 // This is the distance (deg) from the zero position until
 // the tube is completely shut.
-static constexpr float kMaxMove = 50.0f * kMoveDir;
+static constexpr float MaxMove = 50.0f * MoveDir;
 
 // Amplitude of power level for normal operation.
 // Don't go crazy here, you can easily overheat the
 // motor driver chips and stepper motors.
-static constexpr float kMoveAmp = 0.25f;
+static constexpr float MoveAmp = 0.25f;
 
 // Speed/accel for normal moves.  We want the motor
 // to be quick because the PID loop output will be
 // small move and ideally we want it to finish before
 // the next loop cycle
-static constexpr float kMoveVel = 2000.0f;
-static constexpr float kMoveAccel = kMoveVel / 0.05f;
+static constexpr float MoveVel = 2000.0f;
+static constexpr float MoveAccel = MoveVel / 0.05f;
 
 // This table is used to roughly linearize the pinch valve
 // output.  It was built by adjusting the pinch valve and
@@ -71,9 +71,9 @@ static constexpr float kMoveAccel = kMoveVel / 0.05f;
 // the setting for 0 flow rate (normally 0) and the last entry
 // should be the setting for 100% flow rate.  The minimum
 // length of the table is 2 entries.
-static constexpr float kFlowTable[] = {0.0000f, 0.0410f, 0.0689f, 0.0987f,
-                                       0.1275f, 0.1590f, 0.1932f, 0.2359f,
-                                       0.2940f, 0.3988f, 1.0000f};
+static constexpr float FlowTable[] = {0.0000f, 0.0410f, 0.0689f, 0.0987f,
+                                      0.1275f, 0.1590f, 0.1932f, 0.2359f,
+                                      0.2940f, 0.3988f, 1.0000f};
 
 PinchValve::PinchValve(int motor_index) { motor_index_ = motor_index; }
 
@@ -108,16 +108,16 @@ void PinchValve::Home() {
 
   // Limit motor power during homing.
   case PinchValveHomeState::LowerAmp:
-    err = mtr->SetAmpAll(kHomeAmp);
+    err = mtr->SetAmpAll(HomeAmp);
     if (err == StepMtrErr::Ok)
       home_state_ = PinchValveHomeState::SetHomeSpeed;
     break;
 
   // Set the move speed/accel to be used during homing
   case PinchValveHomeState::SetHomeSpeed:
-    err = mtr->SetMaxSpeed(kHomeVel);
+    err = mtr->SetMaxSpeed(HomeVel);
     if (err == StepMtrErr::Ok)
-      err = mtr->SetAccel(kHomeAccel);
+      err = mtr->SetAccel(HomeAccel);
     if (err == StepMtrErr::Ok)
       home_state_ = PinchValveHomeState::MoveToStop;
     break;
@@ -125,7 +125,7 @@ void PinchValve::Home() {
   // Start a relative move into the hard stop
   case PinchValveHomeState::MoveToStop:
     move_start_time_ = hal.Now();
-    err = mtr->MoveRel(kHomeDist);
+    err = mtr->MoveRel(HomeDist);
     if (err == StepMtrErr::Ok)
       home_state_ = PinchValveHomeState::WaitMoveStop;
     break;
@@ -140,7 +140,7 @@ void PinchValve::Home() {
 
   // Switch to normal power setting
   case PinchValveHomeState::SetNormalAmp:
-    err = mtr->SetAmpAll(kMoveAmp);
+    err = mtr->SetAmpAll(MoveAmp);
     if (err == StepMtrErr::Ok)
       home_state_ = PinchValveHomeState::MoveOffset;
     break;
@@ -150,7 +150,7 @@ void PinchValve::Home() {
   // just touching the tube, but not squeezing it.
   case PinchValveHomeState::MoveOffset:
     move_start_time_ = hal.Now();
-    err = mtr->MoveRel(-kHomeOffset);
+    err = mtr->MoveRel(-HomeOffset);
     if (err == StepMtrErr::Ok)
       home_state_ = PinchValveHomeState::WaitMoveOffset;
     break;
@@ -172,9 +172,9 @@ void PinchValve::Home() {
   // Switch to normal move speed/accel
   case PinchValveHomeState::SetNormalSpeed:
 
-    err = mtr->SetMaxSpeed(kMoveVel);
+    err = mtr->SetMaxSpeed(MoveVel);
     if (err == StepMtrErr::Ok)
-      err = mtr->SetAccel(kMoveAccel);
+      err = mtr->SetAccel(MoveAccel);
     if (err == StepMtrErr::Ok)
       home_state_ = PinchValveHomeState::Homed;
 
@@ -197,7 +197,7 @@ void PinchValve::SetOutput(float value) {
   value = std::clamp(value, 0.0f, 1.0f);
 
   // Number of intervals defined by the table.
-  float tbl_len = std::size(kFlowTable) - 1;
+  float tbl_len = std::size(FlowTable) - 1;
 
   // Convert the input value based on a table
   // used to linearize the pinch valve output
@@ -205,15 +205,15 @@ void PinchValve::SetOutput(float value) {
   float f = value * tbl_len - static_cast<float>(n);
 
   if (n == static_cast<int>(tbl_len))
-    value = kFlowTable[n];
+    value = FlowTable[n];
   else
-    value = kFlowTable[n] + f * (kFlowTable[n + 1] - kFlowTable[n]);
+    value = FlowTable[n] + f * (FlowTable[n + 1] - FlowTable[n]);
 
   // Convert the value to an absolute position in deg
   // The motor's zero position is at the home offset
   // which corresponds to fully open (i.e. 100% flow)
-  // The valve is closed at a position of -kMaxMove;
-  float pos = (value - 1.0f) * kMaxMove;
+  // The valve is closed at a position of -MaxMove;
+  float pos = (value - 1.0f) * MaxMove;
 
   // Once you put a move in motion you can't change the destination position
   // until the move ends. That means that if the servo loop commands a

--- a/software/controller/lib/core/pinch_valve.h
+++ b/software/controller/lib/core/pinch_valve.h
@@ -20,17 +20,17 @@ limitations under the License.
 #include "units.h"
 
 enum class PinchValveHomeState {
-  kDisabled,
-  kLowerAmp,
-  kSetHomeSpeed,
-  kMoveToStop,
-  kWaitMoveStop,
-  kSetNormalAmp,
-  kMoveOffset,
-  kWaitMoveOffset,
-  kZeroPos,
-  kSetNormalSpeed,
-  kHomed
+  Disabled,
+  LowerAmp,
+  SetHomeSpeed,
+  MoveToStop,
+  WaitMoveStop,
+  SetNormalAmp,
+  MoveOffset,
+  WaitMoveOffset,
+  ZeroPos,
+  SetNormalSpeed,
+  Homed
 };
 
 // The PinchValve represents a single stepper driven pinch
@@ -72,7 +72,7 @@ public:
   void Disable();
 
   // Return true if the pinch valve is ready for action
-  bool IsReady() { return home_state_ == PinchValveHomeState::kHomed; }
+  bool IsReady() { return home_state_ == PinchValveHomeState::Homed; }
 
 private:
   Time move_start_time_;
@@ -81,7 +81,7 @@ private:
 
   float last_command_{-1.0f};
 
-  PinchValveHomeState home_state_{PinchValveHomeState::kDisabled};
+  PinchValveHomeState home_state_{PinchValveHomeState::Disabled};
 };
 
 #endif

--- a/software/controller/lib/core/pinch_valve.h
+++ b/software/controller/lib/core/pinch_valve.h
@@ -20,17 +20,17 @@ limitations under the License.
 #include "units.h"
 
 enum class PinchValveHomeState {
-  DISABLED,
-  LOWER_AMP,
-  SET_HOME_SPEED,
-  MOVE_TO_STOP,
-  WAIT_MOVE_STOP,
-  SET_NORMAL_AMP,
-  MOVE_OFFSET,
-  WAIT_MOVE_OFFSET,
-  ZERO_POS,
-  SET_NORMAL_SPEED,
-  HOMED
+  kDisabled,
+  kLowerAmp,
+  kSetHomeSpeed,
+  kMoveToStop,
+  kWaitMoveStop,
+  kSetNormalAmp,
+  kMoveOffset,
+  kWaitMoveOffset,
+  kZeroPos,
+  kSetNormalSpeed,
+  kHomed
 };
 
 // The PinchValve represents a single stepper driven pinch
@@ -72,7 +72,7 @@ public:
   void Disable();
 
   // Return true if the pinch valve is ready for action
-  bool IsReady() { return home_state_ == PinchValveHomeState::HOMED; }
+  bool IsReady() { return home_state_ == PinchValveHomeState::kHomed; }
 
 private:
   Time move_start_time_;
@@ -81,7 +81,7 @@ private:
 
   float last_command_{-1.0f};
 
-  PinchValveHomeState home_state_{PinchValveHomeState::DISABLED};
+  PinchValveHomeState home_state_{PinchValveHomeState::kDisabled};
 };
 
 #endif

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -54,14 +54,14 @@ static_assert(kVenturiChokeDiameter > meters(0));
 
 AnalogPin Sensors::PinFor(Sensor s) {
   switch (s) {
-  case Sensor::kPatientPressure:
-    return AnalogPin::kPatientPressure;
-  case Sensor::kInflowPressureDiff:
-    return AnalogPin::kInflowPressureDiff;
-  case Sensor::kOutflowPressureDiff:
-    return AnalogPin::kOutflowPressureDiff;
-  case Sensor::kFIO2:
-    return AnalogPin::kFIO2;
+  case Sensor::PatientPressure:
+    return AnalogPin::PatientPressure;
+  case Sensor::InflowPressureDiff:
+    return AnalogPin::InflowPressureDiff;
+  case Sensor::OutflowPressureDiff:
+    return AnalogPin::OutflowPressureDiff;
+  case Sensor::FIO2:
+    return AnalogPin::FIO2;
   }
   // Switch above covers all cases.
   __builtin_unreachable();
@@ -90,8 +90,8 @@ void Sensors::Calibrate() {
   // open any necessary valves, and recalibrate.
   hal.Delay(milliseconds(20));
 
-  for (Sensor s : {Sensor::kPatientPressure, Sensor::kInflowPressureDiff,
-                   Sensor::kOutflowPressureDiff, Sensor::kFIO2}) {
+  for (Sensor s : {Sensor::PatientPressure, Sensor::InflowPressureDiff,
+                   Sensor::OutflowPressureDiff, Sensor::FIO2}) {
     sensors_zero_vals_[static_cast<int>(s)] = hal.AnalogRead(PinFor(s));
   }
 }
@@ -133,8 +133,8 @@ float Sensors::ReadOxygenSensor(Pressure p_ambient) const {
   static const float kOxygenSensorGain{0.060f};
 
   // TODO: raise alarm if fio2 is out of expected (0,1) range
-  return (hal.AnalogRead(PinFor(Sensor::kFIO2)) -
-          sensors_zero_vals_[static_cast<int>(Sensor::kFIO2)])
+  return (hal.AnalogRead(PinFor(Sensor::FIO2)) -
+          sensors_zero_vals_[static_cast<int>(Sensor::FIO2)])
                  .volts() /
              (kAmplifierGain * kOxygenSensorGain) / p_ambient.atm() +
          kO2ConcentrationInAir;
@@ -158,11 +158,11 @@ VolumetricFlow Sensors::PressureDeltaToFlow(Pressure delta) {
 }
 
 SensorReadings Sensors::GetReadings() const {
-  auto patient_pressure = ReadPressureSensor(Sensor::kPatientPressure);
+  auto patient_pressure = ReadPressureSensor(Sensor::PatientPressure);
   // Flow rate is inhalation flow minus exhalation flow. Positive value is flow
   // into lungs, and negative is flow out of lungs.
-  auto inflow_delta = ReadPressureSensor(Sensor::kInflowPressureDiff);
-  auto outflow_delta = ReadPressureSensor(Sensor::kOutflowPressureDiff);
+  auto inflow_delta = ReadPressureSensor(Sensor::InflowPressureDiff);
+  auto outflow_delta = ReadPressureSensor(Sensor::OutflowPressureDiff);
   // Fraction of Inspired Oxygen assuming ambient pressure of 101.3 kPa
   // TODO: measure ambient pressure from an additional sensor and/or estimate
   // from user input (from altitude?)

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -36,7 +36,7 @@ static DebugFloat dbg_flow_uncorrected("flow_uncorrected",
 // altitude - need mechanism to adjust based on delivery? Constant involving
 // density of air. Density assumed at 15 deg. Celsius and 1 atm of pressure.
 // Sourced from https://en.wikipedia.org/wiki/Density_of_air
-static const float kDensityOfAirKgPerCubicMeter{1.225f}; // kg/m^3
+static const float DensityOfAirKgPerCubicMeter{1.225f}; // kg/m^3
 
 // Diameters and correction coefficient relating to 3/4in Venturi, see
 // https://bit.ly/2ARuReg.
@@ -45,12 +45,12 @@ static const float kDensityOfAirKgPerCubicMeter{1.225f}; // kg/m^3
 // roughly 10^4 and machined (rather than cast) surfaces. Data fit is in good
 // agreement based on comparison to Fleisch pneumotachograph; see
 // https://github.com/RespiraWorks/Ventilator/pull/476
-constexpr static Length kVenturiPortDiameter{millimeters(15.05f)};
-constexpr static Length kVenturiChokeDiameter{millimeters(5.5f)};
-constexpr static float kVenturiCorrection{0.97f};
+constexpr static Length VenturiPortDiameter{millimeters(15.05f)};
+constexpr static Length VenturiChokeDiameter{millimeters(5.5f)};
+constexpr static float VenturiCorrection{0.97f};
 
-static_assert(kVenturiPortDiameter > kVenturiChokeDiameter);
-static_assert(kVenturiChokeDiameter > meters(0));
+static_assert(VenturiPortDiameter > VenturiChokeDiameter);
+static_assert(VenturiChokeDiameter > meters(0));
 
 AnalogPin Sensors::PinFor(Sensor s) {
   switch (s) {
@@ -107,10 +107,10 @@ Pressure Sensors::ReadPressureSensor(Sensor s) const {
   // The pressure sensor is scaled to 0-3.3V, which is the range captured by
   // our ADC.  Therefore, if we multiply the received voltage by 5/3.3, we get
   // a pressure in kPa.
-  static const float kPressureSensorGain{5.f / 3.3f};
-  return kPa(kPressureSensorGain * (hal.AnalogRead(PinFor(s)) -
-                                    sensors_zero_vals_[static_cast<int>(s)])
-                                       .volts());
+  static const float PressureSensorGain{5.f / 3.3f};
+  return kPa(PressureSensorGain * (hal.AnalogRead(PinFor(s)) -
+                                   sensors_zero_vals_[static_cast<int>(s)])
+                                      .volts());
 }
 
 // Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
@@ -127,17 +127,17 @@ float Sensors::ReadOxygenSensor(Pressure p_ambient) const {
 
   // Standard air O2 concentration. This assumes that calibration occured with
   // pure air, meaning the system has been filled with air only.
-  static const float kO2ConcentrationInAir{0.21f};
+  static const float O2ConcentrationInAir{0.21f};
 
-  static const float kAmplifierGain{50.0f};
-  static const float kOxygenSensorGain{0.060f};
+  static const float AmplifierGain{50.0f};
+  static const float OxygenSensorGain{0.060f};
 
   // TODO: raise alarm if fio2 is out of expected (0,1) range
   return (hal.AnalogRead(PinFor(Sensor::FIO2)) -
           sensors_zero_vals_[static_cast<int>(Sensor::FIO2)])
                  .volts() /
-             (kAmplifierGain * kOxygenSensorGain) / p_ambient.atm() +
-         kO2ConcentrationInAir;
+             (AmplifierGain * OxygenSensorGain) / p_ambient.atm() +
+         O2ConcentrationInAir;
 }
 
 VolumetricFlow Sensors::PressureDeltaToFlow(Pressure delta) {
@@ -148,12 +148,12 @@ VolumetricFlow Sensors::PressureDeltaToFlow(Pressure delta) {
     return static_cast<float>(M_PI) / 4.0f * pow2(diameter.meters());
   };
 
-  float port_area = diameter_to_area_m2(kVenturiPortDiameter);
-  float choke_area = diameter_to_area_m2(kVenturiChokeDiameter);
+  float port_area = diameter_to_area_m2(VenturiPortDiameter);
+  float choke_area = diameter_to_area_m2(VenturiChokeDiameter);
   return cubic_m_per_sec(
-      kVenturiCorrection *
+      VenturiCorrection *
       std::copysign(std::sqrt(std::abs(delta.kPa()) * 1000.0f), delta.kPa()) *
-      std::sqrt(2 / kDensityOfAirKgPerCubicMeter) * port_area * choke_area /
+      std::sqrt(2 / DensityOfAirKgPerCubicMeter) * port_area * choke_area /
       std::sqrt(pow2(port_area) - pow2(choke_area)));
 }
 

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -79,10 +79,10 @@ public:
 
 private:
   enum class Sensor {
-    kPatientPressure,
-    kInflowPressureDiff,
-    kOutflowPressureDiff,
-    kFIO2,
+    PatientPressure,
+    InflowPressureDiff,
+    OutflowPressureDiff,
+    FIO2,
   };
   // Keep this in sync with the Sensor enum!
   constexpr static int kNumSensors{4};

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -60,8 +60,8 @@ public:
 
   // min/max possible reading from MPXV5004GP pressure sensors
   // The canonical list of hardware in the device is: https://bit.ly/3aERr69
-  constexpr static Pressure kMinPressure{kPa(0.0f)};
-  constexpr static Pressure kMaxPressure{kPa(3.92f)};
+  constexpr static Pressure MinPressure{kPa(0.0f)};
+  constexpr static Pressure MaxPressure{kPa(3.92f)};
 
   /*
    * @brief Method implements Bernoulli's equation assuming the Venturi Effect.
@@ -85,14 +85,14 @@ private:
     FIO2,
   };
   // Keep this in sync with the Sensor enum!
-  constexpr static int kNumSensors{4};
+  constexpr static int NumSensors{4};
 
   static AnalogPin PinFor(Sensor s);
   Pressure ReadPressureSensor(Sensor s) const;
   float ReadOxygenSensor(Pressure p_ambient) const;
 
   // Calibrated average sensor values in a zero state.
-  Voltage sensors_zero_vals_[kNumSensors];
+  Voltage sensors_zero_vals_[NumSensors];
 };
 
 #endif // SENSORS_H

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -38,7 +38,7 @@ public:
     context->response_length = 1;
     context->response[0] = 0;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
   }
 };
 
@@ -82,16 +82,16 @@ public:
 //
 // Data passed to the command is a single byte which defines what the command
 // does:
-//  kFlush - Used to disable the trace and flush the trace buffer
-//  kDownload - Used to read data from the buffer
-//  kStart - Used to start recording in the trace buffer
-//  kGetVarId followed by var index (1 byte) - Used to get trace variables ID
-//  kSetVarId followed by var index (1 byte) and variable ID (2 bytes) - Used to
+//  Flush - Used to disable the trace and flush the trace buffer
+//  Download - Used to read data from the buffer
+//  Start - Used to start recording in the trace buffer
+//  GetVarId followed by var index (1 byte) - Used to get trace variables ID
+//  SetVarId followed by var index (1 byte) and variable ID (2 bytes) - Used to
 //    set traced variable id
-//  kGetPeriod - Used to get the trace period
-//  kSetPeriod followed by desired trace period (4 bytes) - Used to set the
+//  GetPeriod - Used to get the trace period
+//  SetPeriod followed by desired trace period (4 bytes) - Used to set the
 //    trace period
-//  kCountSamples - Used to get the number of samples currently in the trace
+//  CountSamples - Used to get the number of samples currently in the trace
 //    buffer
 
 class TraceHandler : public Handler {
@@ -100,14 +100,14 @@ public:
   ErrorCode Process(Context *context) override;
 
   enum class Subcommand : uint8_t {
-    kFlush = 0x00,    // disable and flush the trace buffer
-    kDownload = 0x01, // download data from the trace buffer
-    kStart = 0x02,    // start tracing data
-    kGetVarId = 0x03, // get traced variable id
-    kSetVarId = 0x04, // set traced variable id
-    kGetPeriod = 0x05,
-    kSetPeriod = 0x06,
-    kCountSamples = 0x07, // get number of samples in the trace buffer
+    Flush = 0x00,    // disable and flush the trace buffer
+    Download = 0x01, // download data from the trace buffer
+    Start = 0x02,    // start tracing data
+    GetVarId = 0x03, // get traced variable id
+    SetVarId = 0x04, // set traced variable id
+    GetPeriod = 0x05,
+    SetPeriod = 0x06,
+    CountSamples = 0x07, // get number of samples in the trace buffer
   };
 
 private:
@@ -123,7 +123,7 @@ private:
 // which defines what the command does and the structure of its data.
 //
 // Sub-commands:
-//  kGetInfo - Used to read info about a variable.  The debug interface calls
+//  GetInfo - Used to read info about a variable.  The debug interface calls
 //             this repeatedly on startup to enumerate the variables currently
 //             supported by the code.  This way new debug variables can be added
 //             on the fly without modifying the Python code to match.
@@ -133,9 +133,9 @@ private:
 //             the variable.
 //             See the code below for details of the output format
 //
-//  kGet - Read the variables value.
+//  Get - Read the variables value.
 //
-//  kSet - Set the variables value.
+//  Set - Set the variables value.
 //
 class VarHandler : public Handler {
 public:
@@ -143,9 +143,9 @@ public:
   ErrorCode Process(Context *context) override;
 
   enum class Subcommand : uint8_t {
-    kGetInfo = 0x00, // get variable info (name, type, help string)
-    kGet = 0x01,     // get variable value
-    kSet = 0x02,     // set variable value
+    GetInfo = 0x00, // get variable info (name, type, help string)
+    Get = 0x01,     // get variable value
+    Set = 0x02,     // set variable value
   };
 
 private:
@@ -167,10 +167,10 @@ private:
 // which defines what the command does and the structure of its data.
 //
 // Sub-commands:
-//  kRead, followed by a 16 bits address and a 16 bits length :
+//  Read, followed by a 16 bits address and a 16 bits length :
 //          Used to read length data bytes at given address in EEPROM
 //
-//  kWrite, followed by a 16 bits address and some data bytes :
+//  Write, followed by a 16 bits address and some data bytes :
 //          Used to write given data at given address
 class EepromHandler : public Handler {
 public:
@@ -178,8 +178,8 @@ public:
   ErrorCode Process(Context *context) override;
 
   enum class Subcommand : uint8_t {
-    kRead = 0x00,
-    kWrite = 0x01,
+    Read = 0x00,
+    Write = 0x01,
   };
 
 private:

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -186,7 +186,7 @@ private:
   ErrorCode Read(uint16_t address, Context *context);
   ErrorCode Write(uint16_t address, Context *context);
 
-  static constexpr uint16_t kMaxWriteLength{1024};
+  static constexpr uint16_t MaxWriteLength{1024};
   I2Ceeprom *eeprom_;
 };
 

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -68,8 +68,8 @@ struct Context {
   uint32_t response_length; // (actual) length of the response once the
                             // command is processed
   bool *processed; // pointer to a boolean that informs the interface handler
-                   // that a command's response is available (some commands take
-                   // time)
+                   // that a command's response is available (some commands
+                   // take time)
 };
 
 // Each debug command is represented by an instance of this virtual class

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -21,40 +21,35 @@ limitations under the License.
 namespace Debug {
 
 // States for the internal state machine
-enum class State {
-  kAwaitingCommand,
-  kProcessing,
-  kAwaitingResponse,
-  kResponding
-};
+enum class State { AwaitingCommand, Processing, AwaitingResponse, Responding };
 
 // The binary serial interface uses two special characters
 // These values are pretty arbitrary.
 // See debug.cpp for a detailed description of how this works
-enum class SpecialChar : uint8_t { kEscape = 0xf1, kEndTransfer = 0xf2 };
+enum class SpecialChar : uint8_t { Escape = 0xf1, EndTransfer = 0xf2 };
 
 enum class ErrorCode : uint8_t {
-  kNone = 0x00,            // No error (=success)
-  kCrcError = 0x01,        // CRC error on command
-  kUnknownCommand = 0x02,  // Unknown command code received
-  kMissingData = 0x03,     // Not enough data passed with command
-  kNoMemory = 0x04,        // Insufficient memory
-  kInternalError = 0x05,   // Some type of internal error (aka bug)
-  kUnknownVariable = 0x06, // The requested variable ID is invalid
-  kInvalidData = 0x07,     // data is out of range
-  kTimeout = 0x08,         // response timeout
+  None = 0x00,            // No error (=success)
+  CrcError = 0x01,        // CRC error on command
+  UnknownCommand = 0x02,  // Unknown command code received
+  MissingData = 0x03,     // Not enough data passed with command
+  NoMemory = 0x04,        // Insufficient memory
+  InternalError = 0x05,   // Some type of internal error (aka bug)
+  UnknownVariable = 0x06, // The requested variable ID is invalid
+  InvalidData = 0x07,     // data is out of range
+  Timeout = 0x08,         // response timeout
 };
 
 namespace Command {
 
 enum class Code : uint8_t {
-  kMode = 0x00,         // Return the current firmware mode
-  kPeek = 0x01,         // Peek into RAM
-  kPoke = 0x02,         // Poke values into RAM
-  kConsole = 0x03,      // Read strings from the print buffer - deprecated
-  kVariable = 0x04,     // Variable access
-  kTrace = 0x05,        // Data trace commands
-  kEepromAccess = 0x06, // Read/Write in I2C EEPROM
+  Mode = 0x00,         // Return the current firmware mode
+  Peek = 0x01,         // Peek into RAM
+  Poke = 0x02,         // Poke values into RAM
+  Console = 0x03,      // Read strings from the print buffer - deprecated
+  Variable = 0x04,     // Variable access
+  Trace = 0x05,        // Data trace commands
+  EepromAccess = 0x06, // Read/Write in I2C EEPROM
 };
 
 // Structure that represents a command's parameters
@@ -80,7 +75,7 @@ public:
   // Returns an error code.  For any non-zero error, the values returned in
   // response_length and response will be ignored.
   [[nodiscard]] virtual ErrorCode Process(Context *context) {
-    return ErrorCode::kUnknownCommand;
+    return ErrorCode::UnknownCommand;
   }
 };
 

--- a/software/controller/lib/debug/eeprom_cmd.cpp
+++ b/software/controller/lib/debug/eeprom_cmd.cpp
@@ -65,12 +65,12 @@ ErrorCode EepromHandler::Write(const uint16_t address, Context *context) {
   // the subcommand and address bytes
   uint16_t length = static_cast<uint16_t>(context->request_length - 3);
 
-  if (length > kMaxWriteLength)
+  if (length > MaxWriteLength)
     return ErrorCode::NoMemory;
 
   // copy request data in our own array to allow eeprom to reinterpret_cast
   // the pointer we pass it (as pointers to const cannot be cast)
-  uint8_t request[kMaxWriteLength] = {0};
+  uint8_t request[MaxWriteLength] = {0};
   memcpy(&request[0], &(context->request[3]), length);
   context->response_length = 0;
   if (eeprom_->WriteBytes(address, length, &request, context->processed)) {

--- a/software/controller/lib/debug/eeprom_cmd.cpp
+++ b/software/controller/lib/debug/eeprom_cmd.cpp
@@ -20,7 +20,7 @@ ErrorCode EepromHandler::Process(Context *context) {
 
   // We have at least subcommand and address (3 bytes)
   if (context->request_length < 3)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   // Whatever the subcommand, bytes 1 and 2 are the address
   uint16_t address = u8_to_u16(&context->request[1]);
@@ -29,44 +29,44 @@ ErrorCode EepromHandler::Process(Context *context) {
 
   // Process subcommand
   switch (subcommand) {
-  case Subcommand::kRead:
+  case Subcommand::Read:
     return Read(address, context);
 
-  case Subcommand::kWrite:
+  case Subcommand::Write:
     return Write(address, context);
 
   default:
-    return ErrorCode::kInvalidData;
+    return ErrorCode::InvalidData;
   }
 }
 
 ErrorCode EepromHandler::Read(const uint16_t address, Context *context) {
   // Read command requires length (bytes 3 and 4)
   if (context->request_length < 5)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
   uint16_t length = u8_to_u16(&context->request[3]);
   if (length > context->max_response_length)
-    return ErrorCode::kNoMemory;
+    return ErrorCode::NoMemory;
 
   if (eeprom_->ReadBytes(address, length, context->response,
                          context->processed)) {
     // only set response_length if the read has been successfully sent
     context->response_length = length;
   }
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 ErrorCode EepromHandler::Write(const uint16_t address, Context *context) {
   // at least one byte of data is given after the address
   if (context->request_length < 4)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   // length of data to be written is the length of the request minus
   // the subcommand and address bytes
   uint16_t length = static_cast<uint16_t>(context->request_length - 3);
 
   if (length > kMaxWriteLength)
-    return ErrorCode::kNoMemory;
+    return ErrorCode::NoMemory;
 
   // copy request data in our own array to allow eeprom to reinterpret_cast
   // the pointer we pass it (as pointers to const cannot be cast)
@@ -74,10 +74,10 @@ ErrorCode EepromHandler::Write(const uint16_t address, Context *context) {
   memcpy(&request[0], &(context->request[3]), length);
   context->response_length = 0;
   if (eeprom_->WriteBytes(address, length, &request, context->processed)) {
-    return ErrorCode::kNone;
+    return ErrorCode::None;
   } else {
     // could not send write request for some reason
-    return ErrorCode::kInternalError;
+    return ErrorCode::InternalError;
   }
 }
 

--- a/software/controller/lib/debug/interface.cpp
+++ b/software/controller/lib/debug/interface.cpp
@@ -46,28 +46,28 @@ bool Interface::Poll() {
   // or a full command has been received.  Either way, the
   // ReadNextByte function will return false when its time
   // to move on.
-  case State::kAwaitingCommand:
+  case State::AwaitingCommand:
     while (ReadNextByte()) {
     }
     return false;
 
   // Process the current command
-  case State::kProcessing:
+  case State::Processing:
     ProcessCommand();
     request_size_ = 0;
     return false;
 
   // Wait for command to be processed
-  case State::kAwaitingResponse:
+  case State::AwaitingResponse:
     if (command_processed_) {
-      SendResponse(ErrorCode::kNone, response_length_);
+      SendResponse(ErrorCode::None, response_length_);
     } else if (hal.Now() > command_start_time_ + milliseconds(100)) {
-      SendError(ErrorCode::kTimeout);
+      SendError(ErrorCode::Timeout);
     }
     return false;
 
   // Send my response
-  case State::kResponding:
+  case State::Responding:
     while (SendNextByte()) {
     }
     return true;
@@ -98,14 +98,14 @@ bool Interface::ReadNextByte() {
 
   // If this is an escape character, don't save it just keep track
   // of the fact that we saw it.
-  if (byte == static_cast<uint8_t>(SpecialChar::kEscape)) {
+  if (byte == static_cast<uint8_t>(SpecialChar::Escape)) {
     escape_next_byte_ = true;
     return true;
   }
 
   // If this is an termination character, then change our state and return false
-  if (byte == static_cast<uint8_t>(SpecialChar::kEndTransfer)) {
-    state_ = State::kProcessing;
+  if (byte == static_cast<uint8_t>(SpecialChar::EndTransfer)) {
+    state_ = State::Processing;
     return false;
   }
 
@@ -129,10 +129,10 @@ bool Interface::SendNextByte() {
   char next_char = response_[response_bytes_sent_++];
 
   // If its a special character, I need to escape it.
-  if ((next_char == static_cast<char>(SpecialChar::kEndTransfer)) ||
-      (next_char == static_cast<char>(SpecialChar::kEscape))) {
+  if ((next_char == static_cast<char>(SpecialChar::EndTransfer)) ||
+      (next_char == static_cast<char>(SpecialChar::Escape))) {
     char escaped_char[2];
-    escaped_char[0] = static_cast<char>(SpecialChar::kEscape);
+    escaped_char[0] = static_cast<char>(SpecialChar::Escape);
     escaped_char[1] = next_char;
     (void)hal.DebugWrite(escaped_char, 2);
   } else {
@@ -146,10 +146,10 @@ bool Interface::SendNextByte() {
   // If that was the last byte in my response, send the
   // termination character and start waiting on the next
   // command.
-  char end_transfer = static_cast<char>(SpecialChar::kEndTransfer);
+  char end_transfer = static_cast<char>(SpecialChar::EndTransfer);
   (void)hal.DebugWrite(&end_transfer, 1);
 
-  state_ = State::kAwaitingCommand;
+  state_ = State::AwaitingCommand;
   response_bytes_sent_ = 0;
   return false;
 }
@@ -160,24 +160,24 @@ void Interface::ProcessCommand() {
   // is the value of request_size_, which should be at least 3 (8 bits command
   // code + 16 bits checksum). If its not, I just ignore the command and jump to
   // waiting for the next one.
-  // This means we can send kEndTransfer characters to synchronize
+  // This means we can send EndTransfer characters to synchronize
   // communication if necessary
   if (request_size_ < 3) {
     request_size_ = 0;
-    state_ = State::kAwaitingCommand;
+    state_ = State::AwaitingCommand;
     return;
   }
 
   uint16_t crc = ComputeCRC(request_, request_size_ - 2);
 
   if (crc != u8_to_u16(&request_[request_size_ - 2])) {
-    SendError(ErrorCode::kCrcError);
+    SendError(ErrorCode::CrcError);
     return;
   }
 
   Command::Handler *cmd_handler = registry_[request_[0]];
   if (!cmd_handler) {
-    SendError(ErrorCode::kUnknownCommand);
+    SendError(ErrorCode::UnknownCommand);
     return;
   }
 
@@ -195,12 +195,12 @@ void Interface::ProcessCommand() {
   };
   ErrorCode error = cmd_handler->Process(&context);
 
-  if (error != ErrorCode::kNone) {
+  if (error != ErrorCode::None) {
     SendError(error);
     return;
   }
 
-  state_ = State::kAwaitingResponse;
+  state_ = State::AwaitingResponse;
   command_start_time_ = hal.Now();
   response_length_ = context.response_length;
 }
@@ -212,7 +212,7 @@ void Interface::SendResponse(ErrorCode error, uint32_t response_length) {
   // and append this to the end of the response
   uint16_t crc = ComputeCRC(response_, response_length + 1);
   u16_to_u8(crc, &response_[response_length + 1]);
-  state_ = State::kResponding;
+  state_ = State::Responding;
   response_bytes_sent_ = 0;
   // The size of the response that will be sent includes the error code (1 byte)
   // and checksum (2 bytes).

--- a/software/controller/lib/debug/interface.cpp
+++ b/software/controller/lib/debug/interface.cpp
@@ -221,14 +221,14 @@ void Interface::SendResponse(ErrorCode error, uint32_t response_length) {
 
 // 16-bit CRC calculation for debug commands and responses
 uint16_t Interface::ComputeCRC(const uint8_t *buffer, size_t length) {
-  static constexpr uint16_t kCRC16POLY = 0xA001;
-  static bool kInit = false;
-  static uint16_t kCrcTable[256];
+  static constexpr uint16_t CRC16POLY = 0xA001;
+  static bool Init = false;
+  static uint16_t CrcTable[256];
 
   // The first time this is called I'll build a table
   // to speed up CRC handling
-  if (!kInit) {
-    kInit = true;
+  if (!Init) {
+    Init = true;
     for (uint16_t byte = 0; byte < 256; byte++) {
       uint16_t crc = byte;
 
@@ -236,17 +236,17 @@ uint16_t Interface::ComputeCRC(const uint8_t *buffer, size_t length) {
         bool lsb = (crc & 1) == 1;
         crc = static_cast<uint16_t>(crc >> 1);
         if (lsb)
-          crc ^= kCRC16POLY;
+          crc ^= CRC16POLY;
       }
 
-      kCrcTable[byte] = crc;
+      CrcTable[byte] = crc;
     }
   }
 
   uint16_t crc = 0;
 
   for (uint32_t byte_number = 0; byte_number < length; byte_number++) {
-    uint16_t local_crc = kCrcTable[0xFF & (buffer[byte_number] ^ crc)];
+    uint16_t local_crc = CrcTable[0xFF & (buffer[byte_number] ^ crc)];
 
     crc = static_cast<uint16_t>(local_crc ^ (crc >> 8));
   }

--- a/software/controller/lib/debug/interface.h
+++ b/software/controller/lib/debug/interface.h
@@ -47,8 +47,8 @@ namespace Debug {
 // <term> is a special character value indicating the end of a command.
 //
 // Two special char values are used (see debug_types.h) :
-// - kEndTransfer (0xF2), aka term - Signifies the end of a command.
-// - kEscape  (0xF1) - used to send a special character as data.
+// - EndTransfer (0xF2), aka term - Signifies the end of a command.
+// - Escape  (0xF1) - used to send a special character as data.
 //
 // The escape byte causes the serial processor to treat the next byte as
 // data no matter what its value is.  It's used when the data being sent
@@ -67,9 +67,9 @@ public:
   void SampleTraceVars() { trace_->MaybeSample(); }
 
 private:
-  State state_{State::kAwaitingCommand};
+  State state_{State::AwaitingCommand};
 
-  // Buffer into which request data is written in kAwaitingCommand state
+  // Buffer into which request data is written in AwaitingCommand state
   uint8_t request_[500] = {0};
   uint32_t request_size_{0};
   // Remember when we receive an escape char (in case the call happens in
@@ -77,7 +77,7 @@ private:
   bool escape_next_byte_{false};
 
   // Buffer into which the command handler writes its response and which is then
-  // sent in kResponding state.
+  // sent in Responding state.
   uint8_t response_[500] = {0};
   uint32_t response_size_{0};
   uint32_t response_bytes_sent_{0};

--- a/software/controller/lib/debug/peek_cmd.cpp
+++ b/software/controller/lib/debug/peek_cmd.cpp
@@ -22,7 +22,7 @@ ErrorCode PeekHandler::Process(Context *context) {
   // Length should be exactly 6, but if more data is passed
   // I'll just ignore it.
   if (context->request_length < 6)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   size_t address = address_msw_ + u8_to_u32(&context->request[0]);
   uint32_t count = u8_to_u16(&context->request[4]);
@@ -55,7 +55,7 @@ ErrorCode PeekHandler::Process(Context *context) {
 
   context->response_length = count;
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 } // namespace Debug::Command

--- a/software/controller/lib/debug/poke_cmd.cpp
+++ b/software/controller/lib/debug/poke_cmd.cpp
@@ -21,7 +21,7 @@ ErrorCode PokeHandler::Process(Context *context) {
   // Total command length must be at least 5.  That's
   // four for the address and at least one data byte.
   if (context->request_length < 5)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   size_t address = address_msw_ + u8_to_u32(&context->request[0]);
   uint32_t count = context->request_length - 4;
@@ -53,7 +53,7 @@ ErrorCode PokeHandler::Process(Context *context) {
 
   context->response_length = 0;
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 } // namespace Debug::Command

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -43,7 +43,7 @@ void Trace::MaybeSample() {
 }
 
 bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
-  if (index >= kMaxTraceVars) {
+  if (index >= MaxTraceVars) {
     return false;
   }
   traced_vars_[index] = DebugVar::FindVar(id);
@@ -54,14 +54,14 @@ bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
 }
 
 int16_t Trace::GetTracedVarId(uint8_t index) {
-  if (index >= kMaxTraceVars) {
+  if (index >= MaxTraceVars) {
     return -1;
   }
   return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
 }
 
 [[nodiscard]] bool
-Trace::GetNextTraceRecord(std::array<uint32_t, kMaxTraceVars> *record,
+Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
                           size_t *count) {
   // Grab one sample with interrupts disabled.
   // There's a chance the trace is still running, so we could get interrupted

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -23,7 +23,7 @@ limitations under the License.
 
 namespace Debug {
 
-static constexpr uint32_t kMaxTraceVars{4};
+static constexpr uint32_t MaxTraceVars{4};
 
 /*
  * Implements a data trace facility.
@@ -67,7 +67,7 @@ public:
   }
 
   template <int index> void SetTracedVarId(int32_t id) {
-    static_assert(index >= 0 && index < kMaxTraceVars);
+    static_assert(index >= 0 && index < MaxTraceVars);
     traced_vars_[index] = DebugVar::FindVar(static_cast<uint16_t>(id));
     // The layout of the trace buffer is just a bunch of uint32_t's one per
     // each variable of each sample cycle. In order to be able to interpret
@@ -77,7 +77,7 @@ public:
   }
 
   template <int index> int32_t GetTracedVarId() {
-    static_assert(index >= 0 && index < kMaxTraceVars);
+    static_assert(index >= 0 && index < MaxTraceVars);
     return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
   }
 
@@ -90,8 +90,7 @@ public:
   // Sets *count to the number of elements actually set in *record.
   // This will equal GetNumActiveVars() but is easier to use for testing.
   [[nodiscard]] bool
-  GetNextTraceRecord(std::array<uint32_t, kMaxTraceVars> *record,
-                     size_t *count);
+  GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record, size_t *count);
 
 private:
   // This function is called at the end of the high priority loop function.
@@ -107,7 +106,7 @@ private:
   // Number of loop cycles elapsed since last sample was captured.
   uint32_t cycles_count_{0};
 
-  std::array<DebugVarBase *, kMaxTraceVars> traced_vars_ = {nullptr};
+  std::array<DebugVarBase *, MaxTraceVars> traced_vars_ = {nullptr};
 
   // This circular buffer is as big as we consider reasonable, to give a good
   // tracing capability: 40% of the RAM available on our STM32

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef TRACE_H_
-#define TRACE_H_
+#ifndef TRACE_H
+#define TRACE_H
 
 #include "circular_buffer.h"
 #include "vars.h"
@@ -116,4 +116,4 @@ private:
 
 } // namespace Debug
 
-#endif // TRACE_H_
+#endif // TRACE_H

--- a/software/controller/lib/debug/trace_cmd.cpp
+++ b/software/controller/lib/debug/trace_cmd.cpp
@@ -116,7 +116,7 @@ ErrorCode TraceHandler::ReadTraceBuffer(Context *context) {
     samples_count = max_samples;
   }
 
-  std::array<uint32_t, kMaxTraceVars> record;
+  std::array<uint32_t, MaxTraceVars> record;
   for (size_t sample = 0; sample < samples_count; sample++) {
     // This shouldn't fail since I've already confirmed
     // the number of elements in the buffer.  If it does

--- a/software/controller/lib/debug/trace_cmd.cpp
+++ b/software/controller/lib/debug/trace_cmd.cpp
@@ -23,67 +23,67 @@ ErrorCode TraceHandler::Process(Context *context) {
   // The first byte of data is always required, this
   // gives the sub-command.
   if (context->request_length < 1)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   Subcommand subcommand{context->request[0]};
 
   switch (subcommand) {
-  // Sub-command kFlushTrace is used to flush the trace buffer
+  // Sub-command FlushTrace is used to flush the trace buffer
   // It also disables the trace
-  case Subcommand::kFlush: {
+  case Subcommand::Flush: {
     trace_->Stop();
     context->response_length = 0;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
   }
 
-  // Sub-command kDownloadTrace is used to read data from the buffer
-  case Subcommand::kDownload:
+  // Sub-command DownloadTrace is used to read data from the buffer
+  case Subcommand::Download:
     return ReadTraceBuffer(context);
 
-  case Subcommand::kStart:
+  case Subcommand::Start:
     trace_->Start();
     context->response_length = 0;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
 
-  case Subcommand::kGetVarId:
+  case Subcommand::GetVarId:
     return GetTraceVar(context);
 
-  case Subcommand::kSetVarId:
+  case Subcommand::SetVarId:
     return SetTraceVar(context);
 
-  case Subcommand::kGetPeriod:
+  case Subcommand::GetPeriod:
     // response (trace period) is 32 bits (4 bytes) long
     if (context->max_response_length < 4)
-      return ErrorCode::kNoMemory;
+      return ErrorCode::NoMemory;
     u32_to_u8(trace_->GetPeriod(), context->response);
     context->response_length = 4;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
 
-  case Subcommand::kSetPeriod:
+  case Subcommand::SetPeriod:
     // trace period is a 32 bits int, meaning the request (including subcommand)
     // is 5 bytes long
     if (context->request_length < 5)
-      return ErrorCode::kMissingData;
+      return ErrorCode::MissingData;
     trace_->SetPeriod(u8_to_u32(&(context->request[1])));
     context->response_length = 0;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
 
-  case Subcommand::kCountSamples:
+  case Subcommand::CountSamples:
     // response (num samples) is 4 bytes long, make sure I have enough room
     if (context->max_response_length < 4)
-      return ErrorCode::kNoMemory;
+      return ErrorCode::NoMemory;
     u32_to_u8(static_cast<uint32_t>(trace_->GetNumSamples()),
               context->response);
     context->response_length = 4;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
 
   default:
-    return ErrorCode::kInvalidData;
+    return ErrorCode::InvalidData;
   }
 }
 
@@ -96,7 +96,7 @@ ErrorCode TraceHandler::ReadTraceBuffer(Context *context) {
   if (!var_count) {
     context->response_length = 0;
     *(context->processed) = true;
-    return ErrorCode::kNone;
+    return ErrorCode::None;
   }
 
   // See how many samples I can return
@@ -107,7 +107,7 @@ ErrorCode TraceHandler::ReadTraceBuffer(Context *context) {
   // If there's not enough room for even one sample, return an error.
   // That really shouldn't happen
   if (max_samples == 0) {
-    return ErrorCode::kNoMemory;
+    return ErrorCode::NoMemory;
   }
 
   // Find the total number of samples in the buffer
@@ -133,41 +133,41 @@ ErrorCode TraceHandler::ReadTraceBuffer(Context *context) {
   context->response_length =
       static_cast<uint32_t>(samples_count * var_count * sizeof(uint32_t));
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 ErrorCode TraceHandler::SetTraceVar(Context *context) {
   // 3 extra bytes are required to provide variable index and variable ID
   if (context->request_length < 4)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
   // extract index and var_id from request
   uint8_t index = context->request[1];
   uint16_t var_id = u8_to_u16(&context->request[2]);
   if (!trace_->SetTracedVarId(index, var_id)) {
-    return ErrorCode::kInvalidData;
+    return ErrorCode::InvalidData;
   }
   // no response is required, only the error code
   context->response_length = 0;
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 ErrorCode TraceHandler::GetTraceVar(Context *context) {
   // 1 extra byte is required to provide variable index
   if (context->request_length < 2)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   uint8_t index = context->request[1];
 
   // response (var ID) is 16 bits (2 bytes) long
   if (context->max_response_length < 2)
-    return ErrorCode::kNoMemory;
+    return ErrorCode::NoMemory;
   context->response_length = 2;
 
   u16_to_u8(static_cast<uint16_t>(trace_->GetTracedVarId(index)),
             context->response);
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 } // namespace Debug::Command

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -25,23 +25,23 @@ ErrorCode VarHandler::Process(Context *context) {
   // The first byte of data is always required, this
   // gives the sub-command.
   if (context->request_length < 1)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   Subcommand subcommand{context->request[0]};
 
   switch (subcommand) {
   // Return info about one of the variables.
-  case Subcommand::kGetInfo:
+  case Subcommand::GetInfo:
     return GetVarInfo(context);
 
-  case Subcommand::kGet:
+  case Subcommand::Get:
     return GetVar(context);
 
-  case Subcommand::kSet:
+  case Subcommand::Set:
     return SetVar(context);
 
   default:
-    return ErrorCode::kInvalidData;
+    return ErrorCode::InvalidData;
   }
 }
 
@@ -55,13 +55,13 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
 
   // We expect a 16-bit ID to be passed
   if (context->request_length < 3)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
   const auto *var = DebugVar::FindVar(var_id);
   if (!var)
-    return ErrorCode::kUnknownVariable;
+    return ErrorCode::UnknownVariable;
 
   // The info I return consists of the following:
   // <type> - 1 byte variable type code
@@ -81,7 +81,7 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
   // Fail if the strings are too large to fit.
   if (context->max_response_length <
       8 + name_length + format_length + help_length)
-    return ErrorCode::kNoMemory;
+    return ErrorCode::NoMemory;
 
   uint32_t count = 0;
   context->response[count++] = static_cast<uint8_t>(var->GetType());
@@ -103,49 +103,49 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
 
   context->response_length = count;
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 ErrorCode VarHandler::GetVar(Context *context) {
   // We expect a 16-bit ID to be passed
   if (context->request_length < 3)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
   auto *var = DebugVar::FindVar(var_id);
   if (!var)
-    return ErrorCode::kUnknownVariable;
+    return ErrorCode::UnknownVariable;
 
   if (context->max_response_length < 4)
-    return ErrorCode::kNoMemory;
+    return ErrorCode::NoMemory;
 
   u32_to_u8(var->GetValue(), context->response);
   context->response_length = 4;
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 ErrorCode VarHandler::SetVar(Context *context) {
   // We expect a 16-bit ID to be passed
   if (context->request_length < 3)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
   auto *var = DebugVar::FindVar(var_id);
   if (!var)
-    return ErrorCode::kUnknownVariable;
+    return ErrorCode::UnknownVariable;
 
   uint32_t count = context->request_length - 3;
 
   if (count < 4)
-    return ErrorCode::kMissingData;
+    return ErrorCode::MissingData;
 
   var->SetValue(u8_to_u32(context->request + 3));
   context->response_length = 0;
   *(context->processed) = true;
-  return ErrorCode::kNone;
+  return ErrorCode::None;
 }
 
 } // namespace Debug::Command

--- a/software/controller/lib/debugvars/vars.cpp
+++ b/software/controller/lib/debugvars/vars.cpp
@@ -17,5 +17,5 @@ limitations under the License.
 #include <string.h>
 
 // static member variables
-DebugVarBase *DebugVarBase::var_list[100];
-uint16_t DebugVarBase::var_count = 0;
+DebugVarBase *DebugVarBase::var_list_[100];
+uint16_t DebugVarBase::var_count_ = 0;

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -21,9 +21,9 @@ limitations under the License.
 
 // Defines the type of variable
 enum class VarType {
-  INT32 = 1,
-  UINT32 = 2,
-  FLOAT = 3,
+  kInt32 = 1,
+  kUInt32 = 2,
+  kFloat = 3,
 };
 
 // This class represents a variable that you can read/write using the
@@ -44,16 +44,16 @@ public:
   // as to how the variable data should be displayed.
   DebugVarBase(VarType type, const char *name, const char *help,
                const char *fmt)
-      : type_(type), name_(name), help_(help), fmt_(fmt), id_(var_count) {
-    if (var_count < static_cast<uint16_t>(std::size(var_list)))
-      var_list[id_] = this;
-    var_count++;
+      : type_(type), name_(name), help_(help), fmt_(fmt), id_(var_count_) {
+    if (var_count_ < static_cast<uint16_t>(std::size(var_list_)))
+      var_list_[id_] = this;
+    var_count_++;
   }
 
   static DebugVarBase *FindVar(uint16_t vid) {
-    if (vid >= std::size(var_list))
+    if (vid >= std::size(var_list_))
       return nullptr;
-    return var_list[vid];
+    return var_list_[vid];
   }
 
   virtual uint32_t GetValue() = 0;
@@ -74,8 +74,8 @@ private:
 
   // List of all the variables in the system.
   // Increase size as necessary
-  static DebugVarBase *var_list[100];
-  static uint16_t var_count;
+  static DebugVarBase *var_list_[100];
+  static uint16_t var_count_;
 };
 
 template <typename GetFn, typename SetFn>
@@ -99,17 +99,17 @@ public:
   // @param data Pointer to an actual variable in C++ code that this will access
   DebugVar(const char *name, int32_t *data, const char *help = "",
            const char *fmt = "%d")
-      : DebugVar(VarType::INT32, name, data, help, fmt) {}
+      : DebugVar(VarType::kInt32, name, data, help, fmt) {}
 
   // Like above, but unsigned
   DebugVar(const char *name, uint32_t *data, const char *help = "",
            const char *fmt = "%u")
-      : DebugVar(VarType::UINT32, name, data, help, fmt) {}
+      : DebugVar(VarType::kUInt32, name, data, help, fmt) {}
 
   // Like above, but float
   DebugVar(const char *name, float *data, const char *help = "",
            const char *fmt = "%.3f")
-      : DebugVar(VarType::FLOAT, name, data, help, fmt) {}
+      : DebugVar(VarType::kFloat, name, data, help, fmt) {}
 
   // Gets the current value of the variable as an uint32_t.
   uint32_t GetValue() override {

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -21,9 +21,9 @@ limitations under the License.
 
 // Defines the type of variable
 enum class VarType {
-  kInt32 = 1,
-  kUInt32 = 2,
-  kFloat = 3,
+  Int32 = 1,
+  UInt32 = 2,
+  Float = 3,
 };
 
 // This class represents a variable that you can read/write using the
@@ -99,17 +99,17 @@ public:
   // @param data Pointer to an actual variable in C++ code that this will access
   DebugVar(const char *name, int32_t *data, const char *help = "",
            const char *fmt = "%d")
-      : DebugVar(VarType::kInt32, name, data, help, fmt) {}
+      : DebugVar(VarType::Int32, name, data, help, fmt) {}
 
   // Like above, but unsigned
   DebugVar(const char *name, uint32_t *data, const char *help = "",
            const char *fmt = "%u")
-      : DebugVar(VarType::kUInt32, name, data, help, fmt) {}
+      : DebugVar(VarType::UInt32, name, data, help, fmt) {}
 
   // Like above, but float
   DebugVar(const char *name, float *data, const char *help = "",
            const char *fmt = "%.3f")
-      : DebugVar(VarType::kFloat, name, data, help, fmt) {}
+      : DebugVar(VarType::Float, name, data, help, fmt) {}
 
   // Gets the current value of the variable as an uint32_t.
   uint32_t GetValue() override {

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -125,11 +125,11 @@ void HalApi::InitADC() {
   EnableClock(kAdcBase);
 
   // Configure the 4 pins used as analog inputs
-  GpioPinMode(kGpioABase, 0, GPIOPinMode::kAnalog);
-  GpioPinMode(kGpioABase, 1, GPIOPinMode::kAnalog);
-  GpioPinMode(kGpioABase, 4, GPIOPinMode::kAnalog);
-  GpioPinMode(kGpioBBase, 0, GPIOPinMode::kAnalog);
-  GpioPinMode(kGpioCBase, 1, GPIOPinMode::kAnalog);
+  GpioPinMode(kGpioABase, 0, GPIOPinMode::Analog);
+  GpioPinMode(kGpioABase, 1, GPIOPinMode::Analog);
+  GpioPinMode(kGpioABase, 4, GPIOPinMode::Analog);
+  GpioPinMode(kGpioBBase, 0, GPIOPinMode::Analog);
+  GpioPinMode(kGpioCBase, 1, GPIOPinMode::Analog);
 
   // Perform a power-up and calibration sequence on
   // the A/D converter
@@ -196,7 +196,7 @@ void HalApi::InitADC() {
   // I use DMA1 channel 1 to copy my A/D readings into my buffer ([RM] 11.4.4)
   EnableClock(kDma1Base);
   DmaReg *dma = kDma1Base;
-  int c1 = static_cast<int>(DmaChannel::kChan1);
+  int c1 = static_cast<int>(DmaChannel::Chan1);
 
   dma->channel[c1].peripheral_address = &adc->adc[0].data;
   dma->channel[c1].memory_address = adc_buff;
@@ -207,7 +207,7 @@ void HalApi::InitADC() {
   dma->channel[c1].config.half_tx_interrupt = 0;
   dma->channel[c1].config.tx_error_interrupt = 0;
   dma->channel[c1].config.direction =
-      static_cast<uint32_t>(DmaChannelDir::kPeripheralToMemory);
+      static_cast<uint32_t>(DmaChannelDir::PeripheralToMemory);
   dma->channel[c1].config.circular = 1;
   dma->channel[c1].config.peripheral_increment = 0;
   dma->channel[c1].config.memory_increment = 1;
@@ -224,13 +224,13 @@ void HalApi::InitADC() {
 Voltage HalApi::AnalogRead(AnalogPin pin) {
   int offset = [&] {
     switch (pin) {
-    case AnalogPin::kPatientPressure:
+    case AnalogPin::PatientPressure:
       return 0;
-    case AnalogPin::kInflowPressureDiff:
+    case AnalogPin::InflowPressureDiff:
       return 1;
-    case AnalogPin::kOutflowPressureDiff:
+    case AnalogPin::OutflowPressureDiff:
       return 2;
-    case AnalogPin::kFIO2:
+    case AnalogPin::FIO2:
       return 3;
     }
     // All cases covered above (and GCC checks this).

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -70,7 +70,7 @@ Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 */
 
 // How long a period (in seconds) we want to average the A/D readings.
-static constexpr float sample_history_time_sec = 0.001f;
+static constexpr float kSampleHistoryTimeSec = 0.001f;
 
 // Total number of A/D inputs we're sampling
 static constexpr int kAdcChannels = 4;
@@ -79,35 +79,35 @@ static constexpr int kAdcChannels = 4;
 // and sum them before moving on to the next input.  The constant is set
 // as a log base 2, so a value of 3 for example would mean sample 8 times
 // (2^3 == 8).  Legal values range from 0 to 8.
-static constexpr int oversample_log2 = 4;
-static constexpr int oversample_count = 1 << oversample_log2;
+static constexpr int kOversampleLog2 = 4;
+static constexpr int kOversampleCount = 1 << kOversampleLog2;
 
 // [RM] 16.4.30: Oversampler (pg 425)
 // This calculated constant gives the maximum A/D reading based on the
 // number of samples.
-static constexpr int max_adc_reading =
-    (oversample_log2 >= 4) ? 65536 : (1 << (12 + oversample_log2));
+static constexpr int kMaxAdcReading =
+    (kOversampleLog2 >= 4) ? 65536 : (1 << (12 + kOversampleLog2));
 
 // Set sample time ([RM] 16.4.12). I'm using 92.5 A/D clocks to sample.
 // A/D sample time in CPU clock cycles.  Fixed for now
 // This is the time we give the analog input to charge the A/D sampling cap.
-static constexpr int adc_samp_time = 92;
+static constexpr int kAdcSampleTime = 92;
 
 // Time of an A/D conversion in CPU clock cycles.  This is the sample time + 13
-static constexpr int adc_conversion_time = adc_samp_time + 13;
+static constexpr int kAdcConversionTime = kAdcSampleTime + 13;
 
 // Calculate how long our history buffer needs to be based on the above.
-static constexpr int adc_samp_history =
-    static_cast<int>(sample_history_time_sec * CPU_FREQ / adc_conversion_time /
-                     oversample_count / kAdcChannels);
+static constexpr int kAdcSampleHistory =
+    static_cast<int>(kSampleHistoryTimeSec * CPU_FREQ / kAdcConversionTime /
+                     kOversampleCount / kAdcChannels);
 
 // This scaler converts the sum of the A/D readings (a total of
-// adc_samp_history) into a voltage.  The A/D is scaled so a value of 0
-// corresponds to 0 volts, and max_adc_reading corresponds to 3.3V
-static constexpr float adc_scaler = 3.3f / (max_adc_reading * adc_samp_history);
+// kAdcSampleHistory) into a voltage.  The A/D is scaled so a value of 0
+// corresponds to 0 volts, and kMaxAdcReading corresponds to 3.3V
+static constexpr float kAdcScaler = 3.3f / (kMaxAdcReading * kAdcSampleHistory);
 
 // This buffer will hold the readings from the A/D
-static volatile uint16_t adc_buff[adc_samp_history * kAdcChannels];
+static volatile uint16_t adc_buff[kAdcSampleHistory * kAdcChannels];
 
 // NOTE - we need the sample history to be small for two reasons:
 // - We sum to a 32-bit floating point number and will lose precision
@@ -117,108 +117,111 @@ static volatile uint16_t adc_buff[adc_samp_history * kAdcChannels];
 //
 // If you get hit with this assertion you may need to rethink the
 // way this function works.
-static_assert(adc_samp_history < 100);
+static_assert(kAdcSampleHistory < 100);
 
 void HalApi::InitADC() {
 
   // Enable the clock to the A/D converter
-  EnableClock(ADC_BASE);
+  EnableClock(kAdcBase);
 
   // Configure the 4 pins used as analog inputs
-  GPIO_PinMode(GPIO_A_BASE, 0, GPIO_PinMode::ANALOG);
-  GPIO_PinMode(GPIO_A_BASE, 1, GPIO_PinMode::ANALOG);
-  GPIO_PinMode(GPIO_A_BASE, 4, GPIO_PinMode::ANALOG);
-  GPIO_PinMode(GPIO_B_BASE, 0, GPIO_PinMode::ANALOG);
-  GPIO_PinMode(GPIO_C_BASE, 1, GPIO_PinMode::ANALOG);
+  GpioPinMode(kGpioABase, 0, GPIOPinMode::kAnalog);
+  GpioPinMode(kGpioABase, 1, GPIOPinMode::kAnalog);
+  GpioPinMode(kGpioABase, 4, GPIOPinMode::kAnalog);
+  GpioPinMode(kGpioBBase, 0, GPIOPinMode::kAnalog);
+  GpioPinMode(kGpioCBase, 1, GPIOPinMode::kAnalog);
 
   // Perform a power-up and calibration sequence on
   // the A/D converter
-  ADC_Regs *adc = ADC_BASE;
+  AdcReg *adc = kAdcBase;
 
   // Exit deep power down mode and turn on the
   // internal voltage regulator.
-  adc->adc[0].ctrl = 0x10000000;
+  adc->adc[0].control = 0x10000000;
 
   // Wait for the startup time ([RM] 16.4.6) specified in the STM32
   // [DS] for the voltage regulator to become ready.
   // The time in the [DS] is 20 microseconds ([DS] 6.3.18)
   // but I'll wait for 30 just to be extra conservative
-  Hal.delay(microseconds(30));
+  hal.Delay(microseconds(30));
 
   // Calibrate the A/D for single ended channels ([RM] 16.4.8)
-  adc->adc[0].ctrl |= 0x80000000;
+  adc->adc[0].control |= 0x80000000;
 
   // Wait until the CAL bit is cleared meaning
   // calibration is finished
-  while (adc->adc[0].ctrl & 0x80000000) {
+  while (adc->adc[0].control & 0x80000000) {
   }
 
   // Enable the A/D ([RM] 16.4.9)
   // Clear all the status bits
-  adc->adc[0].stat = 0x3FF;
+  adc->adc[0].status = 0x3FF;
 
   // Enable the A/D
-  adc->adc[0].ctrl |= 0x00000001;
+  adc->adc[0].control |= 0x00000001;
 
   // Wait for the ADRDY status bit to be set
-  while (!(adc->adc[0].stat & 0x00000001)) {
+  while (!(adc->adc[0].status & 0x00000001)) {
   }
 
-  adc->adc[0].cfg1.dmaen = 1;
-  adc->adc[0].cfg1.dmacfg = 1;
-  adc->adc[0].cfg1.cont = 1;
+  adc->adc[0].configuration1.dma_enable = 1;
+  adc->adc[0].configuration1.dma_config = 1;
+  adc->adc[0].configuration1.continuous_conversion = 1;
 
-  adc->adc[0].cfg2.rovse = (oversample_log2 > 0) ? 1 : 0;
+  adc->adc[0].configuration2.regular_oversampling =
+      (kOversampleLog2 > 0) ? 1 : 0;
 
-  adc->adc[0].cfg2.ovsr = (oversample_log2 > 0) ? oversample_log2 - 1 : 0;
+  adc->adc[0].configuration2.oversampling_ratio =
+      (kOversampleLog2 > 0) ? kOversampleLog2 - 1 : 0;
 
-  adc->adc[0].cfg2.ovss = (oversample_log2 < 4) ? 0 : (oversample_log2 - 4);
+  adc->adc[0].configuration2.oversampling_shift =
+      (kOversampleLog2 < 4) ? 0 : (kOversampleLog2 - 4);
 
   // Set sample times ([RM] 16.4.12). I'm using 92.5 A/D clocks to sample.
-  static_assert(adc_samp_time == 92);
-  adc->adc[0].samp.smp5 = 5;
-  adc->adc[0].samp.smp6 = 5;
-  adc->adc[0].samp.smp9 = 5;
-  adc->adc[0].samp.smp15 = 5;
-  adc->adc[0].samp.smp2 = 5;
+  static_assert(kAdcSampleTime == 92);
+  adc->adc[0].sample_times.ch5 = 5;
+  adc->adc[0].sample_times.ch6 = 5;
+  adc->adc[0].sample_times.ch9 = 5;
+  adc->adc[0].sample_times.ch15 = 5;
+  adc->adc[0].sample_times.ch2 = 5;
 
   // Set conversion sequence length:
-  adc->adc[0].seq.len = kAdcChannels - 1;
+  adc->adc[0].sequence.length = kAdcChannels - 1;
 
-  adc->adc[0].seq.sq1 = 6;
-  adc->adc[0].seq.sq2 = 9;
-  adc->adc[0].seq.sq3 = 15;
-  adc->adc[0].seq.sq4 = 2;
+  adc->adc[0].sequence.sequence1 = 6;
+  adc->adc[0].sequence.sequence2 = 9;
+  adc->adc[0].sequence.sequence3 = 15;
+  adc->adc[0].sequence.sequence4 = 2;
 
   // I use DMA1 channel 1 to copy my A/D readings into my buffer ([RM] 11.4.4)
-  EnableClock(DMA1_BASE);
-  DMA_Regs *dma = DMA1_BASE;
-  int C1 = static_cast<int>(DMA_Chan::C1);
+  EnableClock(kDma1Base);
+  DmaReg *dma = kDma1Base;
+  int c1 = static_cast<int>(DmaChannel::kChan1);
 
-  dma->channel[C1].pAddr = &adc->adc[0].data;
-  dma->channel[C1].mAddr = adc_buff;
-  dma->channel[C1].count = adc_samp_history * kAdcChannels;
+  dma->channel[c1].peripheral_address = &adc->adc[0].data;
+  dma->channel[c1].memory_address = adc_buff;
+  dma->channel[c1].count = kAdcSampleHistory * kAdcChannels;
 
-  dma->channel[C1].config.enable = 0;
-  dma->channel[C1].config.tcie = 0;
-  dma->channel[C1].config.htie = 0;
-  dma->channel[C1].config.teie = 0;
-  dma->channel[C1].config.dir =
-      static_cast<uint32_t>(DmaChannelDir::PERIPHERAL_TO_MEM);
-  dma->channel[C1].config.circular = 1;
-  dma->channel[C1].config.perInc = 0;
-  dma->channel[C1].config.memInc = 1;
-  dma->channel[C1].config.psize = 1;
-  dma->channel[C1].config.msize = 1;
-  dma->channel[C1].config.priority = 0;
-  dma->channel[C1].config.enable = 1;
+  dma->channel[c1].config.enable = 0;
+  dma->channel[c1].config.tx_complete_interrupt = 0;
+  dma->channel[c1].config.half_tx_interrupt = 0;
+  dma->channel[c1].config.tx_error_interrupt = 0;
+  dma->channel[c1].config.direction =
+      static_cast<uint32_t>(DmaChannelDir::kPeripheralToMemory);
+  dma->channel[c1].config.circular = 1;
+  dma->channel[c1].config.peripheral_increment = 0;
+  dma->channel[c1].config.memory_increment = 1;
+  dma->channel[c1].config.peripheral_size = 1;
+  dma->channel[c1].config.memory_size = 1;
+  dma->channel[c1].config.priority = 0;
+  dma->channel[c1].config.enable = 1;
 
   // Start the A/D converter
-  adc->adc[0].ctrl |= 4;
+  adc->adc[0].control |= 4;
 }
 
 // Read the specified analog input.
-Voltage HalApi::analogRead(AnalogPin pin) {
+Voltage HalApi::AnalogRead(AnalogPin pin) {
   int offset = [&] {
     switch (pin) {
     case AnalogPin::kPatientPressure:
@@ -239,10 +242,10 @@ Voltage HalApi::analogRead(AnalogPin pin) {
   // background, but that shouldn't cause any problems because memory
   // accesses for 16-bit values are atomic.
   float sum = 0;
-  for (int i = 0; i < adc_samp_history; i++)
+  for (int i = 0; i < kAdcSampleHistory; i++)
     sum += adc_buff[i * kAdcChannels + offset];
 
-  return volts(sum * adc_scaler);
+  return volts(sum * kAdcScaler);
 }
 
 #endif

--- a/software/controller/lib/hal/buzzer.cpp
+++ b/software/controller/lib/hal/buzzer.cpp
@@ -31,20 +31,20 @@ limitations under the License.
 #include <algorithm>
 
 void HalApi::InitBuzzer() {
-  static constexpr int kBuzzerFreqHz = 2400;
+  static constexpr int BuzzerFreqHz = 2400;
 
-  EnableClock(kTimer3Base);
+  EnableClock(Timer3Base);
 
   // Connect PB4 to timer 3
   // The STM32 datasheet has a table (table 17) which shows
   // which functions can be connected to each pin.  For
   // PB4 we select function 2 to connect it to timer 3.
-  GpioPinAltFunc(kGpioBBase, 4, 2);
+  GpioPinAltFunc(GpioBBase, 4, 2);
 
-  TimerReg *tmr = kTimer3Base;
+  TimerReg *tmr = Timer3Base;
 
   // Set the frequency
-  tmr->auto_reload = (CPU_FREQ / kBuzzerFreqHz) - 1;
+  tmr->auto_reload = (CPU_FREQ / BuzzerFreqHz) - 1;
 
   // Configure channel 1 in PWM output mode 1
   // with preload enabled.  The preload means that
@@ -70,13 +70,13 @@ void HalApi::InitBuzzer() {
 }
 
 void HalApi::BuzzerOff() {
-  TimerReg *tmr = kTimer3Base;
+  TimerReg *tmr = Timer3Base;
   tmr->capture_compare[0] = 0;
 }
 
 // Set the buzzer on with the specified volume (0 to 1)
 void HalApi::BuzzerOn(float volume) {
-  TimerReg *tmr = kTimer3Base;
+  TimerReg *tmr = Timer3Base;
 
   volume = std::clamp(volume, 0.0f, 1.0f);
 

--- a/software/controller/lib/hal/buzzer.cpp
+++ b/software/controller/lib/hal/buzzer.cpp
@@ -31,20 +31,20 @@ limitations under the License.
 #include <algorithm>
 
 void HalApi::InitBuzzer() {
-  const int buzzerFreqHz = 2400;
+  static constexpr int kBuzzerFreqHz = 2400;
 
-  EnableClock(TIMER3_BASE);
+  EnableClock(kTimer3Base);
 
   // Connect PB4 to timer 3
   // The STM32 datasheet has a table (table 17) which shows
   // which functions can be connected to each pin.  For
   // PB4 we select function 2 to connect it to timer 3.
-  GPIO_PinAltFunc(GPIO_B_BASE, 4, 2);
+  GpioPinAltFunc(kGpioBBase, 4, 2);
 
-  TimerRegs *tmr = TIMER3_BASE;
+  TimerReg *tmr = kTimer3Base;
 
   // Set the frequency
-  tmr->reload = (CPU_FREQ / buzzerFreqHz) - 1;
+  tmr->auto_reload = (CPU_FREQ / kBuzzerFreqHz) - 1;
 
   // Configure channel 1 in PWM output mode 1
   // with preload enabled.  The preload means that
@@ -52,38 +52,37 @@ void HalApi::InitBuzzer() {
   // register and copied to the active register
   // at the start of the next cycle.
   //
-  // TODO - the ccMode and ccEnable registers of the timer
-  // should really be converted to bit flags for better
-  // readability
-  tmr->ccMode[0] = 0x0068;
+  // TODO - the capture_compare_mode and capture_compare_enable registers of
+  // the timer should really be converted to bit flags for better readability
+  tmr->capture_compare_mode[0] = 0x0068;
 
-  tmr->ccEnable = 0x01;
+  tmr->capture_compare_enable = 0x01;
 
   // Start with 0% duty cycle
-  tmr->compare[0] = 0;
+  tmr->capture_compare[0] = 0;
 
   // Load the shadow registers
   tmr->event = 1;
 
   // Start the counter
-  tmr->ctrl1.s.arpe = 1;
-  tmr->ctrl1.s.cen = 1;
+  tmr->control_reg1.bitfield.auto_reload_preload = 1;
+  tmr->control_reg1.bitfield.counter_enable = 1;
 }
 
 void HalApi::BuzzerOff() {
-  TimerRegs *tmr = TIMER3_BASE;
-  tmr->compare[0] = 0;
+  TimerReg *tmr = kTimer3Base;
+  tmr->capture_compare[0] = 0;
 }
 
 // Set the buzzer on with the specified volume (0 to 1)
 void HalApi::BuzzerOn(float volume) {
-  TimerRegs *tmr = TIMER3_BASE;
+  TimerReg *tmr = kTimer3Base;
 
   volume = std::clamp(volume, 0.0f, 1.0f);
 
   // We get maximum volume at about 80% duty cycle
-  float duty = volume * 0.8f * static_cast<float>(tmr->reload);
-  tmr->compare[0] = static_cast<int>(duty);
+  float duty = volume * 0.8f * static_cast<float>(tmr->auto_reload);
+  tmr->capture_compare[0] = static_cast<int>(duty);
 }
 
 #endif

--- a/software/controller/lib/hal/circular_buffer.h
+++ b/software/controller/lib/hal/circular_buffer.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef CIRCULAR_BUFFER_H_
-#define CIRCULAR_BUFFER_H_
+#ifndef CIRCULAR_BUFFER_H
+#define CIRCULAR_BUFFER_H
 
 #include "hal.h"
 #include <optional>

--- a/software/controller/lib/hal/eeprom.cpp
+++ b/software/controller/lib/hal/eeprom.cpp
@@ -34,7 +34,7 @@ bool I2Ceeprom::ReadBytes(uint16_t offset, uint16_t length, void *data,
   bool discarded = false;
   I2C::Request pointer_set = {
       .slave_address = address_,
-      .direction = I2C::ExchangeDirection::kWrite,
+      .direction = I2C::ExchangeDirection::Write,
       .size = 2,
       .data = &offset_address[0],
       .processed = &discarded,
@@ -42,7 +42,7 @@ bool I2Ceeprom::ReadBytes(uint16_t offset, uint16_t length, void *data,
 
   I2C::Request read_request = {
       .slave_address = address_,
-      .direction = I2C::ExchangeDirection::kRead,
+      .direction = I2C::ExchangeDirection::Read,
       .size = length,
       .data = data,
       .processed = processed,
@@ -86,7 +86,7 @@ bool I2Ceeprom::WriteBytes(uint16_t offset, uint16_t length, void *data,
 
     I2C::Request request = {
         .slave_address = address_,
-        .direction = I2C::ExchangeDirection::kWrite,
+        .direction = I2C::ExchangeDirection::Write,
         .size = static_cast<uint8_t>(request_length + 2),
         .data = &write_data[0],
         .processed = processed,

--- a/software/controller/lib/hal/eeprom.h
+++ b/software/controller/lib/hal/eeprom.h
@@ -17,8 +17,8 @@ limitations under the License.
 // https://ww1.microchip.com/downloads/en/DeviceDoc/24AA256-24LC256-24FC256-Data-Sheet-20001203W.pdf
 // The EEPROM we have on the board is at address 0x50 (see [PCBsp])
 
-#ifndef EEPROM_H_
-#define EEPROM_H_
+#ifndef EEPROM_H
+#define EEPROM_H
 
 #include "i2c.h"
 #include <stdint.h>
@@ -72,4 +72,4 @@ private:
   bool ReceiveBytes(const I2C::Request &request) override;
 };
 
-#endif // EEPROM_H_
+#endif // EEPROM_H

--- a/software/controller/lib/hal/eeprom.h
+++ b/software/controller/lib/hal/eeprom.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include "i2c.h"
 #include <stdint.h>
 
-static constexpr uint32_t kMaxMemorySize{65535};
+static constexpr uint32_t MaxMemorySize{65535};
 
 // This class defines an I²C addressable EEPROM.
 class I2Ceeprom {
@@ -67,7 +67,7 @@ public:
 
 private:
   uint32_t address_pointer_{0};
-  uint8_t memory_[kMaxMemorySize];
+  uint8_t memory_[MaxMemorySize];
   bool SendBytes(const I2C::Request &request) override;
   bool ReceiveBytes(const I2C::Request &request) override;
 };

--- a/software/controller/lib/hal/flash.cpp
+++ b/software/controller/lib/hal/flash.cpp
@@ -24,8 +24,8 @@ limitations under the License.
  * [RM] 3.3.7
  */
 static bool ValidFlashParameters(uint32_t addr, size_t ct) {
-  return (addr >= flash_start_addr) and
-         (addr + ct <= flash_start_addr + flash_size) and !(ct & 7) and
+  return (addr >= kFlashStartAddr) and
+         (addr + ct <= kFlashStartAddr + kFlashSize) and !(ct & 7) and
          !(addr & 7);
 }
 
@@ -50,7 +50,7 @@ static inline void UnlockFlash(FlashReg *reg) {
  * BSY bit set will cause the AHB bus to stall until the BSY bit is cleared.
  * [RM] 3.3.5
  */
-static inline void LockFlash(FlashReg *reg) { reg->ctrl.lock = 1; }
+static inline void LockFlash(FlashReg *reg) { reg->control.flash_lock = 1; }
 
 /*
  * Erase a single 2k page of flash given the starting
@@ -59,28 +59,28 @@ static inline void LockFlash(FlashReg *reg) { reg->ctrl.lock = 1; }
  * Returns true on success or false on failure
  */
 bool HalApi::FlashErasePage(uint32_t addr) {
-  if (!ValidFlashParameters(addr, flash_page_size))
+  if (!ValidFlashParameters(addr, kFlashPageSize))
     return false;
 
   // Clear all the status bits
-  FlashReg *reg = FLASH_BASE;
+  FlashReg *reg = kFlashBase;
   reg->status = 0x0000C3FB;
 
   UnlockFlash(reg);
 
   // Find the page number
-  uint8_t n = static_cast<uint8_t>((addr - flash_start_addr) / flash_page_size);
+  uint8_t n = static_cast<uint8_t>((addr - kFlashStartAddr) / kFlashPageSize);
 
-  reg->ctrl.page = n;
-  reg->ctrl.page_erase = 1;
-  reg->ctrl.start = 1;
+  reg->control.page = n;
+  reg->control.page_erase = 1;
+  reg->control.start_operation = 1;
 
   // Wait for the busy bit to clear
   while (reg->status & 0x00010000) {
   }
 
-  reg->ctrl.page = 0;
-  reg->ctrl.page_erase = 0;
+  reg->control.page = 0;
+  reg->control.page_erase = 0;
 
   LockFlash(reg);
   return true;
@@ -90,7 +90,7 @@ bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) {
 
   if (!ValidFlashParameters(addr, ct))
     return false;
-  FlashReg *reg = FLASH_BASE;
+  FlashReg *reg = kFlashBase;
 
   // Clear all the status bits
   reg->status = 0x0000C3FB;
@@ -98,7 +98,7 @@ bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) {
   UnlockFlash(reg);
 
   // Set the PG bit to start programming
-  reg->ctrl.program = 1;
+  reg->control.program = 1;
 
   auto *dest = (uint32_t *)addr;
   auto *ptr = (uint32_t *)data;
@@ -119,7 +119,7 @@ bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) {
     reg->status = 0x00000001;
   }
 
-  reg->ctrl.program = 0;
+  reg->control.program = 0;
 
   LockFlash(reg);
   return !(reg->status & 0x0000C3FA);

--- a/software/controller/lib/hal/flash.cpp
+++ b/software/controller/lib/hal/flash.cpp
@@ -24,8 +24,8 @@ limitations under the License.
  * [RM] 3.3.7
  */
 static bool ValidFlashParameters(uint32_t addr, size_t ct) {
-  return (addr >= kFlashStartAddr) and
-         (addr + ct <= kFlashStartAddr + kFlashSize) and !(ct & 7) and
+  return (addr >= FlashStartAddr) and
+         (addr + ct <= FlashStartAddr + FlashSize) and !(ct & 7) and
          !(addr & 7);
 }
 
@@ -59,17 +59,17 @@ static inline void LockFlash(FlashReg *reg) { reg->control.flash_lock = 1; }
  * Returns true on success or false on failure
  */
 bool HalApi::FlashErasePage(uint32_t addr) {
-  if (!ValidFlashParameters(addr, kFlashPageSize))
+  if (!ValidFlashParameters(addr, FlashPageSize))
     return false;
 
   // Clear all the status bits
-  FlashReg *reg = kFlashBase;
+  FlashReg *reg = FlashBase;
   reg->status = 0x0000C3FB;
 
   UnlockFlash(reg);
 
   // Find the page number
-  uint8_t n = static_cast<uint8_t>((addr - kFlashStartAddr) / kFlashPageSize);
+  uint8_t n = static_cast<uint8_t>((addr - FlashStartAddr) / FlashPageSize);
 
   reg->control.page = n;
   reg->control.page_erase = 1;
@@ -90,7 +90,7 @@ bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) {
 
   if (!ValidFlashParameters(addr, ct))
     return false;
-  FlashReg *reg = kFlashBase;
+  FlashReg *reg = FlashBase;
 
   // Clear all the status bits
   reg->status = 0x0000C3FB;

--- a/software/controller/lib/hal/flash.h
+++ b/software/controller/lib/hal/flash.h
@@ -21,8 +21,8 @@ limitations under the License.
 #include <cstdint>
 
 // Flash memory location & size info
-inline constexpr uint32_t kFlashStartAddr{0x08000000};
-inline constexpr size_t kFlashSize{32 * 1024};
-inline constexpr size_t kFlashPageSize{2 * 1024};
+inline constexpr uint32_t FlashStartAddr{0x08000000};
+inline constexpr size_t FlashSize{32 * 1024};
+inline constexpr size_t FlashPageSize{2 * 1024};
 
 #endif

--- a/software/controller/lib/hal/flash.h
+++ b/software/controller/lib/hal/flash.h
@@ -14,15 +14,15 @@ limitations under the License.
 
 */
 
-#ifndef FLASH_H_
-#define FLASH_H_
+#ifndef FLASH_H
+#define FLASH_H
 
 #include <cstddef>
 #include <cstdint>
 
 // Flash memory location & size info
-inline constexpr uint32_t flash_start_addr{0x08000000};
-inline constexpr size_t flash_size{32 * 1024};
-inline constexpr size_t flash_page_size{2 * 1024};
+inline constexpr uint32_t kFlashStartAddr{0x08000000};
+inline constexpr size_t kFlashSize{32 * 1024};
+inline constexpr size_t kFlashPageSize{2 * 1024};
 
 #endif

--- a/software/controller/lib/hal/hal.cpp
+++ b/software/controller/lib/hal/hal.cpp
@@ -1,3 +1,3 @@
 #include "hal.h"
 
-HalApi Hal;
+HalApi hal;

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -64,52 +64,52 @@ limitations under the License.
 // ---------------------------------------------------------------
 
 // Mode of a digital pin.
-// Usage: PinMode::kInput etc.
+// Usage: PinMode::Input etc.
 enum class PinMode {
-  // Test code relies on kInput being the first enumeration (to get the
-  // behavior that kInput pins are the default).
-  kInput,
-  kOutput,
-  kInputPullup
+  // Test code relies on Input being the first enumeration (to get the
+  // behavior that Input pins are the default).
+  Input,
+  Output,
+  InputPullup
 };
 
 // Voltage level of a digital pin.
-// Usage: VoltageLevel::kHigh, kLow
-enum class VoltageLevel { kHigh, kLow };
+// Usage: VoltageLevel::High, Low
+enum class VoltageLevel { High, Low };
 
 enum class AnalogPin {
   // MPXV5004DP pressure sensors:
   // - PATIENT_PRESSURE reads an absolute pressure value at the patient.
   // - {INFLOW,OUTFLOW}_PRESSURE_DIFF, read a differential across a venturi.
   //   They let us measure volumetric flow into and out of the patient.
-  kPatientPressure,
-  kInflowPressureDiff,
-  kOutflowPressureDiff,
+  PatientPressure,
+  InflowPressureDiff,
+  OutflowPressureDiff,
   // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
-  kFIO2,
+  FIO2,
 };
 
 // Pulse-width modulated outputs from the controller.  These can be set to
 // values in [0-255].
 //
-// Pins default to kInput, so if you add a new pin here, be sure to update
-// HalApi::Init() and set it to kOutput!
+// Pins default to Input, so if you add a new pin here, be sure to update
+// HalApi::Init() and set it to Output!
 enum class PwmPin {
   // Controls the fan speed.
-  kBlower,
+  Blower,
 };
 
-// Binary pins set by the controller -- these are booleans, kHigh or kLow.
+// Binary pins set by the controller -- these are booleans, High or Low.
 //
 // PWM pins can of course be HIGH or LOW too, but we separate out purely on/off
 // pins from PWM pins for reasons of "strong typing".
 //
-// Pins default to kInput, so if you add a new pin here, be sure to update
-// HalApi::Init() and set it to kOutput!
+// Pins default to Input, so if you add a new pin here, be sure to update
+// HalApi::Init() and set it to Output!
 enum class BinaryPin {
-  kRedLED,
-  kYellowLED,
-  kGreenLED,
+  RedLED,
+  YellowLED,
+  GreenLED,
 };
 
 // Interrupts on the STM32 are prioritized.  This allows
@@ -122,9 +122,9 @@ enum class BinaryPin {
 // priority of -1, so they can always interrupt any other
 // priority level.
 enum class IntPriority {
-  kCritical = 2, // Very important interrupt
-  kStandard = 5, // Normal hardware interrupts
-  kLow = 8,      // Less important.  Hardware interrupts can interrupt this
+  Critical = 2, // Very important interrupt
+  Standard = 5, // Normal hardware interrupts
+  Low = 8,      // Less important.  Hardware interrupts can interrupt this
 };
 
 enum class InterruptVector;
@@ -332,7 +332,7 @@ public:
   uint32_t CRC32(const uint8_t *data, uint32_t length);
 
 private:
-  // Initializes watchdog, sets appropriate pins to kOutput, etc.  Called by
+  // Initializes watchdog, sets appropriate pins to Output, etc.  Called by
   // HalApi::Init
   void WatchdogInit();
 
@@ -366,7 +366,7 @@ private:
   Time time_ = microsSinceStartup(0);
   bool interrupts_enabled_ = true;
 
-  // The default pin mode on Arduino is kInput, which happens to be the first
+  // The default pin mode on Arduino is Input, which happens to be the first
   // enumerator in PinMode and so the default in these maps!
   //
   // Source: https://www.arduino.cc/en/Tutorial/DigitalPins
@@ -456,13 +456,13 @@ inline void HalApi::SetDigitalPinMode(BinaryPin pin, PinMode mode) {
   binary_pin_modes_[pin] = mode;
 }
 inline void HalApi::DigitalWrite(BinaryPin pin, VoltageLevel value) {
-  if (binary_pin_modes_[pin] != PinMode::kOutput) {
+  if (binary_pin_modes_[pin] != PinMode::Output) {
     assert(false && "Can only write to an OUTPUT pin");
   }
   binary_pin_values_[pin] = value;
 }
 inline void HalApi::AnalogWrite(PwmPin pin, float duty) {
-  if (pwm_pin_modes_[pin] != PinMode::kOutput) {
+  if (pwm_pin_modes_[pin] != PinMode::Output) {
     assert(false && "Can only write to an OUTPUT pin");
   }
   pwm_pin_values_[pin] = duty;

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -219,13 +219,13 @@ void HalApi::InitGpio() {
   EnableClock(kGpioHBase);
 
   // Configure PCB ID pins as inputs.
-  GpioPinMode(kGpioBBase, 1, GPIOPinMode::kInput);
-  GpioPinMode(kGpioABase, 12, GPIOPinMode::kInput);
+  GpioPinMode(kGpioBBase, 1, GPIOPinMode::Input);
+  GpioPinMode(kGpioABase, 12, GPIOPinMode::Input);
 
   // Configure LED pins as outputs
-  GpioPinMode(kGpioCBase, 13, GPIOPinMode::kOutput);
-  GpioPinMode(kGpioCBase, 14, GPIOPinMode::kOutput);
-  GpioPinMode(kGpioCBase, 15, GPIOPinMode::kOutput);
+  GpioPinMode(kGpioCBase, 13, GPIOPinMode::Output);
+  GpioPinMode(kGpioCBase, 14, GPIOPinMode::Output);
+  GpioPinMode(kGpioCBase, 15, GPIOPinMode::Output);
 
   // Turn all three LEDs off initially
   GpioClrPin(kGpioCBase, 13);
@@ -237,11 +237,11 @@ void HalApi::InitGpio() {
 void HalApi::DigitalWrite(BinaryPin pin, VoltageLevel value) {
   auto [base, bit] = [&]() -> std::pair<GpioReg *, int> {
     switch (pin) {
-    case BinaryPin::kRedLED:
+    case BinaryPin::RedLED:
       return {kGpioCBase, 13};
-    case BinaryPin::kYellowLED:
+    case BinaryPin::YellowLED:
       return {kGpioCBase, 14};
-    case BinaryPin::kGreenLED:
+    case BinaryPin::GreenLED:
       return {kGpioCBase, 15};
     }
     // All cases covered above (and GCC checks this).
@@ -249,11 +249,11 @@ void HalApi::DigitalWrite(BinaryPin pin, VoltageLevel value) {
   }();
 
   switch (value) {
-  case VoltageLevel::kHigh:
+  case VoltageLevel::High:
     GpioSetPin(base, bit);
     break;
 
-  case VoltageLevel::kLow:
+  case VoltageLevel::Low:
     GpioClrPin(base, bit);
     break;
   }
@@ -287,7 +287,7 @@ void HalApi::InitSysTimer() {
   tmr->control_reg1.bitfield.counter_enable = 1;
   tmr->interrupts_enable = 1;
 
-  EnableInterrupt(InterruptVector::kTimer6, IntPriority::kStandard);
+  EnableInterrupt(InterruptVector::Timer6, IntPriority::Standard);
 }
 
 static void Timer6ISR() {
@@ -368,7 +368,7 @@ void HalApi::StartLoopTimer(const Duration &period, void (*callback)(void *),
   // for normal hardware interrupts.  This means that other
   // interrupts can be serviced while controller functions
   // are running.
-  EnableInterrupt(InterruptVector::kTimer15, IntPriority::kLow);
+  EnableInterrupt(InterruptVector::Timer15, IntPriority::Low);
 }
 
 static float latency, max_latency, loop_time;
@@ -463,7 +463,7 @@ void HalApi::InitPwmOut() {
 void HalApi::AnalogWrite(PwmPin pin, float duty) {
   auto [tmr, chan] = [&]() -> std::pair<TimerReg *, int> {
     switch (pin) {
-    case PwmPin::kBlower:
+    case PwmPin::Blower:
       return {kTimer2Base, 1};
     }
     // All cases covered above (and GCC checks this).
@@ -626,10 +626,10 @@ void HalApi::InitUARTs() {
 #endif
   debug_uart.Init(115200);
 
-  EnableInterrupt(InterruptVector::kDma1Channel2, IntPriority::kStandard);
-  EnableInterrupt(InterruptVector::kDma1Channel3, IntPriority::kStandard);
-  EnableInterrupt(InterruptVector::kUART2, IntPriority::kStandard);
-  EnableInterrupt(InterruptVector::kUART3, IntPriority::kStandard);
+  EnableInterrupt(InterruptVector::Dma1Channel2, IntPriority::Standard);
+  EnableInterrupt(InterruptVector::Dma1Channel3, IntPriority::Standard);
+  EnableInterrupt(InterruptVector::Uart2, IntPriority::Standard);
+  EnableInterrupt(InterruptVector::Uart3, IntPriority::Standard);
 }
 
 static void Uart2ISR() { debug_uart.ISR(); }

--- a/software/controller/lib/hal/hal_stm32.h
+++ b/software/controller/lib/hal/hal_stm32.h
@@ -20,8 +20,8 @@ STM32L452 processor used on the controller.
 Reference abbreviations [RM], [DS], etc are defined in hal/README.md.
 */
 
-#ifndef HAL_STM32_H_
-#define HAL_STM32_H_
+#ifndef HAL_STM32_H
+#define HAL_STM32_H
 
 #if !defined(BARE_STM32)
 #error                                                                         \
@@ -38,91 +38,91 @@ Reference abbreviations [RM], [DS], etc are defined in hal/README.md.
 // The values here are the offsets into the interrupt table.
 // These can be found in [RM] chapter 12 (NVIC)
 enum class InterruptVector {
-  DMA1_CH2 = 0x70,
-  DMA1_CH3 = 0x074,
-  TIMER15 = 0xA0,
-  I2C1_EV = 0xBC,
-  I2C1_ERR = 0xC0,
-  SPI1 = 0xCC,
-  UART2 = 0x0D8,
-  UART3 = 0x0DC,
-  TIMER6 = 0x118,
-  DMA2_CH3 = 0x128,
-  DMA2_CH6 = 0x150,
-  DMA2_CH7 = 0x157,
+  kDma1Channel2 = 0x70,
+  kDma1Channel3 = 0x074,
+  kTimer15 = 0xA0,
+  kI2c1Event = 0xBC,
+  kI2c1Error = 0xC0,
+  kSpi1 = 0xCC,
+  kUART2 = 0x0D8,
+  kUART3 = 0x0DC,
+  kTimer6 = 0x118,
+  kDma2Channel3 = 0x128,
+  kDma2Channel6 = 0x150,
+  kDma2Channel7 = 0x157,
 };
 
 // Handy functions for controlling GPIO
 
 // Each pin has a 2-bit mode value that can be set using this function.
 // Pin 0 mode is in bits 0-1, pin 1 in 2-3, etc.  ([RM] 8.4.1)
-enum class GPIO_PinMode {
-  IN = 0,
-  OUT = 1,
-  ALT = 2,
-  ANALOG = 3,
+enum class GPIOPinMode {
+  kInput = 0,
+  kOutput = 1,
+  kAlternateFunction = 2,
+  kAnalog = 3,
 };
 
-inline void GPIO_PinMode(GPIO_Regs *gpio, int pin, GPIO_PinMode mode) {
+inline void GpioPinMode(GpioReg *gpio, int pin, GPIOPinMode mode) {
   gpio->mode &= ~(0b11 << (pin * 2));
   gpio->mode |= (static_cast<int>(mode) << (pin * 2));
 }
 
 // Value for GPIO{A,B,...E,H}_OTYPER ([RM] 8.4.2)
-enum class GPIO_OutType { PUSHPULL = 0, OPENDRAIN = 1 };
+enum class GPIOOutType { kPushPull = 0, kOpenDrain = 1 };
 
-inline void GPIO_OutType(GPIO_Regs *gpio, int pin, GPIO_OutType outType) {
-  if (outType == GPIO_OutType::OPENDRAIN)
-    gpio->outType |= 1 << pin;
+inline void GpioOutType(GpioReg *gpio, int pin, GPIOOutType output_type) {
+  if (output_type == GPIOOutType::kOpenDrain)
+    gpio->output_type |= 1 << pin;
   else
-    gpio->outType &= ~(1 << pin);
+    gpio->output_type &= ~(1 << pin);
 }
 
 // Output pin speeds are set using two consecutive bits / pin.
-enum class GPIO_OutSpeed { LOW = 0, MEDIUM = 1, HIGH = 2, SMOKIN = 3 };
-inline void GPIO_OutSpeed(GPIO_Regs *gpio, int pin, GPIO_OutSpeed speed) {
-  int S = static_cast<int>(speed);
-  gpio->outSpeed &= ~(0b11 << (2 * pin));
-  gpio->outSpeed |= (S << (2 * pin));
+enum class GPIOOutSpeed { kSlow = 0, kMedium = 1, kFast = 2, kSmoking = 3 };
+inline void GpioOutSpeed(GpioReg *gpio, int pin, GPIOOutSpeed speed) {
+  int s = static_cast<int>(speed);
+  gpio->output_speed &= ~(0b11 << (2 * pin));
+  gpio->output_speed |= (s << (2 * pin));
 }
 
 // Many GPIO pins can be repurposed with an alternate function
 // See Table 17 and 18 [DS] for alternate functions
 // See [RM] 8.4.9 and 8.4.10 for GPIO alternate function selection
-inline void GPIO_PinAltFunc(GPIO_Regs *gpio, int pin, int func) {
-  GPIO_PinMode(gpio, pin, GPIO_PinMode::ALT);
+inline void GpioPinAltFunc(GpioReg *gpio, int pin, int func) {
+  GpioPinMode(gpio, pin, GPIOPinMode::kAlternateFunction);
 
   int x = (pin < 8) ? 0 : 1;
-  gpio->alt[x] |= (func << ((pin & 0b111) * 4));
+  gpio->alternate_function[x] |= (func << ((pin & 0b111) * 4));
 }
 
 // Set a specific output pin
-inline void GPIO_SetPin(GPIO_Regs *gpio, int pin) {
+inline void GpioSetPin(GpioReg *gpio, int pin) {
   gpio->set = static_cast<uint16_t>(1 << pin);
 }
 
 // Clear a specific output pin
-inline void GPIO_ClrPin(GPIO_Regs *gpio, int pin) {
-  gpio->clr = static_cast<uint16_t>(1 << pin);
+inline void GpioClrPin(GpioReg *gpio, int pin) {
+  gpio->clear = static_cast<uint16_t>(1 << pin);
 }
 
 // Return the current value of an input pin
-inline int GPIO_GetPin(GPIO_Regs *gpio, int pin) {
-  return (gpio->inDat & (1 << pin)) ? 1 : 0;
+inline int GpioGetPin(GpioReg *gpio, int pin) {
+  return (gpio->input_data & (1 << pin)) ? 1 : 0;
 }
 
 // This adds a pull-up resistor to an input pin
-inline void GPIO_PullUp(GPIO_Regs *gpio, int pin) {
-  uint32_t x = gpio->pullUpDn & ~(3 << (2 * pin));
+inline void GpioPullUp(GpioReg *gpio, int pin) {
+  uint32_t x = gpio->pullup_pulldown & ~(3 << (2 * pin));
   x |= 1 << (2 * pin);
-  gpio->pullUpDn = x;
+  gpio->pullup_pulldown = x;
 }
 
 // This adds a pull-down resistor to an input pin
-inline void GPIO_PullDn(GPIO_Regs *gpio, int pin) {
-  uint32_t x = gpio->pullUpDn & ~(3 << (2 * pin));
+inline void GpioPullDn(GpioReg *gpio, int pin) {
+  uint32_t x = gpio->pullup_pulldown & ~(3 << (2 * pin));
   x |= 2 << (2 * pin);
-  gpio->pullUpDn = x;
+  gpio->pullup_pulldown = x;
 }
 
 #endif

--- a/software/controller/lib/hal/hal_stm32.h
+++ b/software/controller/lib/hal/hal_stm32.h
@@ -38,18 +38,18 @@ Reference abbreviations [RM], [DS], etc are defined in hal/README.md.
 // The values here are the offsets into the interrupt table.
 // These can be found in [RM] chapter 12 (NVIC)
 enum class InterruptVector {
-  kDma1Channel2 = 0x70,
-  kDma1Channel3 = 0x074,
-  kTimer15 = 0xA0,
-  kI2c1Event = 0xBC,
-  kI2c1Error = 0xC0,
-  kSpi1 = 0xCC,
-  kUART2 = 0x0D8,
-  kUART3 = 0x0DC,
-  kTimer6 = 0x118,
-  kDma2Channel3 = 0x128,
-  kDma2Channel6 = 0x150,
-  kDma2Channel7 = 0x157,
+  Dma1Channel2 = 0x70,
+  Dma1Channel3 = 0x074,
+  Timer15 = 0xA0,
+  I2c1Event = 0xBC,
+  I2c1Error = 0xC0,
+  Spi1 = 0xCC,
+  Uart2 = 0x0D8,
+  Uart3 = 0x0DC,
+  Timer6 = 0x118,
+  Dma2Channel3 = 0x128,
+  Dma2Channel6 = 0x150,
+  Dma2Channel7 = 0x157,
 };
 
 // Handy functions for controlling GPIO
@@ -57,10 +57,10 @@ enum class InterruptVector {
 // Each pin has a 2-bit mode value that can be set using this function.
 // Pin 0 mode is in bits 0-1, pin 1 in 2-3, etc.  ([RM] 8.4.1)
 enum class GPIOPinMode {
-  kInput = 0,
-  kOutput = 1,
-  kAlternateFunction = 2,
-  kAnalog = 3,
+  Input = 0,
+  Output = 1,
+  AlternateFunction = 2,
+  Analog = 3,
 };
 
 inline void GpioPinMode(GpioReg *gpio, int pin, GPIOPinMode mode) {
@@ -69,17 +69,17 @@ inline void GpioPinMode(GpioReg *gpio, int pin, GPIOPinMode mode) {
 }
 
 // Value for GPIO{A,B,...E,H}_OTYPER ([RM] 8.4.2)
-enum class GPIOOutType { kPushPull = 0, kOpenDrain = 1 };
+enum class GPIOOutType { PushPull = 0, OpenDrain = 1 };
 
 inline void GpioOutType(GpioReg *gpio, int pin, GPIOOutType output_type) {
-  if (output_type == GPIOOutType::kOpenDrain)
+  if (output_type == GPIOOutType::OpenDrain)
     gpio->output_type |= 1 << pin;
   else
     gpio->output_type &= ~(1 << pin);
 }
 
 // Output pin speeds are set using two consecutive bits / pin.
-enum class GPIOOutSpeed { kSlow = 0, kMedium = 1, kFast = 2, kSmoking = 3 };
+enum class GPIOOutSpeed { Slow = 0, Medium = 1, Fast = 2, Smoking = 3 };
 inline void GpioOutSpeed(GpioReg *gpio, int pin, GPIOOutSpeed speed) {
   int s = static_cast<int>(speed);
   gpio->output_speed &= ~(0b11 << (2 * pin));
@@ -90,7 +90,7 @@ inline void GpioOutSpeed(GpioReg *gpio, int pin, GPIOOutSpeed speed) {
 // See Table 17 and 18 [DS] for alternate functions
 // See [RM] 8.4.9 and 8.4.10 for GPIO alternate function selection
 inline void GpioPinAltFunc(GpioReg *gpio, int pin, int func) {
-  GpioPinMode(gpio, pin, GPIOPinMode::kAlternateFunction);
+  GpioPinMode(gpio, pin, GPIOPinMode::AlternateFunction);
 
   int x = (pin < 8) ? 0 : 1;
   gpio->alternate_function[x] |= (func << ((pin & 0b111) * 4));

--- a/software/controller/lib/hal/hal_stm32_regs.h
+++ b/software/controller/lib/hal/hal_stm32_regs.h
@@ -51,7 +51,7 @@ struct RccStruct {
   uint32_t independent_clock_config2;
 };
 typedef volatile RccStruct RccReg;
-inline RccReg *const kRccBase = reinterpret_cast<RccReg *>(0x40021000);
+inline RccReg *const RccBase = reinterpret_cast<RccReg *>(0x40021000);
 
 // [PM] 4.4 System control block (SCB) (pg 221)
 struct SysControlStruct {
@@ -81,7 +81,7 @@ struct SysControlStruct {
                                   // register
 };
 typedef volatile SysControlStruct SysControlReg;
-inline SysControlReg *const kSysControlBase =
+inline SysControlReg *const SysControlBase =
     reinterpret_cast<SysControlReg *>(0xE000E000);
 
 // [PM] 4.3 Nested vectored interrupt controller (NVIC) (pg 208)
@@ -94,7 +94,7 @@ struct InterruptControlStruct {
   uint8_t priority[1024];
 };
 typedef volatile InterruptControlStruct InterruptControlReg;
-inline InterruptControlReg *const kNvicBase =
+inline InterruptControlReg *const NvicBase =
     reinterpret_cast<InterruptControlReg *>(0xE000E100);
 
 // [RM] 38.8 USART Registers (pg 1238)
@@ -261,10 +261,10 @@ struct UartStruct {
   uint32_t tx_data;
 };
 typedef volatile UartStruct UartReg;
-inline UartReg *const kUart1Base = reinterpret_cast<UartReg *>(0x40013800);
-inline UartReg *const kUart2Base = reinterpret_cast<UartReg *>(0x40004400);
-inline UartReg *const kUart3Base = reinterpret_cast<UartReg *>(0x40004800);
-inline UartReg *const kUart4Base = reinterpret_cast<UartReg *>(0x40004C00);
+inline UartReg *const Uart1Base = reinterpret_cast<UartReg *>(0x40013800);
+inline UartReg *const Uart2Base = reinterpret_cast<UartReg *>(0x40004400);
+inline UartReg *const Uart3Base = reinterpret_cast<UartReg *>(0x40004800);
+inline UartReg *const Uart4Base = reinterpret_cast<UartReg *>(0x40004C00);
 
 // [RM] 16.6 ADC Registers (for each ADC) (pg 450)
 struct AdcStruct {
@@ -389,7 +389,7 @@ struct AdcStruct {
   uint32_t common_data;
 };
 typedef volatile AdcStruct AdcReg;
-inline AdcReg *const kAdcBase = reinterpret_cast<AdcReg *>(0X50040000);
+inline AdcReg *const AdcBase = reinterpret_cast<AdcReg *>(0X50040000);
 
 // Timer Register
 // NOTE: Offset values and applicable registers depend on timer used
@@ -439,16 +439,16 @@ struct TimerStruct {
 typedef volatile TimerStruct TimerReg;
 
 // [RM] 26 Advanced-control Timers (TIM1) (pg 718)
-inline TimerReg *const kTimer1Base = reinterpret_cast<TimerReg *>(0x40012C00);
+inline TimerReg *const Timer1Base = reinterpret_cast<TimerReg *>(0x40012C00);
 // [RM] 27 General-purpose Timers (TIM2/TIM3) (pg 817)
-inline TimerReg *const kTimer2Base = reinterpret_cast<TimerReg *>(0x40000000);
-inline TimerReg *const kTimer3Base = reinterpret_cast<TimerReg *>(0x40000400);
+inline TimerReg *const Timer2Base = reinterpret_cast<TimerReg *>(0x40000000);
+inline TimerReg *const Timer3Base = reinterpret_cast<TimerReg *>(0x40000400);
 // [RM] 29 Basic Timers (TIM6/TIM7) (pg 968)
-inline TimerReg *const kTimer6Base = reinterpret_cast<TimerReg *>(0x40001000);
-inline TimerReg *const kTimer7Base = reinterpret_cast<TimerReg *>(0x40001400);
+inline TimerReg *const Timer6Base = reinterpret_cast<TimerReg *>(0x40001000);
+inline TimerReg *const Timer7Base = reinterpret_cast<TimerReg *>(0x40001400);
 // [RM] 28 General-purpose Timers (TIM15/TIM16) (pg 887)
-inline TimerReg *const kTimer15Base = reinterpret_cast<TimerReg *>(0x40014000);
-inline TimerReg *const kTimer16Base = reinterpret_cast<TimerReg *>(0x40014400);
+inline TimerReg *const Timer15Base = reinterpret_cast<TimerReg *>(0x40014000);
+inline TimerReg *const Timer16Base = reinterpret_cast<TimerReg *>(0x40014400);
 
 // [RM] 3.7 Flash Registers (pg 100)
 struct FlashStruct {
@@ -501,7 +501,7 @@ struct FlashStruct {
   uint32_t wrp_area_b;
 };
 typedef volatile FlashStruct FlashReg;
-inline FlashReg *const kFlashBase = reinterpret_cast<FlashReg *>(0x40022000);
+inline FlashReg *const FlashBase = reinterpret_cast<FlashReg *>(0x40022000);
 
 // [RM] 11.4.4 DMA channels (pg 302)
 enum class DmaChannel {
@@ -625,8 +625,8 @@ struct DmaStruct {
   } channel_select; // Channel Selection Register [RM] 11.6.7 (pg 317)
 };
 typedef volatile DmaStruct DmaReg;
-inline DmaReg *const kDma1Base = reinterpret_cast<DmaReg *>(0x40020000);
-inline DmaReg *const kDma2Base = reinterpret_cast<DmaReg *>(0x40020400);
+inline DmaReg *const Dma1Base = reinterpret_cast<DmaReg *>(0x40020000);
+inline DmaReg *const Dma2Base = reinterpret_cast<DmaReg *>(0x40020400);
 
 /* Select the source for a DMA channel:
   @param dma        Address of DMA registers
@@ -708,9 +708,9 @@ struct SpiStruct {
   uint32_t tx_crc;
 };
 typedef volatile SpiStruct SpiReg;
-inline SpiReg *const kSpi1Base = reinterpret_cast<SpiReg *>(0x40013000);
-inline SpiReg *const kSpi2Base = reinterpret_cast<SpiReg *>(0x40003800);
-inline SpiReg *const kSpi3Base = reinterpret_cast<SpiReg *>(0x40003C00);
+inline SpiReg *const Spi1Base = reinterpret_cast<SpiReg *>(0x40013000);
+inline SpiReg *const Spi2Base = reinterpret_cast<SpiReg *>(0x40003800);
+inline SpiReg *const Spi3Base = reinterpret_cast<SpiReg *>(0x40003C00);
 
 // [RM] 37.7 I2C Registers
 struct I2CStruct {
@@ -812,10 +812,10 @@ struct I2CStruct {
   uint32_t tx_data;            // Transmit data register [RM] 37.7.11
 };
 typedef volatile I2CStruct I2CReg;
-inline I2CReg *const kI2C1Base = reinterpret_cast<I2CReg *>(0x40005400);
-inline I2CReg *const kI2C2Base = reinterpret_cast<I2CReg *>(0x40005800);
-inline I2CReg *const kI2C3Base = reinterpret_cast<I2CReg *>(0x40005c00);
-inline I2CReg *const kI2C4Base = reinterpret_cast<I2CReg *>(0x40008400);
+inline I2CReg *const I2C1Base = reinterpret_cast<I2CReg *>(0x40005400);
+inline I2CReg *const I2C2Base = reinterpret_cast<I2CReg *>(0x40005800);
+inline I2CReg *const I2C3Base = reinterpret_cast<I2CReg *>(0x40005c00);
+inline I2CReg *const I2C4Base = reinterpret_cast<I2CReg *>(0x40008400);
 
 // Watchdog timer
 // [RM] 32.4 Watchdog Registers (pg 1016)
@@ -827,7 +827,7 @@ struct WatchdogStruct {
   uint32_t window;    // Window register [RM] 32.4.5
 };
 typedef volatile WatchdogStruct WatchdogReg;
-inline WatchdogReg *const kWatchdogBase =
+inline WatchdogReg *const WatchdogBase =
     reinterpret_cast<WatchdogReg *>(0x40003000);
 
 // CRC calculation unit
@@ -841,7 +841,7 @@ struct CrcStruct {
   uint32_t polynomial; // CRC polynomial [RM] 14.4.5
 };
 typedef volatile CrcStruct CrcReg;
-inline CrcReg *const kCrcBase = reinterpret_cast<CrcReg *>(0x40023000);
+inline CrcReg *const CrcBase = reinterpret_cast<CrcReg *>(0x40023000);
 
 // General Purpose I/O
 // [RM] 8.4 GPIO Registers (pg 267)
@@ -860,11 +860,11 @@ struct GpioStruct {
   uint32_t reset;                 // Reset register [RM] 8.4.11
 };
 typedef volatile GpioStruct GpioReg;
-inline GpioReg *const kGpioABase = reinterpret_cast<GpioReg *>(0x48000000);
-inline GpioReg *const kGpioBBase = reinterpret_cast<GpioReg *>(0x48000400);
-inline GpioReg *const kGpioCBase = reinterpret_cast<GpioReg *>(0x48000800);
-inline GpioReg *const kGpioDBase = reinterpret_cast<GpioReg *>(0x48000C00);
-inline GpioReg *const kGpioEBase = reinterpret_cast<GpioReg *>(0x48001000);
-inline GpioReg *const kGpioHBase = reinterpret_cast<GpioReg *>(0x48001C00);
+inline GpioReg *const GpioABase = reinterpret_cast<GpioReg *>(0x48000000);
+inline GpioReg *const GpioBBase = reinterpret_cast<GpioReg *>(0x48000400);
+inline GpioReg *const GpioCBase = reinterpret_cast<GpioReg *>(0x48000800);
+inline GpioReg *const GpioDBase = reinterpret_cast<GpioReg *>(0x48000C00);
+inline GpioReg *const GpioEBase = reinterpret_cast<GpioReg *>(0x48001000);
+inline GpioReg *const GpioHBase = reinterpret_cast<GpioReg *>(0x48001C00);
 
 #endif

--- a/software/controller/lib/hal/hal_stm32_regs.h
+++ b/software/controller/lib/hal/hal_stm32_regs.h
@@ -505,17 +505,17 @@ inline FlashReg *const kFlashBase = reinterpret_cast<FlashReg *>(0x40022000);
 
 // [RM] 11.4.4 DMA channels (pg 302)
 enum class DmaChannel {
-  kChan1 = 0,
-  kChan2 = 1,
-  kChan3 = 2,
-  kChan4 = 3,
-  kChan5 = 4,
-  kChan6 = 5,
-  kChan7 = 6,
+  Chan1 = 0,
+  Chan2 = 1,
+  Chan3 = 2,
+  Chan4 = 3,
+  Chan5 = 4,
+  Chan6 = 5,
+  Chan7 = 6,
 };
 
-enum class DmaChannelDir { kPeripheralToMemory = 0, kMemoryToPeripheral = 1 };
-enum class DmaTransferSize { kByte = 0, kHalfWord = 1, kWord = 2 };
+enum class DmaChannelDir { PeripheralToMemory = 0, MemoryToPeripheral = 1 };
+enum class DmaTransferSize { Byte = 0, HalfWord = 1, Word = 2 };
 
 struct DmaStruct {
   union {
@@ -645,10 +645,10 @@ inline void DmaSelectChannel(DmaReg *dma, DmaChannel chan, int selection) {
 }
 
 enum class DmaInterrupt {
-  kGlobal = 1,
-  kTransferComplete = 2,
-  kHalfTransfer = 4,
-  kTransferError = 8
+  Global = 1,
+  TransferComplete = 2,
+  HalfTransfer = 4,
+  TransferError = 8
 };
 
 // Detect a DMA Interrupt

--- a/software/controller/lib/hal/hal_stm32_regs.h
+++ b/software/controller/lib/hal/hal_stm32_regs.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef __HAL_STM32_REGS
-#define __HAL_STM32_REGS
+#ifndef HAL_STM32_REGS_H
+#define HAL_STM32_REGS_H
 
 #include <stdint.h>
 
@@ -29,513 +29,495 @@ Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 */
 
 // [PM] 4.4 System control block (SCB) (pg 221)
-struct RCC_Regs_ {    // <Offset> <Name>
-  uint32_t clkCtrl;   // 0x00 clock control register (RCC_CR)
-  uint32_t clkCal;    // 0x04 Internal clock sources calibration register
-                      // (RCC_ICSCR)
-  uint32_t clkCfg;    // 0x08 clock configuration register (RCC_CFGR)
-  uint32_t pllCfg;    // 0x0C PLL configuration register (RCC_PLLCFGR)
-  uint32_t pllSaiCfg; // 0x10 PLLSAI1 configuration register (RCC_PLLSAI1CFGR)
-  uint32_t rsvd1;
-  uint32_t clkIntEna; // 0x18 Clock interrupt enable register ( RCC_CIER)
-  uint32_t clkIntFlg; // 0x1C Clock interrupt flag register ( RCC_CIFR)
-  uint32_t clkIntClr; // 0x20 Clock interrupt clear register ( RCC_CICR)
-  uint32_t rsvd2;
-  uint32_t periphReset[8];  // 0x28 peripheral reset registers
-  uint32_t periphClkEna[8]; // 0x48 peripheral clock registers
-  uint32_t sleepClkEna[8];  // 0x68 Clock enable in sleep
-  uint32_t indClkCfg;       // 0x88 Peripherals independent clock configuration
-                            // register (RCC_CCIPR)
-  uint32_t rsvd3;
-  uint32_t backup;     // 0x90 Backup domain control register (RCC_BDCR)
-  uint32_t status;     // 0x94 control & status register (RCC_CSR)
-  uint32_t recovery;   // 0x98 Clock recovery RC register (RCC_CRRCR)
-  uint32_t indClkCfg2; // 0x9C Peripherals independent clock configuration
-                       // register
-                       // (RCC_CCIPR2)
+struct RccStruct {
+  uint32_t clock_control;
+  uint32_t clock_calibration;
+  uint32_t clock_config;
+  uint32_t pll_config;
+  uint32_t pll_sai_config;
+  uint32_t reserved1;
+  uint32_t clock_interrupt_enable;
+  uint32_t clock_interrupt_flag;
+  uint32_t clock_interrupt_clear;
+  uint32_t reserved2;
+  uint32_t peripheral_reset[8];
+  uint32_t peripheral_clock_enable[8];
+  uint32_t sleep_clock_enable[8];
+  uint32_t independent_clock_config;
+  uint32_t reserved3;
+  uint32_t backup;
+  uint32_t status;
+  uint32_t recovery;
+  uint32_t independent_clock_config2;
 };
-typedef volatile RCC_Regs_ RCC_Regs;
-inline RCC_Regs *const RCC_BASE = reinterpret_cast<RCC_Regs *>(0x40021000);
+typedef volatile RccStruct RccReg;
+inline RccReg *const kRccBase = reinterpret_cast<RccReg *>(0x40021000);
 
 // [PM] 4.4 System control block (SCB) (pg 221)
-struct SysCtrl_Reg_ {
-  uint32_t rsvd0;      // 0xE000E000
-  uint32_t intType;    // 0xE000E004
-  uint32_t auxCtrl;    // 0xE000E008 - Auxiliary Control Register
-  uint32_t rsvd1;      // 0xE000E00C
-  uint32_t systick[3]; // 0xE000E010 - SysTick Timer
-  uint32_t rsvd2[57];
-  uint32_t nvic[768];  // 0xE000E100 - NVIC Register [RM] 4.3 (pg 208)
-  uint32_t cpuid;      // 0xE000ED00 - CPUID Base Register
-  uint32_t intCtrl;    // 0xE000ED04 - Interrupt Control and State Register
-  uint32_t vtable;     // 0xE000ED08 - Vector Table Offset Register
-  uint32_t apInt;      // 0xE000ED0C - Application Interrupt and Reset Control
-                       // Register
-  uint32_t sysCtrl;    // 0xE000ED10 - System Control Register
-  uint32_t cfgCtrl;    // 0xE000ED14 - Configuration and Control Register
-  uint32_t sysPri[3];  // 0xE000ED18 - System Handler Priority Registers (1-3)
-  uint32_t sysHdnCtrl; // 0xE000ED24 - System Handler Control and State
-                       // Register
-  uint32_t faultStat;  // 0xE000ED28 - Configurable Fault Status Register
-  uint32_t hardFaultStat; // 0xE000ED2C - Hard Fault Status Register
-  uint32_t rsvd3;
-  uint32_t mmFaultAddr; // 0xE000ED34 - Memory Management Fault Address
-                        // Register
-  uint32_t faultAddr;   // 0xE000ED38 - Bus Fault Address Register
-  uint32_t rsvd4[19];
-  uint32_t cpac; // 0xE000ED88 - Coprocessor access control register
+struct SysControlStruct {
+  uint32_t reserved0;
+  uint32_t int_type;
+  uint32_t aux_control;
+  uint32_t reserved1;
+  uint32_t sys_tick[3];
+  uint32_t reserved2[57];
+  uint32_t nvic[768]; // 0xE000E100 - NVIC Register [RM] 4.3 (pg 208)
+  uint32_t cpu_id;
+  uint32_t int_control;
+  uint32_t vector_table;
+  uint32_t app_interrupt; // 0xE000ED0C - Application Interrupt and Reset
+                          // Control Register
+  uint32_t system_control;
+  uint32_t config_control; // 0xE000ED14 - Configuration and Control Register
+  uint32_t system_priority[3];
+  uint32_t system_handler_control;
+  uint32_t fault_status;
+  uint32_t hard_fault_status;
+  uint32_t reserved3;
+  uint32_t mm_fault_address;
+  uint32_t bus_fault_addr;
+  uint32_t reserved4[19];
+  uint32_t coproc_access_control; // 0xE000ED88 - Coprocessor access control
+                                  // register
 };
-typedef volatile SysCtrl_Reg_ SysCtrl_Reg;
-inline SysCtrl_Reg *const SYSCTL_BASE =
-    reinterpret_cast<SysCtrl_Reg *>(0xE000E000);
+typedef volatile SysControlStruct SysControlReg;
+inline SysControlReg *const kSysControlBase =
+    reinterpret_cast<SysControlReg *>(0xE000E000);
 
 // [PM] 4.3 Nested vectored interrupt controller (NVIC) (pg 208)
-struct IntCtrl_Regs_ {
-  uint32_t setEna[32];
-  uint32_t clrEna[32];
-  uint32_t setPend[32];
-  uint32_t clrPend[32];
+struct InterruptControlStruct {
+  uint32_t set_enable[32];
+  uint32_t clear_enable[32];
+  uint32_t set_pending[32];
+  uint32_t clear_pending[32];
   uint32_t active[64];
   uint8_t priority[1024];
 };
-typedef volatile IntCtrl_Regs_ IntCtrl_Regs;
-inline IntCtrl_Regs *const NVIC_BASE =
-    reinterpret_cast<IntCtrl_Regs *>(0xE000E100);
+typedef volatile InterruptControlStruct InterruptControlReg;
+inline InterruptControlReg *const kNvicBase =
+    reinterpret_cast<InterruptControlReg *>(0xE000E100);
 
 // [RM] 38.8 USART Registers (pg 1238)
-struct UART_Regs_ {
+struct UartStruct {
   union {
     struct {
-      uint32_t ue : 1;     // USART enable
-      uint32_t uesm : 1;   // USART enable in Stop mode
-      uint32_t re : 1;     // Receiver enable
-      uint32_t te : 1;     // Transmitter enable
-      uint32_t idleie : 1; // IDLE interrupt enable
-      uint32_t rxneie : 1; // RXNE interrupt enable
-      uint32_t tcie : 1;   // Transmission complete interrupt enable
-      uint32_t txeie : 1;  // Transmit interrupt enable
-      uint32_t peie : 1;   // Parity Error interrupt enable
-      uint32_t ps : 1;     // Parity selection
-      uint32_t pce : 1;    // Parity control enable
-      uint32_t wake : 1;   // Receiver wakeup method
-      uint32_t m0 : 1;     // Word length 0
-      uint32_t mme : 1;    // Mute mode enable
-      uint32_t cmie : 1;   // Character match interrupt enable
-      uint32_t over8 : 1;  // Oversampling mode
-      uint32_t dedt : 5;   // Driver Enable de-assertion time
-      uint32_t deat : 5;   // Driver Enable assertion time
-      uint32_t rtoie : 1;  // Receiver timeout interrupt enable
-      uint32_t eobie : 1;  // End of Block interrupt enable
-      uint32_t m1 : 1;     // Word length 1
-      uint32_t rsvd : 3;
-    } s;
-    uint32_t r;
-  } ctrl1; // Control Register 1 (USART_CR1) [RM] 38.8.1 (pg 1238)
+      uint32_t enable : 1;
+      uint32_t stop_mode : 1;
+      uint32_t rx_enable : 1;
+      uint32_t tx_enable : 1;
+      uint32_t idle_interrupt : 1;
+      uint32_t rx_interrupt : 1;
+      uint32_t tx_complete_interrupt : 1;
+      uint32_t tx_interrupt : 1;
+      uint32_t parity_error_interrupt : 1;
+      uint32_t parity : 1;
+      uint32_t parity_control_enable : 1;
+      uint32_t rx_wakeup_method : 1;
+      uint32_t word_length0 : 1;
+      uint32_t mute_mode_enable : 1;
+      uint32_t char_match_interrupt : 1;
+      uint32_t oversampling_mode : 1;
+      uint32_t driver_deassertion_time : 5; // Driver Enable de-assertion time
+      uint32_t driver_assertion_time : 5;   // Driver Enable assertion time
+      uint32_t rx_timeout_interrupt : 1;
+      uint32_t eob_interrupt : 1; // End of Block interrupt enable
+      uint32_t word_length1 : 1;
+      uint32_t reserved : 3;
+    } bitfield;
+    uint32_t full_reg;
+  } control_reg1; // Control Register 1 (USART_CR1) [RM] 38.8.1 (pg 1238)
   union {
     struct {
-      uint32_t rsvd2 : 4;
-      uint32_t addm7 : 1; // 7-bit Address Detection/4-bit Address
-                          // Detection
-      uint32_t lbdl : 1;  // LIN break detection length
-      uint32_t lbdie : 1; // LIN break detection interrupt enable
-      uint32_t rsvd1 : 1;
-      uint32_t lbcl : 1;     // Last bit clock pulse
-      uint32_t cpha : 1;     // Clock phase
-      uint32_t cpol : 1;     // Clock polarity
-      uint32_t clken : 1;    // Clock enable
-      uint32_t stop : 2;     // STOP bits
-      uint32_t linen : 1;    // LIN mode enable
-      uint32_t swap : 1;     // Swap TX/RX pins
-      uint32_t rxinv : 1;    // RX pin active level inversion
-      uint32_t txinv : 1;    // TX pin active level inversion
-      uint32_t datainv : 1;  // Binary data inversion
-      uint32_t msbfirst : 1; // Most significant bit first
-      uint32_t abren : 1;    // Auto baud rate enable
-      uint32_t abrmod : 2;   // Auto baud rate mode
-      uint32_t rtoen : 1;    // Receiver timeout enable
-      uint32_t addr : 8;     // used for character detection during normal
-                             // reception This bit field can only be written
-                             // when reception is disabled (RE = 0) or the
-                             // USART is disabled (UE=0)
-    } s;
-    uint32_t r;
-  } ctrl2; // Control Register 2 (USART_CR2) [RM] 38.8.2 (pg 1241)
+      uint32_t reserved2 : 4;
+      uint32_t address_detection_mode : 1; // 7-bit | 4bit Address Detection
+      uint32_t break_detection_length : 1;
+      uint32_t break_detection_interrput : 1;
+      uint32_t reserved1 : 1;
+      uint32_t last_bit_clock_pulse : 1;
+      uint32_t clock_phase : 1;
+      uint32_t clock_polarity : 1;
+      uint32_t clock_enable : 1;
+      uint32_t stop_bits : 2;
+      uint32_t lin_mode_enable : 1;
+      uint32_t swap_rx_tx_pins : 1;
+      uint32_t rx_inversion : 1;
+      uint32_t tx_inversion : 1;
+      uint32_t data_inversion : 1;
+      uint32_t msb_first : 1;
+      uint32_t auto_baudrate_enable : 1;
+      uint32_t auto_baudrate_mode : 2;
+      uint32_t rx_timeout_enable : 1;
+      uint32_t addr : 8; // used for character detection during normal
+                         // reception.  This bit field can only be written
+                         // when reception is disabled (RE = 0) or the
+                         // USART is disabled (UE=0)
+    } bitfield;
+    uint32_t full_reg;
+  } control2; // Control Register 2 (USART_CR2) [RM] 38.8.2 (pg 1241)
   union {
     struct {
-      uint32_t eie : 1;    // Error interrupt enable
-      uint32_t iren : 1;   // IrDA mode enable
-      uint32_t irlp : 1;   // IrDA low-power
-      uint32_t hdsel : 1;  // Half-duplex selection
-      uint32_t nack : 1;   // Smartcard NACK enable
-      uint32_t scen : 1;   // Smartcard mode enable
-      uint32_t dmar : 1;   // DMA enable receiver
-      uint32_t dmat : 1;   // DMA enable transmitter
-      uint32_t rtse : 1;   // RTS enable
-      uint32_t ctse : 1;   // CTS enable
-      uint32_t ctsie : 1;  // CTS interrupt enable
+      uint32_t error_interrupt : 1;
+      uint32_t irda_mode : 1;
+      uint32_t irda_low_power : 1;
+      uint32_t half_duplex : 1;
+      uint32_t smartcard_nack_enable : 1;
+      uint32_t smartcard_mode : 1;
+      uint32_t rx_dma : 1;
+      uint32_t tx_dma : 1;
+      uint32_t rts_enable : 1;
+      uint32_t cts_enable : 1;
+      uint32_t cts_interrupt : 1;
       uint32_t onebit : 1; // One sample bit method enable
-      uint32_t ovrdis : 1; // Overrun Disable
-      uint32_t ddre : 1;   // DMA Disable on Reception Error
-      uint32_t dem : 1;    // Driver enable mode
-      uint32_t dep : 1;    // Driver enable polarity selection
-      uint32_t rsvd2 : 1;
-      uint32_t scarcnt : 3; // Smartcard auto-retry count
-      uint32_t wus : 2;     // Wakeup from Stop mode interrupt flag selection
-      uint32_t wufie : 1;   // Wakeup from Stop mode interrupt enable
-      uint32_t ucesm : 1;   // USART Clock Enable in Stop mode.
-      uint32_t tcbgtie : 1; // Transmission complete before guard time
-                            // interrupt enable
-      uint32_t rsvd : 7;
-    } s;
-    uint32_t r;
-  } ctrl3; // Control Register 3 [RM] 38.8.3  (pg 1245)
-  uint32_t baud;
-  uint32_t guard;
+      uint32_t overrun_disable : 1;
+      uint32_t dma_disable_on_rx_error : 1;
+      uint32_t driver_enable_mode : 1;
+      uint32_t driver_enable_polarity : 1;
+      uint32_t reserved2 : 1;
+      uint32_t smartcard_auto_retry_count : 3;
+      uint32_t wakeup_stop_interrupt_select : 2;
+      uint32_t wakeup_stop_interrupt_enable : 1;
+      uint32_t uart_clock_stop_mode : 1;
+      uint32_t tx_complete_before_guard_interrupt : 1;
+      uint32_t reserved : 7;
+    } bitfield;
+    uint32_t full_reg;
+  } control3; // Control Register 3 [RM] 38.8.3  (pg 1245)
+  uint32_t baudrate;
+  uint32_t guard_time;
   union {
     struct {
-      uint32_t rto : 24; // receiver timeout
-      uint32_t blen : 8; // block length
-    } s;
-    uint32_t r;
+      uint32_t rx_timeout : 24;
+      uint32_t block_length : 8;
+    } bitfield;
+    uint32_t full_reg;
   } timeout; // Receiver Timeout Register (USART_RTOR) [RM] 38.8.6 (pg 1251)
   union {
     struct {
-      uint32_t abrrq : 1; // auto baud rate request
-      uint32_t sbkrq : 1; // send break request
-      uint32_t mmrq : 1;  // mute  mode request
-      uint32_t rxfrq : 1; // receive data flush request
-      uint32_t txfrq : 1; // transmit data flush request
-      uint32_t rsvd : 27;
-    } s;
-    uint32_t r;
+      uint32_t auto_baudrate : 1;
+      uint32_t send_break : 1;
+      uint32_t mute_mode : 1;
+      uint32_t flush_rx : 1;
+      uint32_t flush_tx : 1;
+      uint32_t reserved : 27;
+    } bitfield;
+    uint32_t full_reg;
   } request; // Request Register (USART_QRQ) [RM] 38.8.7 (pg 1252)
   union {
     struct {
-      const uint32_t pe : 1;    // parity error
-      const uint32_t fe : 1;    // framing error
-      const uint32_t nf : 1;    // START bit noise detection flag
-      const uint32_t ore : 1;   // overrun error
-      const uint32_t idle : 1;  // idle line detected
-      const uint32_t rxne : 1;  // read data register not empty
-      const uint32_t tc : 1;    // transmission complete
-      const uint32_t txe : 1;   // transmit data register empty
-      const uint32_t lbdf : 1;  // LIN break detection flag
-      const uint32_t ctsif : 1; // CTS interrupt flag
-      const uint32_t cts : 1;   // CTS flag
-      const uint32_t rtof : 1;  // receiver timeout
-      const uint32_t eobf : 1;  // end of block flag
-      const uint32_t rsvd : 1;
-      const uint32_t abre : 1;  // auto baud rate error
-      const uint32_t abrf : 1;  // auto baud rate flag
-      const uint32_t busy : 1;  // busy flag
-      const uint32_t cmf : 1;   // character match flag
-      const uint32_t sbkf : 1;  // send break flag
-      const uint32_t rwu : 1;   // receiver wakeup from Mute mode
-      const uint32_t wuf : 1;   // wakeup from Stop mode flag
-      const uint32_t teack : 1; // transmit enable acknowledge flag
-      const uint32_t reack : 1; // receive enable acknowledge flag
-      const uint32_t rsvd2 : 2;
-      const uint32_t tcbgt : 1; // trans. complete before guard time
-                                // completion
-      const uint32_t rsvd3 : 6;
-    } s;
-    uint32_t r;
+      const uint32_t parity_error : 1;
+      const uint32_t framing_error : 1;
+      const uint32_t noise_detection : 1;
+      const uint32_t overrun_error : 1;
+      const uint32_t idle : 1;
+      const uint32_t rx_not_empty : 1;
+      const uint32_t tx_complete : 1;
+      const uint32_t tx_empty : 1;
+      const uint32_t lin_break_detected : 1;
+      const uint32_t cts_interrupt : 1;
+      const uint32_t cts : 1;
+      const uint32_t rx_timeout : 1;
+      const uint32_t end_of_block : 1;
+      const uint32_t reserved : 1;
+      const uint32_t auto_baudrate_error : 1;
+      const uint32_t auto_baudrate_flag : 1;
+      const uint32_t busy : 1;
+      const uint32_t char_match : 1;
+      const uint32_t send_break : 1;
+      const uint32_t rx_wakeup : 1;
+      const uint32_t wakeup_from_stop : 1;
+      const uint32_t tx_enable_ack : 1;
+      const uint32_t rx_enable_ack : 1;
+      const uint32_t reserved2 : 2;
+      const uint32_t tx_complete_before_guard : 1;
+      const uint32_t reserved3 : 6;
+    } bitfield;
+    uint32_t full_reg;
   } status; // [RM] 38.8.8 Interrupt And Status Register (USART_ISR) (pg 1253)
   union {
     struct {
-      uint32_t pecf : 1;   // parity error clear flag
-      uint32_t fecf : 1;   // framing error clear flag
-      uint32_t ncf : 1;    // noise detected clear flag
-      uint32_t orecf : 1;  // overrun error clear flag
-      uint32_t idlecf : 1; // idle line detected clear flag
-      uint32_t rsvd : 1;
-      uint32_t tccf : 1;    // transmission complete clear flag
-      uint32_t tcbgtcf : 1; // transmission completed before guard time
-                            // clear fl.
-      uint32_t lbdcf : 1;   // LIN break detection clear flag
-      uint32_t ctscf : 1;   // CTS clear flag
-      uint32_t rsvd2 : 1;
-      uint32_t rtocf : 1; // receiver timeout clear flag
-      uint32_t eobcf : 1; // end of block clear flag
-      uint32_t rsvd3 : 4;
-      uint32_t cmcf : 1; // character match clear flag
-      uint32_t rsvd4 : 2;
-      uint32_t wucf : 1; // wakeup from stop mode clear flag
-      uint32_t rsvd5 : 11;
-    } s;
-    uint32_t r;
-  } intClear; // [RM] 38.8.9 Interrupt Flag Clear Register (USART_ICR) (pg
-              // 1257)
-  uint32_t rxDat;
-  uint32_t txDat;
+      uint32_t parity_error_clear : 1;
+      uint32_t framing_error_clear : 1;
+      uint32_t noise_detected_clear : 1;
+      uint32_t overrun_clear : 1;
+      uint32_t clear_idle : 1;
+      uint32_t reserved : 1;
+      uint32_t tx_complete_clear : 1;
+      uint32_t tx_complete_before_guard_clear : 1;
+      uint32_t lin_break_detected_clear : 1;
+      uint32_t cts_clear : 1;
+      uint32_t reserved2 : 1;
+      uint32_t rx_timeout_clear : 1;
+      uint32_t end_of_block_clear : 1;
+      uint32_t reserved3 : 4;
+      uint32_t char_match_clear : 1;
+      uint32_t reserved4 : 2;
+      uint32_t wakeup_from_stop_clear : 1;
+      uint32_t reserved5 : 11;
+    } bitfield;
+    uint32_t full_reg;
+  } interrupt_clear; // [RM] 38.8.9 Interrupt Flag Clear Register (USART_ICR)
+                     // (pg 1257)
+  uint32_t rx_data;
+  uint32_t tx_data;
 };
-typedef volatile UART_Regs_ UART_Regs;
-inline UART_Regs *const UART1_BASE = reinterpret_cast<UART_Regs *>(0x40013800);
-inline UART_Regs *const UART2_BASE = reinterpret_cast<UART_Regs *>(0x40004400);
-inline UART_Regs *const UART3_BASE = reinterpret_cast<UART_Regs *>(0x40004800);
-inline UART_Regs *const UART4_BASE = reinterpret_cast<UART_Regs *>(0x40004C00);
+typedef volatile UartStruct UartReg;
+inline UartReg *const kUart1Base = reinterpret_cast<UartReg *>(0x40013800);
+inline UartReg *const kUart2Base = reinterpret_cast<UartReg *>(0x40004400);
+inline UartReg *const kUart3Base = reinterpret_cast<UartReg *>(0x40004800);
+inline UartReg *const kUart4Base = reinterpret_cast<UartReg *>(0x40004C00);
 
 // [RM] 16.6 ADC Registers (for each ADC) (pg 450)
-struct ADC_Regs_ {
+struct AdcStruct {
   // A/D specific registers (0x100 total length)
   struct {
-    uint32_t stat;   // 0x00 - interrupt and status register (ADC_ISR)
-    uint32_t intEna; // 0x04 - interrupt enable register (ADC_IER)
-    uint32_t ctrl;   // 0x08 - control register (ADC_CR)
+    uint32_t status;
+    uint32_t interrupts_enable;
+    uint32_t control;
     struct {
-      uint32_t dmaen : 1;      // DMA enable
-      uint32_t dmacfg : 1;     // DMA config
-      uint32_t dfsdmcfg : 1;   //
-      uint32_t resolution : 2; // A/D resolution
-      uint32_t align : 1;      // Data alignment
-      uint32_t extsel : 4;     // External trigger selection
-      uint32_t exten : 2;      // External trigger enable
-      uint32_t ovrmod : 1;     // Over run mode
-      uint32_t cont : 1;       // Continuous conversion mode
-      uint32_t autdlh : 1;     // Delayed conversion mode
-      uint32_t rsvd1 : 1;      //
-      uint32_t discen : 1;     // Discontinuous mode
-      uint32_t discnum : 3;    // Discontinuous mode channel count
-      uint32_t jdiscen : 1;    // Discontinuous mode on injected channels
-      uint32_t jqm : 1;        // JSQR mode
-      uint32_t awd1sgl : 1;
-      uint32_t awd1en : 1;
-      uint32_t jawd1en : 1;
-      uint32_t jauto : 1;
-      uint32_t awd1ch : 5;
-      uint32_t jqdis : 1;
-    } cfg1; // 0x0C - [RM] 16.6.4 ADC Configuration Register (ADC_CFGR) (pg
-            // 458)
-
-    struct {
-      uint32_t rovse : 1; // bit 0    - regular oversampling enable
-      uint32_t jovse : 1; // bit 1    - injected oversampling enable
-      uint32_t ovsr : 3;  // bits 2-4 - oversampling ratio
-      uint32_t ovss : 4;  // bits 5-8 - oversampling shift (max 0b1000)
-      uint32_t trovs : 1; // bit 9    - triggered regular oversampling
-      uint32_t rovsm : 1; // bit 10   - regular oversampling mode
-      uint32_t rsvd : 21;
-    } cfg2; // [RM] 16.6.5 ADC configuration register 2 (ADC_CFGR2) (pg 462)
+      uint32_t dma_enable : 1;
+      uint32_t dma_config : 1;
+      uint32_t df_sdm_config : 1;
+      uint32_t resolution : 2;
+      uint32_t alignment : 1;
+      uint32_t external_trigger_selection : 4;
+      uint32_t external_trigger_enable : 2;
+      uint32_t overrun_mode : 1;
+      uint32_t continuous_conversion : 1;
+      uint32_t delayed_conversion : 1;
+      uint32_t reserved1 : 1;
+      uint32_t discontinuous_mode : 1;
+      uint32_t discontinuous_channel_count : 3;
+      uint32_t discontinuous_injected_channels : 1;
+      uint32_t jsqr_mode : 1;
+      uint32_t single_channel_analog_watchdog1 : 1;
+      uint32_t analog_watchdog1_enable : 1;
+      uint32_t analog_watchdog1_on_injected : 1;
+      uint32_t automatic_injected_conversion : 1;
+      uint32_t analog_watchdog1_channel : 5;
+      uint32_t injected_queue_disable : 1;
+    } configuration1; // 0x0C - [RM] 16.6.4 ADC Configuration Register
+                      // (ADC_CFGR) (pg 458)
 
     struct {
-      uint32_t smp0 : 3; // Sample time for channel 0
-      uint32_t smp1 : 3; // Sample time for channel 1
-      uint32_t smp2 : 3; // Sample time for channel 2
-      uint32_t smp3 : 3; // Sample time for channel 3
-      uint32_t smp4 : 3; // Sample time for channel 4
-      uint32_t smp5 : 3; // Sample time for channel 5
-      uint32_t smp6 : 3; // Sample time for channel 6
-      uint32_t smp7 : 3; // Sample time for channel 7
-      uint32_t smp8 : 3; // Sample time for channel 8
-      uint32_t smp9 : 3; // Sample time for channel 9
-      uint32_t rsvd : 2;
+      uint32_t regular_oversampling : 1;
+      uint32_t injected_oversampling : 1;
+      uint32_t oversampling_ratio : 3;
+      uint32_t oversampling_shift : 4;
+      uint32_t triggered_oversampling : 1;
+      uint32_t regular_oversampling_mode : 1;
+      uint32_t reserved : 21;
+    } configuration2; // [RM] 16.6.5 ADC configuration register 2 (ADC_CFGR2)
+                      // (pg 462)
 
-      uint32_t smp10 : 3; // Sample time for channel 10
-      uint32_t smp11 : 3; // Sample time for channel 11
-      uint32_t smp12 : 3; // Sample time for channel 12
-      uint32_t smp13 : 3; // Sample time for channel 13
-      uint32_t smp14 : 3; // Sample time for channel 14
-      uint32_t smp15 : 3; // Sample time for channel 15
-      uint32_t smp16 : 3; // Sample time for channel 16
-      uint32_t smp17 : 3; // Sample time for channel 17
-      uint32_t smp18 : 3; // Sample time for channel 18
-      uint32_t rsvd2 : 5;
-    } samp; // [RM] 16.6.6 ADC Sample Time Register 1 (ADC_SMPR1) (pg 464)
+    struct {
+      uint32_t ch0 : 3;
+      uint32_t ch1 : 3;
+      uint32_t ch2 : 3;
+      uint32_t ch3 : 3;
+      uint32_t ch4 : 3;
+      uint32_t ch5 : 3;
+      uint32_t ch6 : 3;
+      uint32_t ch7 : 3;
+      uint32_t ch8 : 3;
+      uint32_t ch9 : 3;
+      uint32_t reserved1 : 2;
+      uint32_t ch10 : 3;
+      uint32_t ch11 : 3;
+      uint32_t ch12 : 3;
+      uint32_t ch13 : 3;
+      uint32_t ch14 : 3;
+      uint32_t ch15 : 3;
+      uint32_t ch16 : 3;
+      uint32_t ch17 : 3;
+      uint32_t ch18 : 3;
+      uint32_t reserved2 : 5;
+    } sample_times; // [RM] 16.6.6 ADC Sample Time Register 1 (ADC_SMPR1) (pg
+                    // 464)
 
-    uint32_t rsvd1;
-    uint32_t wdog[3]; // 0x20 - [RM] 16.6.8 ADC Watchdog
-    uint32_t rsvd2;
+    uint32_t reserved1;
+    uint32_t watchdogs[3]; // 0x20 - [RM] 16.6.8 ADC Watchdog
+    uint32_t reserved2;
 
     // 4x sequence registers.  These registers are used
     // to define the number of A/D readings and the
     // channel numbers being read.
     struct {
-      // [RM] 16.6.11 ADC Regular Sequence Register 1 (ADC_SQR1) (pg 468)
-      uint32_t len : 6;
-      uint32_t sq1 : 6;
-      uint32_t sq2 : 6;
-      uint32_t sq3 : 6;
-      uint32_t sq4 : 6;
-      uint32_t rsvd1 : 2;
+      uint32_t length : 6;
+      uint32_t sequence1 : 6;
+      uint32_t sequence2 : 6;
+      uint32_t sequence3 : 6;
+      uint32_t sequence4 : 6;
+      uint32_t reserved1 : 2;
 
-      // [RM] 16.6.12 ADC Regular Sequence Register 2 (ADC_SQR2) (pg 469)
-      uint32_t sq5 : 6;
-      uint32_t sq6 : 6;
-      uint32_t sq7 : 6;
-      uint32_t sq8 : 6;
-      uint32_t sq9 : 6;
-      uint32_t rsvd2 : 2;
+      uint32_t sequence5 : 6;
+      uint32_t sequence6 : 6;
+      uint32_t sequence7 : 6;
+      uint32_t sequence8 : 6;
+      uint32_t sequence9 : 6;
+      uint32_t reserved2 : 2;
 
-      // [RM] 16.6.13 ADC regular sequence register 3 (ADC_SQR3) (pg 470)
-      uint32_t sq10 : 6;
-      uint32_t sq11 : 6;
-      uint32_t sq12 : 6;
-      uint32_t sq13 : 6;
-      uint32_t sq14 : 6;
-      uint32_t rsvd3 : 2;
+      uint32_t sequence10 : 6;
+      uint32_t sequence11 : 6;
+      uint32_t sequence12 : 6;
+      uint32_t sequence13 : 6;
+      uint32_t sequence14 : 6;
+      uint32_t reserved3 : 2;
 
-      // [RM] 16.6.14 ADC Regular Sequence Register 4 (ADC_SQR4) (pg 471)
-      uint32_t sq15 : 6;
-      uint32_t sq16 : 6;
-      uint32_t rsvd4 : 20;
-    } seq; // ADC Regular Sequence Register
+      uint32_t sequence15 : 6;
+      uint32_t sequence16 : 6;
+      uint32_t reserved4 : 20;
+    } sequence; // ADC Regular Sequence Register (pg 468)
 
-    uint32_t data; // 0x40 - Regular Data Register [RM] 16.6.15 (pg 471)
-    uint32_t rsvd3[2];
-    uint32_t iSeq; // 0x4C - Injected Sequence Register [RM] 16.6.16 (pg
-                   // 472)
-    uint32_t rsvd4[4];
-    uint32_t offset[4]; // 0x60 - Offset Register [RM] 16.6.17 (pg 473)
-    uint32_t rsvd5[4];
-    uint32_t iData[4]; // 0x80 - Injected Chan Data Reg [RM] 16.6.18 (pg
-                       // 474)
-    uint32_t rsvd6[4];
-    uint32_t wdCfg[2]; // 0xA0 - Analog Watchdog Config Reg [RM] 16.6.19 (pg
-                       // 474)
-    uint32_t rsvd7[2];
-    uint32_t diffSel; // 0xB0 - Differential Mode Selection Reg [RM] 16.6.21
-                      // (pg 476)
-    uint32_t cal;     // 0xB4 - Calibration Factors [RM] 16.6.22 (pg 476)
-    uint32_t rsvd8[18];
+    uint32_t data;
+    uint32_t reserved3[2];
+    uint32_t injected_sequence;
+    uint32_t reserved4[4];
+    uint32_t offset[4];
+    uint32_t reserved5[4];
+    uint32_t injected_data[4];
+    uint32_t reserved6[4];
+    uint32_t watchdoc_config[2];
+    uint32_t reserved7[2];
+    uint32_t differential_mode;
+    uint32_t calibration; // 0xB4 - Calibration Factors [RM] 16.6.22 (pg 476)
+    uint32_t reserved8[18];
   } adc[2]; // Master ADC1, Slave ADC2
 
-  uint32_t comStat; // 0x300 - Common Status Register [RM] 16.7.1 (pg 477)
-  uint32_t rsvd9;
-  uint32_t comCtrl; // 0x304 - Common Control Register [RM] 16.7.2 (pg 479)
-  uint32_t comData; // 0x308 - Common Data Reg Dual Mode [RM] 16.7.3 (pg 482)
+  uint32_t common_status;
+  uint32_t reserved9;
+  uint32_t common_control;
+  uint32_t common_data;
 };
-typedef volatile ADC_Regs_ ADC_Regs;
-inline ADC_Regs *const ADC_BASE = reinterpret_cast<ADC_Regs *>(0X50040000);
+typedef volatile AdcStruct AdcReg;
+inline AdcReg *const kAdcBase = reinterpret_cast<AdcReg *>(0X50040000);
 
 // Timer Register
 // NOTE: Offset values and applicable registers depend on timer used
-struct TimerRegs_ {
+struct TimerStruct {
   union {
     struct {
-      uint32_t cen : 1;  // counter enable
-      uint32_t udis : 1; // update disable
-      uint32_t urs : 1;  // update request source
-      uint32_t opm : 1;  // one-pulse mode
-      uint32_t dir : 1;  // direction
-      uint32_t cms : 2;  // center-aligned mode selection
-      uint32_t arpe : 1; // auto-reload preload enable
-      uint32_t ckd : 2;  // clock division
-      uint32_t rsvd : 1;
-      uint32_t uifremap : 1; // UIF status bit remapping
-      uint32_t rsvd2 : 20;
-    } s;
-    uint32_t r;
-  } ctrl1;
-  uint32_t ctrl2;     // Control Register 2
-  uint32_t slaveCtrl; // Slave Mode Control Register
-  uint32_t intEna;    // DMA/Interrupt Enable Register
-  uint32_t status;    // Status Register
-  uint32_t event;     // Even Generation Register
-  uint32_t ccMode[2]; // Capture/Compare Mode Register (1,2)
-  uint32_t ccEnable;  // Capture/Compare Enable Register
+      uint32_t counter_enable : 1;
+      uint32_t update_disable : 1;
+      uint32_t update_request_source : 1;
+      uint32_t one_pulse_mode : 1;
+      uint32_t direction : 1;
+      uint32_t center_aligned_mode : 2;
+      uint32_t auto_reload_preload : 1;
+      uint32_t clock_division : 2;
+      uint32_t reserved : 1;
+      uint32_t uif_remapping : 1;
+      uint32_t reserved2 : 20;
+    } bitfield;
+    uint32_t full_reg;
+  } control_reg1;
+  uint32_t control2;
+  uint32_t slave_control;
+  uint32_t interrupts_enable;
+  uint32_t status;
+  uint32_t event;
+  uint32_t capture_compare_mode[2];
+  uint32_t capture_compare_enable;
   // The topmost bit of counter will contain contain UIFCOPY if UIFREMAP is
   // enabled, but *this register should not be decomposed into a bitfield
   // struct*.  The idea behind UIFREMAP is to read the counter plus the UIFCOPY
   // value atomically, in one go.
-  uint32_t counter;    // Counter
-  uint32_t prescale;   // Prescaler
-  uint32_t reload;     // Auto-reload Register
-  uint32_t repeat;     // Repetition Counter Register
-  uint32_t compare[4]; // Capture/Compare Register (1-4)
-  uint32_t deadTime;   // Break and Dead-time Register
-  uint32_t dmaCtrl;    // DMA Control Register
-  uint32_t dmaAddr;    // DMA Address for Full Transfer
-  uint32_t opt1;       // Option Register 1
-  uint32_t ccMode3;    // Capture/Compare Mode Register 3
-  uint32_t compare5;   // Capture/Compare Register 5
-  uint32_t compare6;   // Capture/Compare Register 6
-  uint32_t opt2;       // Option Register 2
-  uint32_t opt3;       // Option Register 3
+  uint32_t counter;
+  uint32_t prescaler;
+  uint32_t auto_reload;
+  uint32_t repeat;
+  uint32_t capture_compare[4];
+  uint32_t dead_time;
+  uint32_t dma_control;
+  uint32_t dma_address;
+  uint32_t option1;
+  uint32_t capture_compare_mode3;
+  uint32_t capture_compare_mode5;
+  uint32_t capture_compare_mode6;
+  uint32_t option2;
+  uint32_t option3;
 };
-typedef volatile TimerRegs_ TimerRegs;
+typedef volatile TimerStruct TimerReg;
 
 // [RM] 26 Advanced-control Timers (TIM1) (pg 718)
-inline TimerRegs *const TIMER1_BASE = reinterpret_cast<TimerRegs *>(0x40012C00);
+inline TimerReg *const kTimer1Base = reinterpret_cast<TimerReg *>(0x40012C00);
 // [RM] 27 General-purpose Timers (TIM2/TIM3) (pg 817)
-inline TimerRegs *const TIMER2_BASE = reinterpret_cast<TimerRegs *>(0x40000000);
-inline TimerRegs *const TIMER3_BASE = reinterpret_cast<TimerRegs *>(0x40000400);
+inline TimerReg *const kTimer2Base = reinterpret_cast<TimerReg *>(0x40000000);
+inline TimerReg *const kTimer3Base = reinterpret_cast<TimerReg *>(0x40000400);
 // [RM] 29 Basic Timers (TIM6/TIM7) (pg 968)
-inline TimerRegs *const TIMER6_BASE = reinterpret_cast<TimerRegs *>(0x40001000);
-inline TimerRegs *const TIMER7_BASE = reinterpret_cast<TimerRegs *>(0x40001400);
+inline TimerReg *const kTimer6Base = reinterpret_cast<TimerReg *>(0x40001000);
+inline TimerReg *const kTimer7Base = reinterpret_cast<TimerReg *>(0x40001400);
 // [RM] 28 General-purpose Timers (TIM15/TIM16) (pg 887)
-inline TimerRegs *const TIMER15_BASE =
-    reinterpret_cast<TimerRegs *>(0x40014000);
-inline TimerRegs *const TIMER16_BASE =
-    reinterpret_cast<TimerRegs *>(0x40014400);
+inline TimerReg *const kTimer15Base = reinterpret_cast<TimerReg *>(0x40014000);
+inline TimerReg *const kTimer16Base = reinterpret_cast<TimerReg *>(0x40014400);
 
 // [RM] 3.7 Flash Registers (pg 100)
-struct FlashReg_ {
+struct FlashStruct {
 
   // Access control register
   struct {
-    uint32_t latency : 3; // Number of ait states
-    uint32_t rsvd1 : 5;
-    uint32_t prefecth_ena : 1; // Enable pre-fetch
-    uint32_t icache_ena : 1;   // Instruction cache enable
-    uint32_t dcache_ena : 1;   // Data cache enable
-    uint32_t icache_rst : 1;   // Instruction cache reset
-    uint32_t dcache_rst : 1;   // Data cache reset
-    uint32_t run_pd : 1;       // Power-down during run or low power mode
-    uint32_t sleep_pd : 1;     // Power-down during sleep mode
-    uint32_t rsvd2 : 17;
+    uint32_t latency : 3; // Number of wait states
+    uint32_t reserved1 : 5;
+    uint32_t prefecth_enable : 1;
+    uint32_t instruction_cache_enable : 1;
+    uint32_t data_cache_enable : 1;
+    uint32_t instruction_cache_reset : 1; // Instruction cache reset
+    uint32_t data_cache_reset : 1;        // Data cache reset
+    uint32_t run_powerdown : 1;   // Power-down during run or low power mode
+    uint32_t sleep_powerdown : 1; // Power-down during sleep mode
+    uint32_t reserved2 : 17;
   } access;
 
-  uint32_t pdKey;  // 0x04 - Power-down Key Register (FLASH_PDKEYR)
-  uint32_t key;    // 0x08 - Key Register (FLASH_KEYR)
-  uint32_t optKey; // 0x0C - Option Key Register (FLASH_OPTKEYR)
-  uint32_t status; // 0x10 - Status Register (FLASH_SR)
+  uint32_t powerdown_key;
+  uint32_t key;
+  uint32_t option_key;
+  uint32_t status;
 
   // 0x14 - Control Register (FLASH_CR)
   struct {
-    uint32_t program : 1;    // Set to program flash
-    uint32_t page_erase : 1; // Pase erase
-    uint32_t mass_erase : 1; // Mass erase
-    uint32_t page : 8;       // Page number
-    uint32_t rsvd1 : 5;
-    uint32_t start : 1;     // Flash operation start
-    uint32_t opt_start : 1; // Options modification start
-    uint32_t fast_prog : 1; // Fast programming
-    uint32_t rsvd2 : 5;
-    uint32_t eop_ie : 1;     // End of operation interrupt enable
-    uint32_t err_ie : 1;     // Error interrupt enable
-    uint32_t rderr_ie : 1;   // read error interrupt enable
-    uint32_t obl_launch : 1; // Force option byte reloading
-    uint32_t rsvd3 : 2;
-    uint32_t opt_lock : 1; // Lock the options area
-    uint32_t lock : 1;     // Lock the flash
-  } ctrl;
+    uint32_t program : 1;
+    uint32_t page_erase : 1;
+    uint32_t mass_erase : 1;
+    uint32_t page : 8;
+    uint32_t reserved1 : 5;
+    uint32_t start_operation : 1;
+    uint32_t opt_start : 1;
+    uint32_t fast_programming : 1;
+    uint32_t reserved2 : 5;
+    uint32_t end_op_interrupt : 1;
+    uint32_t error_interrupt : 1;
+    uint32_t read_error_interrupt : 1;
+    uint32_t force_byte_reloading : 1;
+    uint32_t reserved3 : 2;
+    uint32_t options_lock : 1;
+    uint32_t flash_lock : 1;
+  } control;
 
-  uint32_t ecc; // 0x18 - EEC Register (FLASH_EECR)
-  uint32_t rsvd1;
-  uint32_t option;     // 0x20 - Option Register (FLASH_OPTR)
-  uint32_t pcropStart; // 0x24 - PCROP Start Address Register (FLASH_PCROP1SR)
-  uint32_t pcropEnd;   // 0x28 - PCROP End Address Register (FLASH_PCROP1ER)
-  uint32_t wrpA;       // 0x2C - WRP Area A Address Register (FLASH_WRP1AR)
-  uint32_t wrpB;       // 0x30 - WRP Area B Address Register (FLAS_WRP1BR)
+  uint32_t ecc;
+  uint32_t reserved1;
+  uint32_t option;
+  uint32_t pcrop_start_address;
+  uint32_t pcrop_end_address;
+  uint32_t wrp_area_a;
+  uint32_t wrp_area_b;
 };
-typedef volatile FlashReg_ FlashReg;
-inline FlashReg *const FLASH_BASE = reinterpret_cast<FlashReg *>(0x40022000);
+typedef volatile FlashStruct FlashReg;
+inline FlashReg *const kFlashBase = reinterpret_cast<FlashReg *>(0x40022000);
 
 // [RM] 11.4.4 DMA channels (pg 302)
-enum class DMA_Chan {
-  C1 = 0,
-  C2 = 1,
-  C3 = 2,
-  C4 = 3,
-  C5 = 4,
-  C6 = 5,
-  C7 = 6,
+enum class DmaChannel {
+  kChan1 = 0,
+  kChan2 = 1,
+  kChan3 = 2,
+  kChan4 = 3,
+  kChan5 = 4,
+  kChan6 = 5,
+  kChan7 = 6,
 };
 
-enum class DmaChannelDir { PERIPHERAL_TO_MEM = 0, MEM_TO_PERIPHERAL = 1 };
-enum class DmaTransferSize { BITS8 = 0, BITS16 = 1, BITS32 = 2 };
+enum class DmaChannelDir { kPeripheralToMemory = 0, kMemoryToPeripheral = 1 };
+enum class DmaTransferSize { kByte = 0, kHalfWord = 1, kWord = 2 };
 
-struct DMA_Regs_ {
+struct DmaStruct {
   union {
     struct {
       uint32_t gif1 : 1;  // global interrupt flag
@@ -566,10 +548,11 @@ struct DMA_Regs_ {
       uint32_t tcif7 : 1; // transfer complete (TC) flag
       uint32_t htif7 : 1; // half transfer (HT) flag
       uint32_t teif7 : 1; // transfer error (TE) flag
-      uint32_t rsvd : 4;
+      uint32_t reserved : 4;
     };
-    uint32_t r;
-  } intStat; // Interrupt Status Register (DMA_ISR) [RM] 11.6.1 (pg 308)
+    uint32_t full_reg;
+  } interrupt_status; // Interrupt Status Register (DMA_ISR) [RM] 11.6.1 (pg
+                      // 308)
 
   union {
     struct {
@@ -601,32 +584,32 @@ struct DMA_Regs_ {
       uint32_t tcif7 : 1; // transfer complete (TC) flag
       uint32_t htif7 : 1; // half transfer (HT) flag
       uint32_t teif7 : 1; // transfer error (TE) flag
-      uint32_t rsvd : 4;
+      uint32_t reserved : 4;
     };
-    uint32_t r;
-  } intClr; // Interrupt Flag Clear Register [RM] 11.6.2 (pg 311)
+    uint32_t full_reg;
+  } interrupt_clear; // Interrupt Flag Clear Register [RM] 11.6.2 (pg 311)
   struct ChannelRegs {
     struct {
-      uint32_t enable : 1;   // channel enable
-      uint32_t tcie : 1;     // transfer complete interrupt enable
-      uint32_t htie : 1;     // half transfer interrupt enable
-      uint32_t teie : 1;     // transfer error interrupt enable
-      uint32_t dir : 1;      // data xfer direction 0: per->mem, 1: mem->per
-      uint32_t circular : 1; // circular mode
-      uint32_t perInc : 1;   // peripheral increment mode
-      uint32_t memInc : 1;   // memory increment mode
-      uint32_t psize : 2;    // peripheral size 0b00 - 8bits, 0b10 - 32bits
-      uint32_t msize : 2;    // memory size 0b00 - 8bits, 0b10 - 32bits
-      uint32_t priority : 2; // priority level 0b00 - low, 0b11 - high
-      uint32_t mem2mem : 1;  // memory-to-memory mode
-      uint32_t rsvd : 17;
-    } config;       // channel x configuration register [RM] 11.6.3 (pg 312)
-    uint32_t count; // channel x number of data to transfer register
-    volatile void *pAddr; // channel x peripheral address register
-    volatile void *mAddr; // channel x memory address register
-    uint32_t rsvd;
+      uint32_t enable : 1;
+      uint32_t tx_complete_interrupt : 1;
+      uint32_t half_tx_interrupt : 1;
+      uint32_t tx_error_interrupt : 1;
+      uint32_t direction : 1;
+      uint32_t circular : 1;
+      uint32_t peripheral_increment : 1;
+      uint32_t memory_increment : 1;
+      uint32_t peripheral_size : 2;
+      uint32_t memory_size : 2;
+      uint32_t priority : 2;
+      uint32_t mem2mem : 1;
+      uint32_t reserved : 17;
+    } config;
+    uint32_t count;
+    volatile void *peripheral_address;
+    volatile void *memory_address;
+    uint32_t reserved;
   } channel[7];
-  uint32_t rsvd[5];
+  uint32_t reserved[5];
   union {
     struct {
       uint32_t c1s : 4;
@@ -636,159 +619,154 @@ struct DMA_Regs_ {
       uint32_t c5s : 4;
       uint32_t c6s : 4;
       uint32_t c7s : 4;
-      uint32_t rsvd : 4;
+      uint32_t reserved : 4;
     };
-    uint32_t r;
-  } chanSel; // Channel Selection Register [RM] 11.6.7 (pg 317)
+    uint32_t full_reg;
+  } channel_select; // Channel Selection Register [RM] 11.6.7 (pg 317)
 };
-typedef volatile DMA_Regs_ DMA_Regs;
-inline DMA_Regs *const DMA1_BASE = reinterpret_cast<DMA_Regs *>(0x40020000);
-inline DMA_Regs *const DMA2_BASE = reinterpret_cast<DMA_Regs *>(0x40020400);
+typedef volatile DmaStruct DmaReg;
+inline DmaReg *const kDma1Base = reinterpret_cast<DmaReg *>(0x40020000);
+inline DmaReg *const kDma2Base = reinterpret_cast<DmaReg *>(0x40020400);
 
 /* Select the source for a DMA channel:
   @param dma        Address of DMA registers
   @param chan       DMA channel to modify.  Channels are numbered from 0
   @param selection  Selects which peripheral request to map to the channel
 */
-inline void DMA_SelectChannel(DMA_Regs *dma, DMA_Chan chan, int selection) {
+inline void DmaSelectChannel(DmaReg *dma, DmaChannel chan, int selection) {
   selection &= 0x0F;
 
   int x = 4 * static_cast<int>(chan); // 4 bits per channel ([RM] 11.3.2)
 
-  uint32_t val = dma->chanSel.r;
+  uint32_t val = dma->channel_select.full_reg;
   val &= ~(0xF << x);
   val |= selection << x;
-  dma->chanSel.r = val;
+  dma->channel_select.full_reg = val;
 }
 
 enum class DmaInterrupt {
-  GLOBAL = 1,
-  XFER_COMPLETE = 2,
-  HALF_COMPLETE = 4,
-  XFER_ERR = 8
+  kGlobal = 1,
+  kTransferComplete = 2,
+  kHalfTransfer = 4,
+  kTransferError = 8
 };
 
 // Detect a DMA Interrupt
-inline bool DMA_IntStatus(DMA_Regs *dma, DMA_Chan chan,
-                          DmaInterrupt interrupt) {
+inline bool DmaIntStatus(DmaReg *dma, DmaChannel chan, DmaInterrupt interrupt) {
 
   uint32_t x = static_cast<uint32_t>(interrupt);
   x <<= 4 * static_cast<uint8_t>(chan); // 4 events per channel ([RM] 11.6.2)
-  return (x & dma->intStat.r) > 0;
+  return (x & dma->interrupt_status.full_reg) > 0;
 }
 
 // Clear a DMA Interrupt
-inline void DMA_ClearInt(DMA_Regs *dma, DMA_Chan chan, DmaInterrupt interrupt) {
+inline void DmaClearInt(DmaReg *dma, DmaChannel chan, DmaInterrupt interrupt) {
 
   uint32_t x = static_cast<uint32_t>(interrupt);
   x <<= 4 * static_cast<uint8_t>(chan); // 4 events per channel ([RM] 11.6.2)
-  dma->intClr.r = x;
+  dma->interrupt_clear.full_reg = x;
 }
 
 // [RM] 40.6 SPI Registers (pg 1330)
-struct SPI_Regs_ {
+struct SpiStruct {
   struct {
-    uint32_t cpha : 1;       // Clock phase
-    uint32_t cpol : 1;       // Clock polarity
-    uint32_t mstr : 1;       // Master mode
-    uint32_t br : 3;         // Bit rate
-    uint32_t spe : 1;        // SPI enable
-    uint32_t lsb_first : 1;  // Send LSB first
-    uint32_t ssi : 1;        // Internal slave select
-    uint32_t ssm : 1;        // Software slave management
-    uint32_t rx_only : 1;    // Receive mode only
-    uint32_t crcl : 1;       // CRC length
-    uint32_t crc_next : 1;   // CRC transmit next
-    uint32_t crc_ena : 1;    // CRC enable
-    uint32_t bidir_oe : 1;   // Bidirectional output enable
-    uint32_t bidir_mode : 1; // Bidirectional data mode enable
-    uint32_t rsvd : 16;
-  } ctrl1; // Control register 1 (SPIx_CR1) [RM] 40.6.1 (pg 1330)
+    uint32_t clock_phase : 1;
+    uint32_t clock_polarity : 1;
+    uint32_t master : 1;
+    uint32_t bitrate : 3;
+    uint32_t enable : 1;
+    uint32_t lsb_first : 1;
+    uint32_t internal_slave_select : 1;
+    uint32_t sw_slave_management : 1;
+    uint32_t rx_only : 1;
+    uint32_t crc_length : 1;
+    uint32_t crc_next : 1;
+    uint32_t crc_enable : 1;
+    uint32_t bidir_output : 1;
+    uint32_t bidir_mode : 1;
+    uint32_t reserved : 16;
+  } control_reg1; // Control register 1 (SPIx_CR1) [RM] 40.6.1 (pg 1330)
   struct {
-    uint32_t rx_dma_en : 1; // Receive buffer DMA enable
-    uint32_t tx_dma_en : 1; // Transmit buffer DMA enable
-    uint32_t ssoe : 1;      // SS output enable
-    uint32_t nssp : 1;      // NSS pulse management
-    uint32_t frf : 1;       // Frame format
-    uint32_t err_ie : 1;    // Error interrupt enable
-    uint32_t rxne_ie : 1;   // Receive buffer not empty int enable
-    uint32_t txe_ie : 1;    // Transmit buffer empty int enable
-    uint32_t ds : 4;        // Data size
-    uint32_t frxth : 1;     // FIFO reception threshold
-    uint32_t ldma_rx : 1;   // Last DMA xfer for receive
-    uint32_t ldma_tx : 1;   // Last DMA xfer for transmit
-    uint32_t rsvd : 17;
-  } ctrl2;          // Control register 2 (SPIx_CR2) [RM] 40.6.2
-  uint32_t status;  // Status register (SPIx_SR) [RM] 40.6.3
-  uint32_t data;    // Data register (SPIx_Dr) [RM] 40.6.4
-  uint32_t crcPoly; // CRC polynomial register (SPIx_CRCPR) [RM] 40.6.5
-  uint32_t rxCRC;   // Rx CRC register (SPIx_RXCRCR) [RM] 40.6.6
-  uint32_t txCRC;   // Tx CRC register (SPIx_TXCRCR) [RM] 40.6.7
+    uint32_t rx_dma : 1;
+    uint32_t tx_dma : 1;
+    uint32_t ss_output : 1;
+    uint32_t nss_pulse : 1;
+    uint32_t frame_format : 1;
+    uint32_t error_interrupt : 1;
+    uint32_t rx_not_empty_interrupt : 1;
+    uint32_t tx_empty_interrupt : 1;
+    uint32_t data_size : 4;
+    uint32_t fifo_rx_threshold : 1;
+    uint32_t last_dma_rx : 1;
+    uint32_t last_dma_tx : 1;
+    uint32_t reserved : 17;
+  } control2; // Control register 2 (SPIx_CR2) [RM] 40.6.2
+  uint32_t status;
+  uint32_t data;
+  uint32_t crc_polynomial;
+  uint32_t rx_crc;
+  uint32_t tx_crc;
 };
-typedef volatile SPI_Regs_ SPI_Regs;
-inline SPI_Regs *const SPI1_BASE = reinterpret_cast<SPI_Regs *>(0x40013000);
-inline SPI_Regs *const SPI2_BASE = reinterpret_cast<SPI_Regs *>(0x40003800);
-inline SPI_Regs *const SPI3_BASE = reinterpret_cast<SPI_Regs *>(0x40003C00);
+typedef volatile SpiStruct SpiReg;
+inline SpiReg *const kSpi1Base = reinterpret_cast<SpiReg *>(0x40013000);
+inline SpiReg *const kSpi2Base = reinterpret_cast<SpiReg *>(0x40003800);
+inline SpiReg *const kSpi3Base = reinterpret_cast<SpiReg *>(0x40003C00);
 
 // [RM] 37.7 I2C Registers
-struct I2C_Regs_ {
+struct I2CStruct {
   union {
     struct {
-      uint32_t peripheral_en : 1;   // Set to enable the I2C bus
-      uint32_t tx_interrupts : 1;   // Interrupt when TX empty while channel
-                                    // active
-      uint32_t rx_interrupts : 1;   // Interrupt when RX not empty
-      uint32_t addr_interrupts : 1; // Generate interrupts on address
-                                    // match (slave)
-      uint32_t nack_interrupts : 1; // Generate interrupts on NACK
-      uint32_t stop_interrupts : 1; // Generate interrupts on stop
-                                    // detection (slave)
-      uint32_t tx_complete_interrupts : 1; // Interrupt when transfer
-                                           // complete
-      uint32_t error_interrupts : 1;       // Interrupt on error
-      uint32_t dnf_cntrl : 4;              // Configure digital noise filtering
-      uint32_t anf_off : 1;                // Disable analog noise filtering
+      uint32_t enable : 1;
+      uint32_t tx_interrupts : 1;
+      uint32_t rx_interrupts : 1;
+      uint32_t addr_interrupts : 1;
+      uint32_t nack_interrupts : 1;
+      uint32_t stop_interrupts : 1;
+      uint32_t tx_complete_interrupts : 1;
+      uint32_t error_interrupts : 1;
+      uint32_t digital_noise_filter_conntrol : 4;
+      uint32_t analog_noise_filternig_off : 1;
       uint32_t reserved1 : 1;
-      uint32_t dma_tx : 1;        // Enable DMA for TX
-      uint32_t dma_rx : 1;        // Enable DMA for RX
-      uint32_t slave_byte_en : 1; // Enable slave byte control (slave)
-      uint32_t no_stretch : 1;    // Disable Clock stretching (slave)
-      uint32_t wup_en : 1;        // Wake up from Stop Mode
-      uint32_t gc_en : 1;         // General call (slave)
-      uint32_t smd_h_en : 1;      // Use SMBus default host address
-      uint32_t smb_d_en : 1;      // Use SMBus default device address
-      uint32_t alert_en : 1;      // SMBus Alert enable
-      uint32_t pec_en : 1;        // Use SMBus Packet error checking
+      uint32_t dma_tx : 1;
+      uint32_t dma_rx : 1;
+      uint32_t slave_byte : 1;
+      uint32_t no_clock_stretch : 1;
+      uint32_t wake_from_stop : 1;
+      uint32_t general_call : 1;
+      uint32_t smbus_default_host : 1;
+      uint32_t smbus_default_device : 1;
+      uint32_t smbus_alert : 1;
+      uint32_t smbus_packet_error_checking : 1;
       uint32_t reserved2 : 8;
     };
-    uint32_t r;
-  } ctrl1; // Control register 1 [RM] 37.7.1
+    uint32_t full_reg;
+  } control_reg1; // Control register 1 [RM] 37.7.1
   union {
     struct {
-      uint32_t slave_addr_lsb : 1; // lsb of 10 bits slave address
-                                   // (master)
-      uint32_t slave_addr_7b : 7;  // middle 7b bits of slave address
-                                   // (master)
-      uint32_t slave_addr_msb : 2; // msb of 10 bits slave address
-                                   // (master)
-      uint32_t transfer_dir : 1;   // 0 = write, 1 = read (master)
-      uint32_t address_10b : 1;    // Set to enable 10 bits address header
-                                   // (master)
-      uint32_t read_10b_head : 1;  // Clear to send complete read sequence
-                                   // (master)
-      uint32_t start : 1;          // Set to generate START condition
-      uint32_t stop : 1;           // Set to generate STOP after byte transfer
-                                   // (master)
-      uint32_t nack : 1;           // Generate NACK after byte reception (slave)
-      uint32_t n_bytes : 8;        // Set to the number of bytes to send
-      uint32_t reload : 1;         // Set to allow several consecutive transfers
-      uint32_t autoend : 1;        // Set to automatically send stop condition
-      uint32_t pecbyte : 1;        // Set to send SMBus packet error checking
-                                   // byte
+      uint32_t slave_addr_lsb : 1;     // lsb of 10 bits slave address
+                                       // (master)
+      uint32_t slave_addr_7b : 7;      // middle 7b bits of slave address
+                                       // (master)
+      uint32_t slave_addr_msb : 2;     // msb of 10 bits slave address
+                                       // (master)
+      uint32_t transfer_direction : 1; // 0 = write, 1 = read (master)
+      uint32_t address_10b : 1;        // Set to enable 10 bits address header
+                                       // (master)
+      uint32_t read_10b_header : 1;    // Clear to send complete read sequence
+                                       // (master)
+      uint32_t start : 1;              // Set to generate START condition
+      uint32_t stop : 1;    // Set to generate STOP after byte transfer
+                            // (master)
+      uint32_t nack : 1;    // Generate NACK after byte reception (slave)
+      uint32_t n_bytes : 8; // Set to the number of bytes to send
+      uint32_t reload : 1;  // Set to allow several consecutive transfers
+      uint32_t autoend : 1; // Set to automatically send stop condition
+      uint32_t packet_error_check_byte : 1; // Set to send SMBus packet error
+                                            // checking byte
       uint32_t reserved : 5;
     };
-    uint32_t r;
-  } ctrl2;          // Control register 2 [RM] 37.7.2
+    uint32_t full_reg;
+  } control2;       // Control register 2 [RM] 37.7.2
   uint32_t addr[2]; // Own address (1-2) register [RM] 37.7.{3,4} (slave)
   union {
     struct {
@@ -801,7 +779,7 @@ struct I2C_Regs_ {
       uint32_t reserved : 4;
       uint32_t prescaler : 4; // Prescaler
     };
-    uint32_t r;
+    uint32_t full_reg;
   } timing;         // Timing register [RM] 37.7.5
   uint32_t timeout; // Timout register [RM] 37.7.6
   union {
@@ -822,70 +800,71 @@ struct I2C_Regs_ {
       uint32_t alert : 1;
       uint32_t reserved1 : 1;
       uint32_t busy : 1;
-      uint32_t transfer_dir : 1;
+      uint32_t transfer_direction : 1;
       uint32_t address_code : 7;
       uint32_t reserved : 8;
     };
-    uint32_t r;
-  } status;        // Interrupt & status register [RM] 37.7.7
-  uint32_t intClr; // Interrupt clear register [RM] 37.7.8
-  uint32_t pec;    // PEC register [RM] 37.7.9
-  uint32_t rxData; // Receive data register [RM] 37.7.10
-  uint32_t txData; // Transmit data register [RM] 37.7.11
+    uint32_t full_reg;
+  } status;                    // Interrupt & status register [RM] 37.7.7
+  uint32_t interrupt_clear;    // Interrupt clear register [RM] 37.7.8
+  uint32_t packet_error_check; // PEC register [RM] 37.7.9
+  uint32_t rx_data;            // Receive data register [RM] 37.7.10
+  uint32_t tx_data;            // Transmit data register [RM] 37.7.11
 };
-typedef volatile I2C_Regs_ I2C_Regs;
-inline I2C_Regs *const I2C1_BASE = reinterpret_cast<I2C_Regs *>(0x40005400);
-inline I2C_Regs *const I2C2_BASE = reinterpret_cast<I2C_Regs *>(0x40005800);
-inline I2C_Regs *const I2C3_BASE = reinterpret_cast<I2C_Regs *>(0x40005c00);
-inline I2C_Regs *const I2C4_BASE = reinterpret_cast<I2C_Regs *>(0x40008400);
+typedef volatile I2CStruct I2CReg;
+inline I2CReg *const kI2C1Base = reinterpret_cast<I2CReg *>(0x40005400);
+inline I2CReg *const kI2C2Base = reinterpret_cast<I2CReg *>(0x40005800);
+inline I2CReg *const kI2C3Base = reinterpret_cast<I2CReg *>(0x40005c00);
+inline I2CReg *const kI2C4Base = reinterpret_cast<I2CReg *>(0x40008400);
 
 // Watchdog timer
 // [RM] 32.4 Watchdog Registers (pg 1016)
-struct Watchdog_Regs_ {
-  uint32_t key;      // Key register [RM] 32.4.1
-  uint32_t prescale; // Prescale register [RM] 32.4.2
-  uint32_t reload;   // Reload register [RM] 32.4.3
-  uint32_t status;   // Status register [RM] 32.4.4
-  uint32_t window;   // Window register [RM] 32.4.5
+struct WatchdogStruct {
+  uint32_t key;       // Key register [RM] 32.4.1
+  uint32_t prescaler; // Prescale register [RM] 32.4.2
+  uint32_t reload;    // Reload register [RM] 32.4.3
+  uint32_t status;    // Status register [RM] 32.4.4
+  uint32_t window;    // Window register [RM] 32.4.5
 };
-typedef volatile Watchdog_Regs_ Watchdog_Regs;
-inline Watchdog_Regs *const WATCHDOG_BASE =
-    reinterpret_cast<Watchdog_Regs *>(0x40003000);
+typedef volatile WatchdogStruct WatchdogReg;
+inline WatchdogReg *const kWatchdogBase =
+    reinterpret_cast<WatchdogReg *>(0x40003000);
 
 // CRC calculation unit
 // [RM] 14.4 CRC Registers (pg 341)
-struct CRC_Regs_ {
+struct CrcStruct {
   uint32_t data;    // Data register [RM] 14.4.1
   uint32_t scratch; // Independent data register [RM] 14.4.2
-  uint32_t ctrl;    // Control register [RM] 14.4.3
-  uint32_t rsvd;
-  uint32_t init; // Initial CRC value [RM] 14.4.4
-  uint32_t poly; // CRC polynomial [RM] 14.4.5
+  uint32_t control; // Control register [RM] 14.4.3
+  uint32_t reserved;
+  uint32_t init;       // Initial CRC value [RM] 14.4.4
+  uint32_t polynomial; // CRC polynomial [RM] 14.4.5
 };
-typedef volatile CRC_Regs_ CRC_Regs;
-inline CRC_Regs *const CRC_BASE = reinterpret_cast<CRC_Regs *>(0x40023000);
+typedef volatile CrcStruct CrcReg;
+inline CrcReg *const kCrcBase = reinterpret_cast<CrcReg *>(0x40023000);
 
 // General Purpose I/O
 // [RM] 8.4 GPIO Registers (pg 267)
-struct GPIO_Regs_ {
-  uint32_t mode;     // Mode register [RM] 8.4.1
-  uint32_t outType;  // Output type register [RM] 8.4.2
-  uint32_t outSpeed; // Output speed register [RM] 8.4.3
-  uint32_t pullUpDn; // Pull-up/pull-down register [RM] 8.4.4
-  uint32_t inDat;    // Input data register [RM] 8.4.5
-  uint32_t outDat;   // Output data register [RM] 8.4.6
-  uint16_t set;      // Bit set register [RM] 8.4.7
-  uint16_t clr;      // Bit reset register [RM] 8.4.7
-  uint32_t lock;     // Configuration lock register [RM] 8.4.8
-  uint32_t alt[2];   // Alternate function low/high register [RM] 8.4.{9,10}
-  uint32_t reset;    // Reset register [RM] 8.4.11
+struct GpioStruct {
+  uint32_t mode;                  // Mode register [RM] 8.4.1
+  uint32_t output_type;           // Output type register [RM] 8.4.2
+  uint32_t output_speed;          // Output speed register [RM] 8.4.3
+  uint32_t pullup_pulldown;       // Pull-up/pull-down register [RM] 8.4.4
+  uint32_t input_data;            // Input data register [RM] 8.4.5
+  uint32_t output_data;           // Output data register [RM] 8.4.6
+  uint16_t set;                   // Bit set register [RM] 8.4.7
+  uint16_t clear;                 // Bit reset register [RM] 8.4.7
+  uint32_t flash_lock;            // Configuration lock register [RM] 8.4.8
+  uint32_t alternate_function[2]; // Alternate function low/high register
+                                  // [RM] 8.4.{9,10}
+  uint32_t reset;                 // Reset register [RM] 8.4.11
 };
-typedef volatile GPIO_Regs_ GPIO_Regs;
-inline GPIO_Regs *const GPIO_A_BASE = reinterpret_cast<GPIO_Regs *>(0x48000000);
-inline GPIO_Regs *const GPIO_B_BASE = reinterpret_cast<GPIO_Regs *>(0x48000400);
-inline GPIO_Regs *const GPIO_C_BASE = reinterpret_cast<GPIO_Regs *>(0x48000800);
-inline GPIO_Regs *const GPIO_D_BASE = reinterpret_cast<GPIO_Regs *>(0x48000C00);
-inline GPIO_Regs *const GPIO_E_BASE = reinterpret_cast<GPIO_Regs *>(0x48001000);
-inline GPIO_Regs *const GPIO_H_BASE = reinterpret_cast<GPIO_Regs *>(0x48001C00);
+typedef volatile GpioStruct GpioReg;
+inline GpioReg *const kGpioABase = reinterpret_cast<GpioReg *>(0x48000000);
+inline GpioReg *const kGpioBBase = reinterpret_cast<GpioReg *>(0x48000400);
+inline GpioReg *const kGpioCBase = reinterpret_cast<GpioReg *>(0x48000800);
+inline GpioReg *const kGpioDBase = reinterpret_cast<GpioReg *>(0x48000C00);
+inline GpioReg *const kGpioEBase = reinterpret_cast<GpioReg *>(0x48001000);
+inline GpioReg *const kGpioHBase = reinterpret_cast<GpioReg *>(0x48001C00);
 
 #endif

--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -31,43 +31,43 @@ I2C::STM32Channel i2c1;
 // Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 void HalApi::InitI2C() {
   // Enable I2C1 and DMA2 peripheral clocks (we use DMA2 to send/receive data)
-  EnableClock(I2C1_BASE);
-  EnableClock(DMA2_BASE);
+  EnableClock(kI2C1Base);
+  EnableClock(kDma2Base);
 
   // The following pins are used as i2c1 bus on the rev-1 PCB (see [PCB]):
   // - PB8 (I2C1 - DATA)
   // - PB9 (I2C1 - CLOCK)
   // Set Pin Function to I²C (see [DS] Table 17)
-  GPIO_PinAltFunc(GPIO_B_BASE, 8, 4);
-  GPIO_PinAltFunc(GPIO_B_BASE, 9, 4);
-  // Set output speed to HIGH
-  GPIO_OutSpeed(GPIO_B_BASE, 8, GPIO_OutSpeed::HIGH);
-  GPIO_OutSpeed(GPIO_B_BASE, 9, GPIO_OutSpeed::HIGH);
+  GpioPinAltFunc(kGpioBBase, 8, 4);
+  GpioPinAltFunc(kGpioBBase, 9, 4);
+  // Set output speed to kFast
+  GpioOutSpeed(kGpioBBase, 8, GPIOOutSpeed::kFast);
+  GpioOutSpeed(kGpioBBase, 9, GPIOOutSpeed::kFast);
   // Set open drain mode
-  GPIO_OutType(GPIO_B_BASE, 8, GPIO_OutType::OPENDRAIN);
-  GPIO_OutType(GPIO_B_BASE, 9, GPIO_OutType::OPENDRAIN);
+  GpioOutType(kGpioBBase, 8, GPIOOutType::kOpenDrain);
+  GpioOutType(kGpioBBase, 9, GPIOOutType::kOpenDrain);
   // Set Pull Up resistors
-  GPIO_PullUp(GPIO_B_BASE, 8);
-  GPIO_PullUp(GPIO_B_BASE, 9);
+  GpioPullUp(kGpioBBase, 8);
+  GpioPullUp(kGpioBBase, 9);
 
-  EnableInterrupt(InterruptVector::I2C1_EV, IntPriority::LOW);
-  EnableInterrupt(InterruptVector::I2C1_ERR, IntPriority::LOW);
-  EnableInterrupt(InterruptVector::DMA2_CH6, IntPriority::LOW);
-  EnableInterrupt(InterruptVector::DMA2_CH7, IntPriority::LOW);
+  EnableInterrupt(InterruptVector::kI2c1Event, IntPriority::kLow);
+  EnableInterrupt(InterruptVector::kI2c1Error, IntPriority::kLow);
+  EnableInterrupt(InterruptVector::kDma2Channel6, IntPriority::kLow);
+  EnableInterrupt(InterruptVector::kDma2Channel7, IntPriority::kLow);
 
   // init i2c1
-  i2c1.Init(I2C1_BASE, DMA2_BASE, I2C::Speed::kFast);
+  i2c1.Init(kI2C1Base, kDma2Base, I2C::Speed::kFast);
 }
 
 // Those interrupt service routines are specific to our configuration, unlike
 // the I2C::Channel::*ISR() which are generic ISR associated with an I²C channel
-void I2C1_EV_ISR() { i2c1.I2CEventHandler(); };
+void I2c1EventISR() { i2c1.I2CEventHandler(); };
 
-void I2C1_ER_ISR() { i2c1.I2CErrorHandler(); };
+void I2c1ErrorISR() { i2c1.I2CErrorHandler(); };
 
-void DMA2_CH6_ISR() { i2c1.DMAIntHandler(DMA_Chan::C6); };
+void DMA2Channel6ISR() { i2c1.DMAIntHandler(DmaChannel::kChan6); };
 
-void DMA2_CH7_ISR() { i2c1.DMAIntHandler(DMA_Chan::C7); };
+void DMA2Channel7ISR() { i2c1.DMAIntHandler(DmaChannel::kChan7); };
 #else
 I2C::Channel i2c1;
 #endif // BARE_STM32
@@ -267,14 +267,14 @@ void Channel::I2CErrorHandler() {
 }
 
 #if defined(BARE_STM32)
-void STM32Channel::Init(I2C_Regs *i2c, DMA_Regs *dma, Speed speed) {
+void STM32Channel::Init(I2CReg *i2c, DmaReg *dma, Speed speed) {
   i2c_ = i2c;
 
   // Disable I²C peripheral
-  i2c_->ctrl1.peripheral_en = 0;
+  i2c_->control_reg1.enable = 0;
 
   // Set I²C speed using timing values from [RM] table 182
-  i2c_->timing.r = static_cast<uint32_t>(speed);
+  i2c_->timing.full_reg = static_cast<uint32_t>(speed);
 
   // Setup DMA channels
   if (dma != nullptr) {
@@ -282,27 +282,28 @@ void STM32Channel::Init(I2C_Regs *i2c, DMA_Regs *dma, Speed speed) {
   }
 
   // enable I²C peripheral
-  i2c_->ctrl1.peripheral_en = 1;
+  i2c_->control_reg1.enable = 1;
 
   // configure I²C interrupts
-  i2c_->ctrl1.nack_interrupts = 1;
-  i2c_->ctrl1.error_interrupts = 1;
+  i2c_->control_reg1.nack_interrupts = 1;
+  i2c_->control_reg1.error_interrupts = 1;
   // in DMA mode, we do not treat the transfer-specific ones
   if (!dma_enable_) {
-    i2c_->ctrl1.rx_interrupts = 1;
-    i2c_->ctrl1.tx_interrupts = 1;
-    i2c_->ctrl1.tx_complete_interrupts = 1;
+    i2c_->control_reg1.rx_interrupts = 1;
+    i2c_->control_reg1.tx_interrupts = 1;
+    i2c_->control_reg1.tx_complete_interrupts = 1;
   } else {
-    i2c_->ctrl1.rx_interrupts = 0;
-    i2c_->ctrl1.tx_interrupts = 0;
-    i2c_->ctrl1.tx_complete_interrupts = 0;
+    i2c_->control_reg1.rx_interrupts = 0;
+    i2c_->control_reg1.tx_interrupts = 0;
+    i2c_->control_reg1.tx_complete_interrupts = 0;
   }
 }
 
 void STM32Channel::SetupI2CTransfer() {
   // set transfer-specific registers per [RM] p1149 to 1158
-  i2c_->ctrl2.slave_addr_7b = last_request_.slave_address & 0x7f;
-  i2c_->ctrl2.transfer_dir = static_cast<bool>(last_request_.direction);
+  i2c_->control2.slave_addr_7b = last_request_.slave_address & 0x7f;
+  i2c_->control2.transfer_direction =
+      static_cast<bool>(last_request_.direction);
 
   if (dma_enable_) {
     SetupDMATransfer();
@@ -310,16 +311,16 @@ void STM32Channel::SetupI2CTransfer() {
 
   WriteTransferSize();
 
-  i2c_->ctrl2.start = 1;
+  i2c_->control2.start = 1;
 }
 
 // Write the remaining size to the appropriate register with reload logic
 void STM32Channel::WriteTransferSize() {
   if (remaining_size_ <= 255) {
-    i2c_->ctrl2.n_bytes = static_cast<uint8_t>(remaining_size_);
-    i2c_->ctrl2.reload = 0;
+    i2c_->control2.n_bytes = static_cast<uint8_t>(remaining_size_);
+    i2c_->control2.reload = 0;
   } else {
-    i2c_->ctrl2.n_bytes = 255;
+    i2c_->control2.n_bytes = 255;
     // Transfer reload is not currently supported by our HAL in DMA mode,
     // we will treat a reload as a new transfer. In effect this means we
     // will have to reissue the I²C header and start condition.
@@ -328,72 +329,73 @@ void STM32Channel::WriteTransferSize() {
     // by the I²C slave, as it will be split (this is referred to as a
     // Restart condition rather than Reload)
     if (!dma_enable_) {
-      i2c_->ctrl2.reload = 1;
+      i2c_->control2.reload = 1;
     } else {
-      i2c_->ctrl2.reload = 0;
+      i2c_->control2.reload = 0;
     }
   }
 }
 
 // DMA functions are only meaningful in BARE_STM32
-void STM32Channel::SetupDMAChannels(DMA_Regs *dma) {
+void STM32Channel::SetupDMAChannels(DmaReg *dma) {
   // DMA mapping for I²C (see [RM] p299)
   static struct {
-    volatile void *dma;
-    volatile void *i2c;
-    DMA_Chan tx_channel;
-    DMA_Chan rx_channel;
-    uint8_t request;
-  } DMAmap[] = {
-      {DMA1_BASE, I2C1_BASE, DMA_Chan::C6, DMA_Chan::C7, 3},
-      {DMA1_BASE, I2C2_BASE, DMA_Chan::C4, DMA_Chan::C5, 3},
-      {DMA1_BASE, I2C3_BASE, DMA_Chan::C2, DMA_Chan::C3, 3},
-      {DMA2_BASE, I2C1_BASE, DMA_Chan::C7, DMA_Chan::C6, 5},
-      {DMA2_BASE, I2C4_BASE, DMA_Chan::C2, DMA_Chan::C1, 0},
+    volatile void *dma_base;
+    volatile void *i2c_base;
+    DmaChannel tx_channel_id;
+    DmaChannel rx_channel_id;
+    uint8_t request_number;
+  } kDmaMap[] = {
+      {kDma1Base, kI2C1Base, DmaChannel::kChan6, DmaChannel::kChan7, 3},
+      {kDma1Base, kI2C2Base, DmaChannel::kChan4, DmaChannel::kChan5, 3},
+      {kDma1Base, kI2C3Base, DmaChannel::kChan2, DmaChannel::kChan3, 3},
+      {kDma2Base, kI2C1Base, DmaChannel::kChan7, DmaChannel::kChan6, 5},
+      {kDma2Base, kI2C4Base, DmaChannel::kChan2, DmaChannel::kChan1, 0},
   };
-  for (auto &map : DMAmap) {
-    if (dma == map.dma && i2c_ == map.i2c) {
 
+  for (auto &map : kDmaMap) {
+    if (dma == map.dma_base && i2c_ == map.i2c_base) {
       dma_ = dma;
-      tx_channel_ = &dma_->channel[static_cast<uint8_t>(map.tx_channel)];
-      rx_channel_ = &dma_->channel[static_cast<uint8_t>(map.rx_channel)];
+      tx_channel_ = &dma_->channel[static_cast<uint8_t>(map.tx_channel_id)];
+      rx_channel_ = &dma_->channel[static_cast<uint8_t>(map.rx_channel_id)];
 
       // Tell the STM32 that those two DMA channels are used for I2C
-      DMA_SelectChannel(dma, map.rx_channel, map.request);
-      DMA_SelectChannel(dma, map.tx_channel, map.request);
+      DmaSelectChannel(dma, map.rx_channel_id, map.request_number);
+      DmaSelectChannel(dma, map.tx_channel_id, map.request_number);
 
       // configure both DMA channels to handle I²C transfers
       ConfigureDMAChannel(rx_channel_, ExchangeDirection::kRead);
       ConfigureDMAChannel(tx_channel_, ExchangeDirection::kWrite);
 
       dma_enable_ = true;
-      i2c_->ctrl1.dma_rx = 1;
-      i2c_->ctrl1.dma_tx = 1;
+      i2c_->control_reg1.dma_rx = 1;
+      i2c_->control_reg1.dma_tx = 1;
       break;
     }
   }
 }
 
 void I2C::STM32Channel::ConfigureDMAChannel(
-    volatile DMA_Regs::ChannelRegs *channel, ExchangeDirection direction) {
-  channel->config.priority = 0b01; // medium priority
-  channel->config.teie = 1;        // interrupt on error
-  channel->config.htie = 0;        // no half-transfer interrupt
-  channel->config.tcie = 1;        // interrupt on DMA complete
-  channel->config.mem2mem = 0;     // memory-to-memory mode disabled
-  channel->config.msize = static_cast<uint8_t>(DmaTransferSize::BITS8);
-  channel->config.psize = static_cast<uint8_t>(DmaTransferSize::BITS8);
-  channel->config.memInc = 1; // increment dest address
-  channel->config.perInc = 0; // don't increment source address
+    volatile DmaReg::ChannelRegs *channel, ExchangeDirection direction) {
+  channel->config.priority = 0b01;           // medium priority
+  channel->config.tx_error_interrupt = 1;    // interrupt on error
+  channel->config.half_tx_interrupt = 0;     // no half-transfer interrupt
+  channel->config.tx_complete_interrupt = 1; // interrupt on DMA complete
+  channel->config.mem2mem = 0;               // memory-to-memory mode disabled
+  channel->config.memory_size = static_cast<uint8_t>(DmaTransferSize::kByte);
+  channel->config.peripheral_size =
+      static_cast<uint8_t>(DmaTransferSize::kByte);
+  channel->config.memory_increment = 1;     // increment dest address
+  channel->config.peripheral_increment = 0; // don't increment source address
   channel->config.circular = 0;
   if (direction == ExchangeDirection::kRead) {
-    channel->config.dir =
-        static_cast<uint8_t>(DmaChannelDir::PERIPHERAL_TO_MEM);
-    channel->pAddr = &(i2c_->rxData);
+    channel->config.direction =
+        static_cast<uint8_t>(DmaChannelDir::kPeripheralToMemory);
+    channel->peripheral_address = &(i2c_->rx_data);
   } else {
-    channel->config.dir =
-        static_cast<uint8_t>(DmaChannelDir::MEM_TO_PERIPHERAL);
-    channel->pAddr = &(i2c_->txData);
+    channel->config.direction =
+        static_cast<uint8_t>(DmaChannelDir::kMemoryToPeripheral);
+    channel->peripheral_address = &(i2c_->tx_data);
   }
 }
 
@@ -406,14 +408,14 @@ void STM32Channel::SetupDMATransfer() {
   rx_channel_->config.enable = 0;
   tx_channel_->config.enable = 0;
 
-  volatile DMA_Regs::ChannelRegs *channel{nullptr};
+  volatile DmaReg::ChannelRegs *channel{nullptr};
   if (last_request_.direction == ExchangeDirection::kRead) {
     channel = rx_channel_;
   } else {
     channel = tx_channel_;
   }
 
-  channel->mAddr = next_data_;
+  channel->memory_address = next_data_;
 
   if (remaining_size_ <= 255) {
     channel->count = remaining_size_;
@@ -426,16 +428,16 @@ void STM32Channel::SetupDMATransfer() {
   // has been written to the register) may arrive before the last byte is
   // actually written on the line. Tests with both DMA and I2C interrupts
   // enabled to send Stop at the end of the I2C transfer were inconclusive.
-  i2c_->ctrl2.autoend = 1;
+  i2c_->control2.autoend = 1;
 
   channel->config.enable = 1;
 }
 
-void STM32Channel::DMAIntHandler(DMA_Chan chan) {
+void STM32Channel::DMAIntHandler(DmaChannel chan) {
   if (!dma_enable_ || !transfer_in_progress_)
     return;
   dma_->channel[static_cast<uint8_t>(chan)].config.enable = 0;
-  if (DMA_IntStatus(dma_, chan, DmaInterrupt::XFER_COMPLETE)) {
+  if (DmaIntStatus(dma_, chan, DmaInterrupt::kTransferComplete)) {
     if (remaining_size_ > 255) {
       // decrement remaining size by 255 (the size of the DMA transfer)
       remaining_size_ = static_cast<uint16_t>(remaining_size_ - 255);
@@ -444,7 +446,7 @@ void STM32Channel::DMAIntHandler(DMA_Chan chan) {
       remaining_size_ = 0;
       EndTransfer();
     }
-  } else if (DMA_IntStatus(dma_, chan, DmaInterrupt::XFER_ERR)) {
+  } else if (DmaIntStatus(dma_, chan, DmaInterrupt::kTransferError)) {
     // we are dealing with an error --> reset transfer (up to kMaxRetries
     // times)
     if (--error_retry_ > 0) {
@@ -456,7 +458,7 @@ void STM32Channel::DMAIntHandler(DMA_Chan chan) {
     }
   }
   // clear all interrupts and (re-)start the current or next transfer
-  DMA_ClearInt(dma_, chan, DmaInterrupt::GLOBAL);
+  DmaClearInt(dma_, chan, DmaInterrupt::kGlobal);
   StartTransfer();
 }
 #endif // BARE_STM32

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -29,15 +29,15 @@ namespace I2C {
 
 // Speed values correspond to the timing register value from [RM] table 182
 enum class Speed {
-  kSlow = 0x3042C3C7,     // 10 kb/s
-  kStandard = 0x30420F13, // 100 kb/s
-  kFast = 0x10320309,     // 400 kb/s
-  kFastPlus = 0x00200204, // 1 Mb/s
+  Slow = 0x3042C3C7,     // 10 kb/s
+  Standard = 0x30420F13, // 100 kb/s
+  Fast = 0x10320309,     // 400 kb/s
+  FastPlus = 0x00200204, // 1 Mb/s
 };
 
 enum class ExchangeDirection {
-  kWrite = 0,
-  kRead = 1,
+  Write = 0,
+  Read = 1,
 };
 
 // Structure that represents an I²C request. It is up to the caller to
@@ -48,7 +48,7 @@ struct Request {
   uint8_t slave_address{0}; // for now we only support 7 bits addresses
                             // and NOT 10 bits addresses (I²C bus is one
                             // or the other)
-  ExchangeDirection direction{ExchangeDirection::kRead};
+  ExchangeDirection direction{ExchangeDirection::Read};
   uint16_t size{1};         // size (in bytes) of the data to be sent or
                             // received - limited to 16 bits because of DMA
                             // limitation

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -97,18 +97,18 @@ public:
 protected:
   // We queue of a few requests. The number of requests is arbitrary but
   // should be enough for all intents and purposes.
-  static constexpr uint8_t kQueueLength{80};
+  static constexpr uint8_t QueueLength{80};
 
   // We copy the write data into a buffer to make sure nothing can be lost
   // due to the scope of the caller's variable. This is the buffer size.
-  static constexpr uint32_t kWriteBufferSize{4096};
+  static constexpr uint32_t WriteBufferSize{4096};
 
   // Max retry-after-error allowed for a single request.
-  static constexpr int8_t kMaxRetries{5};
+  static constexpr int8_t MaxRetries{5};
 
-  // retry countdown - set to kMaxRetries when starting a request
+  // retry countdown - set to MaxRetries when starting a request
   // If it hits zero, we abort the request.
-  int8_t error_retry_{kMaxRetries};
+  int8_t error_retry_{MaxRetries};
 
   bool dma_enable_{false};
 
@@ -155,8 +155,8 @@ protected:
   // buffer of indexes to know the queue state and let the tested template
   // worry about buffer management but we also use our own Request table
   // (to which the circular buffer elements lead)
-  CircularBuffer<uint8_t, kQueueLength> buffer_;
-  Request queue_[kQueueLength];
+  CircularBuffer<uint8_t, QueueLength> buffer_;
+  Request queue_[QueueLength];
   uint8_t ind_queue_{0};
 
   // Write buffer: the caller may send a write request with the address of
@@ -171,10 +171,10 @@ protected:
   // which
   //    means we lose the ability to retry a request after an I²C (or DMA)
   //    error.
-  uint8_t write_buffer_[kWriteBufferSize];
+  uint8_t write_buffer_[WriteBufferSize];
   uint32_t write_buffer_index_{0};
   uint32_t write_buffer_start_{0};
-  uint32_t wrapping_index_{kWriteBufferSize};
+  uint32_t wrapping_index_{WriteBufferSize};
   bool CopyDataToWriteBuffer(const void *data, uint16_t size);
 };
 
@@ -236,10 +236,10 @@ public:
 private:
   // in test mode, fake sending and receiving data through circular
   // buffers.
-  CircularBuffer<uint8_t, kWriteBufferSize> sent_buffer_;
+  CircularBuffer<uint8_t, WriteBufferSize> sent_buffer_;
   // note it is up to the tester to put data in the rx_buffer before
   // calling I2CEventHandler during a read request
-  CircularBuffer<uint8_t, kWriteBufferSize> rx_buffer_;
+  CircularBuffer<uint8_t, WriteBufferSize> rx_buffer_;
   // fake a NACK condition on next handler call
   bool nack_{false};
 

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -50,19 +50,19 @@ void HalApi::InitPSOL() {
   // I'm using a 20kHz PWM frequency to drive the solenoid
   // This is somewhat arbitrary, but is high enough to ensure
   // that there won't be any audible noise from the switching
-  static constexpr int kPwmFreq = 5000;
+  static constexpr int PwmFreq = 5000;
 
-  EnableClock(kTimer1Base);
+  EnableClock(Timer1Base);
 
   // Connect PA11 to timer 1
   // [DS] table 17 shows which functions can be connected to each pin.
   // For PA11 we select function 1 to connect it to timer 1.
-  GpioPinAltFunc(kGpioABase, 11, 1);
+  GpioPinAltFunc(GpioABase, 11, 1);
 
-  TimerReg *tmr = kTimer1Base;
+  TimerReg *tmr = Timer1Base;
 
   // Set the frequency
-  tmr->auto_reload = (CPU_FREQ / kPwmFreq) - 1;
+  tmr->auto_reload = (CPU_FREQ / PwmFreq) - 1;
 
   // Configure channel 4 in PWM output mode 1
   // with preload enabled.  The preload means that
@@ -94,7 +94,7 @@ void HalApi::InitPSOL() {
 // Set the PSOL output level to a value from 0 (fully closed)
 // to 1 (fully open)
 void HalApi::PSolValue(float val) {
-  TimerReg *tmr = kTimer1Base;
+  TimerReg *tmr = Timer1Base;
 
   val = std::clamp(val, 0.0f, 1.0f);
 

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -166,7 +166,7 @@ class StepMotor {
 
   // This constant gives the maximum number of motors we
   // can support with this driver.
-  static constexpr int kMaxMotors{4};
+  static constexpr int MaxMotors{4};
 
   // Number of motor driver chips present in the system.
   // This is automatically detected at startup.
@@ -297,8 +297,8 @@ public:
   StepMtrErr GetParam(StepMtrParam param, uint32_t *value);
 
 private:
-  static StepMotor motor_[kMaxMotors];
-  static uint8_t dma_buff_[kMaxMotors];
+  static StepMotor motor_[MaxMotors];
+  static uint8_t dma_buff_[MaxMotors];
   static uint8_t param_len_[32];
   static StepCommState coms_state_;
 

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -44,8 +44,8 @@ limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef STEPPER_H_
-#define STEPPER_H_
+#ifndef STEPPER_H
+#define STEPPER_H
 
 #include <stdint.h>
 
@@ -53,78 +53,80 @@ limitations under the License.
 // Not included here are set/get parameter which include
 // the parameter ID value as part of the code.
 enum class StepMtrCmd : uint8_t {
-  NOP = 0,             // Used when there's no other command to send
-  RUN_NEG = 0x50,      // Run negative at constant speed.
-  RUN_POS = 0x51,      // Run positive at constant speed.
-  STEP_CLK_NEG = 0x58, // Switch to step clock mode moving in negative direction
-  STEP_CLK_POS = 0x59, // Switch to step clock mode moving in positive direction
-  MOVE_NEG = 0x40,     // Move - steps, steps is given as a parameter
-  MOVE_POS = 0x41,     // Move + steps, steps is given as a parameter
-  GOTO = 0x60,         // Go to an absolute position using shortest path
-  GOTO_NEG = 0x68,     // Go to an absolute position in negative direction
-  GOTO_POS = 0x69,     // Go to an absolute position in positive direction
-  HOME = 0x70,         // Same as GOTO 0
-  RESET_POS = 0xD8,    // Set absolute position register to 0
-  RESET_DEVICE = 0xC0, // Reset the stepper chip
-  SOFT_STOP = 0xB0,    // Perform a soft stop
-  HARD_STOP = 0xB8,    // Perform a hard stop
-  SOFT_DISABLE = 0xA0, // Soft stop, then disable
-  HARD_DISABLE = 0xA8, // Hard stop, then disable
-  GET_STATUS = 0xD0,   // Read the 16-bit status word
+  kNop = 0,            // Used when there's no other command to send
+  kRunNegative = 0x50, // Run negative at constant speed.
+  kRunPositive = 0x51, // Run positive at constant speed.
+  kStepClockNegative =
+      0x58, // Switch to step clock mode moving in negative direction
+  kStepClockPositive =
+      0x59, // Switch to step clock mode moving in positive direction
+  kMoveNegative = 0x40,  // Move - steps, steps is given as a parameter
+  kMovePositive = 0x41,  // Move + steps, steps is given as a parameter
+  kGoTo = 0x60,          // Go to an absolute position using shortest path
+  kGoToNegative = 0x68,  // Go to an absolute position in negative direction
+  kGoToPositive = 0x69,  // Go to an absolute position in positive direction
+  kHome = 0x70,          // Same as kGoTo 0
+  kResetPosition = 0xD8, // Set absolute position register to 0
+  kResetDevice = 0xC0,   // Reset the stepper chip
+  kSoftStop = 0xB0,      // Perform a soft stop
+  kHardStop = 0xB8,      // Perform a hard stop
+  kSoftDisable = 0xA0,   // Soft stop, then disable
+  kHardDisable = 0xA8,   // Hard stop, then disable
+  kGetStatus = 0xD0,     // Read the 16-bit status word
 };
 
 enum class StepMtrParam : uint8_t {
-  ABS_POS = 0x01,           // Absolute position
-  ELE_POS = 0x02,           // Electrical position
-  MARK_POS = 0x03,          // Mark position
-  SPEED = 0x04,             // Current speed
-  ACCEL = 0x05,             // Acceleration
-  DECEL = 0x06,             // Deceleration
-  MAX_SPEED = 0x07,         // Maximum allowed speed
-  MIN_SPEED = 0x08,         // Minimum allowed speed
-  KVAL_HOLD = 0x09,         //
-  KVAL_RUN = 0x0A,          //
-  KVAL_ACCEL = 0x0B,        //
-  KVAL_DECEL = 0x0C,        //
-  INT_SPEED = 0x0D,         //
-  START_SLOPE = 0x0E,       //
-  FINAL_SLOPE_ACCEL = 0x0F, //
-  FINAL_SLOPE_DECEL = 0x10, //
-  THERMAL_COMP = 0x11,      //
-  ADC_OUT = 0x12,           //
-  OVER_CRNT_THRESH = 0x13,  //
-  STALL_THRESH = 0x14,      //
-  FULL_STEP_SPEED = 0x15,   // Speed at which to switch to full step mode
-  STEP_MODE = 0x16,         //
-  ALARM_ENA = 0x17,         //
-  GATE_CFG1 = 0x18,         //
-  GATE_CFG2 = 0x19,         //
-  CONFIG = 0x1A,            //
-  STATUS = 0x1B,            //
+  kAbsolutePosition = 0x01,         // Absolute position
+  kElectricalPosition = 0x02,       // Electrical position
+  kMarkPosition = 0x03,             // Mark position
+  kSpeed = 0x04,                    // Current speed
+  kAcceleration = 0x05,             // Acceleration
+  kDeceleration = 0x06,             // Deceleration
+  kMaxSpeed = 0x07,                 // Maximum allowed speed
+  kMinSpeed = 0x08,                 // Minimum allowed speed
+  kKValueHold = 0x09,               //
+  kKValueRun = 0x0A,                //
+  kKValueAccelerate = 0x0B,         //
+  kKValueDecelerate = 0x0C,         //
+  kIntersectSpeed = 0x0D,           //
+  kStartSlope = 0x0E,               //
+  kFinalSlopeAcceleration = 0x0F,   //
+  kFinalSlopeDeceleration = 0x10,   //
+  kThermalCompensation = 0x11,      //
+  kAdcOutput = 0x12,                //
+  kOverrideCurrentThreshold = 0x13, //
+  kStallThreshold = 0x14,           //
+  kFullStepSpeed = 0x15, // Speed at which to switch to full step mode
+  kStepMode = 0x16,      //
+  kAlarmEnable = 0x17,   //
+  kGateConfig1 = 0x18,   //
+  kGateConfig2 = 0x19,   //
+  kConfig = 0x1A,        //
+  kStatus = 0x1B,        //
 };
 
 // Error codes returned by my functions
 enum class StepMtrErr {
-  OK,
-  BAD_PARAM,     // The parameter ID is invalid
-  BAD_VALUE,     // Illegal value passed
-  WOULD_BLOCK,   // Call would block, can't be called from within ISR
-  QUEUE_FULL,    // Can't add command to queue, not enough space
-  INVALID_STATE, // Invalid state for command.
+  kOk,
+  kBadParam,     // The parameter ID is invalid
+  kBadValue,     // Illegal value passed
+  kWouldBlock,   // Call would block, can't be called from within ISR
+  kQueueFull,    // Can't add command to queue, not enough space
+  kInvalidState, // Invalid state for command.
 };
 
 // States for the stepper motor communication interface
 enum class StepCommState {
-  IDLE,        // Not currently communicating
-  SEND_QUEUED, // Sending data that was queued up by control loop
-  SEND_SYNC,   // Sending data that the background thread is waiting on.
+  kIdle,       // Not currently communicating
+  kSendQueued, // Sending data that was queued up by control loop
+  kSendSync,   // Sending data that the background thread is waiting on.
 };
 
 enum class StepMoveStatus {
-  STOPPED,
-  ACCELERATING,
-  DECELERATING,
-  CONSTANT_SPEED,
+  kStopped,
+  kAccelerating,
+  kDecelerating,
+  kConstantSpeed,
 };
 
 // Detailed status about the stepper driver chip.
@@ -156,7 +158,7 @@ struct StepperStatus {
   bool command_error{false};
 
   // Specifics of the move status
-  StepMoveStatus move_status{StepMoveStatus::STOPPED};
+  StepMoveStatus move_status{StepMoveStatus::kStopped};
 };
 
 // Represents one of the stepper motors in the system
@@ -341,7 +343,7 @@ private:
 public:
   // Interrupt service routine.
   // This has to be public, but don't call it.
-  static void DMA_ISR();
+  static void DmaISR();
 
   // This function should only be called by the HAL
   // at the end of the high priority loop timer ISR

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -53,80 +53,80 @@ limitations under the License.
 // Not included here are set/get parameter which include
 // the parameter ID value as part of the code.
 enum class StepMtrCmd : uint8_t {
-  kNop = 0,            // Used when there's no other command to send
-  kRunNegative = 0x50, // Run negative at constant speed.
-  kRunPositive = 0x51, // Run positive at constant speed.
-  kStepClockNegative =
+  Nop = 0,            // Used when there's no other command to send
+  RunNegative = 0x50, // Run negative at constant speed.
+  RunPositive = 0x51, // Run positive at constant speed.
+  StepClockNegative =
       0x58, // Switch to step clock mode moving in negative direction
-  kStepClockPositive =
-      0x59, // Switch to step clock mode moving in positive direction
-  kMoveNegative = 0x40,  // Move - steps, steps is given as a parameter
-  kMovePositive = 0x41,  // Move + steps, steps is given as a parameter
-  kGoTo = 0x60,          // Go to an absolute position using shortest path
-  kGoToNegative = 0x68,  // Go to an absolute position in negative direction
-  kGoToPositive = 0x69,  // Go to an absolute position in positive direction
-  kHome = 0x70,          // Same as kGoTo 0
-  kResetPosition = 0xD8, // Set absolute position register to 0
-  kResetDevice = 0xC0,   // Reset the stepper chip
-  kSoftStop = 0xB0,      // Perform a soft stop
-  kHardStop = 0xB8,      // Perform a hard stop
-  kSoftDisable = 0xA0,   // Soft stop, then disable
-  kHardDisable = 0xA8,   // Hard stop, then disable
-  kGetStatus = 0xD0,     // Read the 16-bit status word
+  StepClockPositive =
+      0x59,            // Switch to step clock mode moving in positive direction
+  MoveNegative = 0x40, // Move - steps, steps is given as a parameter
+  MovePositive = 0x41, // Move + steps, steps is given as a parameter
+  GoTo = 0x60,         // Go to an absolute position using shortest path
+  GoToNegative = 0x68, // Go to an absolute position in negative direction
+  GoToPositive = 0x69, // Go to an absolute position in positive direction
+  Home = 0x70,         // Same as GoTo 0
+  ResetPosition = 0xD8, // Set absolute position register to 0
+  ResetDevice = 0xC0,   // Reset the stepper chip
+  SoftStop = 0xB0,      // Perform a soft stop
+  HardStop = 0xB8,      // Perform a hard stop
+  SoftDisable = 0xA0,   // Soft stop, then disable
+  HardDisable = 0xA8,   // Hard stop, then disable
+  GetStatus = 0xD0,     // Read the 16-bit status word
 };
 
 enum class StepMtrParam : uint8_t {
-  kAbsolutePosition = 0x01,         // Absolute position
-  kElectricalPosition = 0x02,       // Electrical position
-  kMarkPosition = 0x03,             // Mark position
-  kSpeed = 0x04,                    // Current speed
-  kAcceleration = 0x05,             // Acceleration
-  kDeceleration = 0x06,             // Deceleration
-  kMaxSpeed = 0x07,                 // Maximum allowed speed
-  kMinSpeed = 0x08,                 // Minimum allowed speed
-  kKValueHold = 0x09,               //
-  kKValueRun = 0x0A,                //
-  kKValueAccelerate = 0x0B,         //
-  kKValueDecelerate = 0x0C,         //
-  kIntersectSpeed = 0x0D,           //
-  kStartSlope = 0x0E,               //
-  kFinalSlopeAcceleration = 0x0F,   //
-  kFinalSlopeDeceleration = 0x10,   //
-  kThermalCompensation = 0x11,      //
-  kAdcOutput = 0x12,                //
-  kOverrideCurrentThreshold = 0x13, //
-  kStallThreshold = 0x14,           //
-  kFullStepSpeed = 0x15, // Speed at which to switch to full step mode
-  kStepMode = 0x16,      //
-  kAlarmEnable = 0x17,   //
-  kGateConfig1 = 0x18,   //
-  kGateConfig2 = 0x19,   //
-  kConfig = 0x1A,        //
-  kStatus = 0x1B,        //
+  AbsolutePosition = 0x01,         // Absolute position
+  ElectricalPosition = 0x02,       // Electrical position
+  MarkPosition = 0x03,             // Mark position
+  Speed = 0x04,                    // Current speed
+  Acceleration = 0x05,             // Acceleration
+  Deceleration = 0x06,             // Deceleration
+  MaxSpeed = 0x07,                 // Maximum allowed speed
+  MinSpeed = 0x08,                 // Minimum allowed speed
+  KValueHold = 0x09,               //
+  KValueRun = 0x0A,                //
+  KValueAccelerate = 0x0B,         //
+  KValueDecelerate = 0x0C,         //
+  IntersectSpeed = 0x0D,           //
+  StartSlope = 0x0E,               //
+  FinalSlopeAcceleration = 0x0F,   //
+  FinalSlopeDeceleration = 0x10,   //
+  ThermalCompensation = 0x11,      //
+  AdcOutput = 0x12,                //
+  OverrideCurrentThreshold = 0x13, //
+  StallThreshold = 0x14,           //
+  FullStepSpeed = 0x15,            // Speed at which to switch to full step mode
+  StepMode = 0x16,                 //
+  AlarmEnable = 0x17,              //
+  GateConfig1 = 0x18,              //
+  GateConfig2 = 0x19,              //
+  Config = 0x1A,                   //
+  Status = 0x1B,                   //
 };
 
 // Error codes returned by my functions
 enum class StepMtrErr {
-  kOk,
-  kBadParam,     // The parameter ID is invalid
-  kBadValue,     // Illegal value passed
-  kWouldBlock,   // Call would block, can't be called from within ISR
-  kQueueFull,    // Can't add command to queue, not enough space
-  kInvalidState, // Invalid state for command.
+  Ok,
+  BadParam,     // The parameter ID is invalid
+  BadValue,     // Illegal value passed
+  WouldBlock,   // Call would block, can't be called from within ISR
+  QueueFull,    // Can't add command to queue, not enough space
+  InvalidState, // Invalid state for command.
 };
 
 // States for the stepper motor communication interface
 enum class StepCommState {
-  kIdle,       // Not currently communicating
-  kSendQueued, // Sending data that was queued up by control loop
-  kSendSync,   // Sending data that the background thread is waiting on.
+  Idle,       // Not currently communicating
+  SendQueued, // Sending data that was queued up by control loop
+  SendSync,   // Sending data that the background thread is waiting on.
 };
 
 enum class StepMoveStatus {
-  kStopped,
-  kAccelerating,
-  kDecelerating,
-  kConstantSpeed,
+  Stopped,
+  Accelerating,
+  Decelerating,
+  ConstantSpeed,
 };
 
 // Detailed status about the stepper driver chip.
@@ -158,7 +158,7 @@ struct StepperStatus {
   bool command_error{false};
 
   // Specifics of the move status
-  StepMoveStatus move_status{StepMoveStatus::kStopped};
+  StepMoveStatus move_status{StepMoveStatus::Stopped};
 };
 
 // Represents one of the stepper motors in the system

--- a/software/controller/lib/hal/uart_dma.cpp
+++ b/software/controller/lib/hal/uart_dma.cpp
@@ -74,9 +74,9 @@ void UartDma::Init(int baud) {
   dma->channel[rx_channel_].config.mem2mem =
       0; // memory-to-memory mode disabled
   dma->channel[rx_channel_].config.memory_size =
-      static_cast<uint32_t>(DmaTransferSize::kByte);
+      static_cast<uint32_t>(DmaTransferSize::Byte);
   dma->channel[rx_channel_].config.peripheral_size =
-      static_cast<uint32_t>(DmaTransferSize::kByte);
+      static_cast<uint32_t>(DmaTransferSize::Byte);
   dma->channel[rx_channel_].config.memory_increment =
       1; // increment destination (memory)
   dma->channel[rx_channel_].config.peripheral_increment =
@@ -84,7 +84,7 @@ void UartDma::Init(int baud) {
                                                  // (peripheral) address
   dma->channel[rx_channel_].config.circular = 0; // not circular
   dma->channel[rx_channel_].config.direction =
-      static_cast<uint32_t>(DmaChannelDir::kPeripheralToMemory);
+      static_cast<uint32_t>(DmaChannelDir::PeripheralToMemory);
 
   dma->channel[tx_channel_].config.priority = 0b11;        // high priority
   dma->channel[tx_channel_].config.tx_error_interrupt = 1; // interrupt on error
@@ -96,9 +96,9 @@ void UartDma::Init(int baud) {
   dma->channel[tx_channel_].config.mem2mem =
       0; // memory-to-memory mode disabled
   dma->channel[tx_channel_].config.memory_size =
-      static_cast<uint32_t>(DmaTransferSize::kByte);
+      static_cast<uint32_t>(DmaTransferSize::Byte);
   dma->channel[tx_channel_].config.peripheral_size =
-      static_cast<uint32_t>(DmaTransferSize::kByte);
+      static_cast<uint32_t>(DmaTransferSize::Byte);
   dma->channel[tx_channel_].config.memory_increment =
       1; // increment source (memory) address
   dma->channel[tx_channel_].config.peripheral_increment =
@@ -106,7 +106,7 @@ void UartDma::Init(int baud) {
                                                  // (peripheral) address
   dma->channel[tx_channel_].config.circular = 0; // not circular
   dma->channel[tx_channel_].config.direction =
-      static_cast<uint32_t>(DmaChannelDir::kMemoryToPeripheral);
+      static_cast<uint32_t>(DmaChannelDir::MemoryToPeripheral);
 }
 
 // Sets up an interrupt on matching char incoming form UART3
@@ -233,15 +233,15 @@ static bool GetRxError() {
 
 void UartDma::UartISR() {
   if (GetRxError()) {
-    RxError e = RxError::kRxUnknownError;
+    RxError e = RxError::RxUnknownError;
     if (RxTimeout()) {
-      e = RxError::kRxTimeout;
+      e = RxError::RxTimeout;
     }
     if (uart->status.bitfield.overrun_error) {
-      e = RxError::kRxOverflow;
+      e = RxError::RxOverflow;
     }
     if (uart->status.bitfield.framing_error) {
-      e = RxError::kRxFramingError;
+      e = RxError::RxFramingError;
     }
 
     uart->request.bitfield.flush_rx =
@@ -279,7 +279,7 @@ void UartDma::DmaTxISR() {
 void UartDma::DmaRxISR() {
   if (dma->interrupt_status.teif3) {
     StopRX();
-    rx_listener_->OnRxError(RxError_t::kRxDmaError);
+    rx_listener_->OnRxError(RxError_t::RxDmaError);
   } else {
     StopRX();
     rx_listener_->onRxComplete();

--- a/software/controller/lib/hal/uart_dma.cpp
+++ b/software/controller/lib/hal/uart_dma.cpp
@@ -32,117 +32,132 @@ limitations under the License.
 // UART will issue an interrupt upon receipt of the specified
 // character.
 
-extern UART_DMA dmaUART;
+extern UartDma dma_uart;
 
 // Performs UART3 initialization
-void UART_DMA::init(int baud) {
+void UartDma::Init(int baud) {
   // Set baud rate register
-  uart->baud = CPU_FREQ / baud;
+  uart->baudrate = CPU_FREQ / baud;
 
-  uart->ctrl3.s.dmar = 1;         // set DMAR bit to enable DMA for receiver
-  uart->ctrl3.s.dmat = 1;         // set DMAT bit to enable DMA for transmitter
-  uart->ctrl3.s.ddre = 1;         // DMA is disabled following a reception error
-  uart->ctrl2.s.rtoen = 1;        // Enable receive timeout feature
-  uart->ctrl2.s.addr = matchChar; // set match char
+  uart->control3.bitfield.rx_dma = 1; // set DMAR bit to enable DMA for receiver
+  uart->control3.bitfield.tx_dma =
+      1; // set DMAT bit to enable DMA for transmitter
+  uart->control3.bitfield.dma_disable_on_rx_error =
+      1; // DMA is disabled following a reception error
+  uart->control2.bitfield.rx_timeout_enable =
+      1;                                      // Enable receive timeout feature
+  uart->control2.bitfield.addr = match_char_; // set match char
 
-  uart->ctrl3.s.eie = 1; // enable interrupt on error
+  uart->control3.bitfield.error_interrupt = 1; // enable interrupt on error
 
-  uart->request.s.rxfrq = 1; // Clear RXNE flag before clearing other flags
+  uart->request.bitfield.flush_rx =
+      1; // Clear RXNE flag before clearing other flags
 
   // Clear error flags.
-  uart->intClear.s.fecf = 1;
-  uart->intClear.s.orecf = 1;
-  uart->intClear.s.rtocf = 1;
+  uart->interrupt_clear.bitfield.framing_error_clear = 1;
+  uart->interrupt_clear.bitfield.overrun_clear = 1;
+  uart->interrupt_clear.bitfield.rx_timeout_clear = 1;
 
-  uart->ctrl1.s.te = 1; // enable transmitter
-  uart->ctrl1.s.re = 1; // Enable receiver
-  uart->ctrl1.s.ue = 1; // enable uart
+  uart->control_reg1.bitfield.tx_enable = 1; // enable transmitter
+  uart->control_reg1.bitfield.rx_enable = 1; // Enable receiver
+  uart->control_reg1.bitfield.enable = 1;    // enable uart
 
   // TODO enable parity checking?
 
-  dma->channel[rxCh].config.priority = 0b11; // high priority
-  dma->channel[rxCh].config.teie = 1;        // interrupt on error
-  dma->channel[rxCh].config.htie = 0;        // no half-transfer interrupt
-  dma->channel[rxCh].config.tcie = 1;        // interrupt on DMA complete
+  dma->channel[rx_channel_].config.priority = 0b11;        // high priority
+  dma->channel[rx_channel_].config.tx_error_interrupt = 1; // interrupt on error
+  dma->channel[rx_channel_].config.half_tx_interrupt =
+      0; // no half-transfer interrupt
+  dma->channel[rx_channel_].config.tx_complete_interrupt =
+      1; // interrupt on DMA complete
 
-  dma->channel[rxCh].config.mem2mem = 0; // memory-to-memory mode disabled
-  dma->channel[rxCh].config.msize =
-      static_cast<uint32_t>(DmaTransferSize::BITS8);
-  dma->channel[rxCh].config.psize =
-      static_cast<uint32_t>(DmaTransferSize::BITS8);
-  dma->channel[rxCh].config.memInc = 1;   // increment destination (memory)
-  dma->channel[rxCh].config.perInc = 0;   // don't increment source
-                                          // (peripheral) address
-  dma->channel[rxCh].config.circular = 0; // not circular
-  dma->channel[rxCh].config.dir =
-      static_cast<uint32_t>(DmaChannelDir::PERIPHERAL_TO_MEM);
+  dma->channel[rx_channel_].config.mem2mem =
+      0; // memory-to-memory mode disabled
+  dma->channel[rx_channel_].config.memory_size =
+      static_cast<uint32_t>(DmaTransferSize::kByte);
+  dma->channel[rx_channel_].config.peripheral_size =
+      static_cast<uint32_t>(DmaTransferSize::kByte);
+  dma->channel[rx_channel_].config.memory_increment =
+      1; // increment destination (memory)
+  dma->channel[rx_channel_].config.peripheral_increment =
+      0;                                         // don't increment source
+                                                 // (peripheral) address
+  dma->channel[rx_channel_].config.circular = 0; // not circular
+  dma->channel[rx_channel_].config.direction =
+      static_cast<uint32_t>(DmaChannelDir::kPeripheralToMemory);
 
-  dma->channel[txCh].config.priority = 0b11; // high priority
-  dma->channel[txCh].config.teie = 1;        // interrupt on error
-  dma->channel[txCh].config.htie = 0;        // no half-transfer interrupt
-  dma->channel[txCh].config.tcie = 1;        // DMA complete interrupt enabled
+  dma->channel[tx_channel_].config.priority = 0b11;        // high priority
+  dma->channel[tx_channel_].config.tx_error_interrupt = 1; // interrupt on error
+  dma->channel[tx_channel_].config.half_tx_interrupt =
+      0; // no half-transfer interrupt
+  dma->channel[tx_channel_].config.tx_complete_interrupt =
+      1; // DMA complete interrupt enabled
 
-  dma->channel[txCh].config.mem2mem = 0; // memory-to-memory mode disabled
-  dma->channel[txCh].config.msize =
-      static_cast<uint32_t>(DmaTransferSize::BITS8);
-  dma->channel[txCh].config.psize =
-      static_cast<uint32_t>(DmaTransferSize::BITS8);
-  dma->channel[txCh].config.memInc = 1;   // increment source (memory) address
-  dma->channel[txCh].config.perInc = 0;   // don't increment dest (peripheral)
-                                          // address
-  dma->channel[txCh].config.circular = 0; // not circular
-  dma->channel[txCh].config.dir =
-      static_cast<uint32_t>(DmaChannelDir::MEM_TO_PERIPHERAL);
+  dma->channel[tx_channel_].config.mem2mem =
+      0; // memory-to-memory mode disabled
+  dma->channel[tx_channel_].config.memory_size =
+      static_cast<uint32_t>(DmaTransferSize::kByte);
+  dma->channel[tx_channel_].config.peripheral_size =
+      static_cast<uint32_t>(DmaTransferSize::kByte);
+  dma->channel[tx_channel_].config.memory_increment =
+      1; // increment source (memory) address
+  dma->channel[tx_channel_].config.peripheral_increment =
+      0;                                         // don't increment dest
+                                                 // (peripheral) address
+  dma->channel[tx_channel_].config.circular = 0; // not circular
+  dma->channel[tx_channel_].config.direction =
+      static_cast<uint32_t>(DmaChannelDir::kMemoryToPeripheral);
 }
 
 // Sets up an interrupt on matching char incoming form UART3
-void UART_DMA::charMatchEnable() {
-  uart->intClear.s.cmcf = 1; // Clear char match flag
-  uart->ctrl1.s.cmie = 1;    // Enable character match interrupt
+void UartDma::CharMatchEnable() {
+  uart->interrupt_clear.bitfield.char_match_clear = 1; // Clear char match flag
+  uart->control_reg1.bitfield.char_match_interrupt =
+      1; // Enable character match interrupt
 }
 
 // Returns true if DMA TX is in progress
-bool UART_DMA::isTxInProgress() const {
+bool UartDma::TxInProgress() const {
   // TODO thread safety
-  return tx_in_progress;
+  return tx_in_progress_;
 }
 
 // Returns true if DMA RX is in progress
-bool UART_DMA::isRxInProgress() const {
+bool UartDma::RxInProgress() const {
   // TODO thread safety
-  return rx_in_progress;
+  return rx_in_progress_;
 }
 
 // Sets up UART to transfer [length] characters from [buf]
 // Returns false if DMA transmission is in progress, does not
 // interrupt previous transmission.
 // Returns true if no transmission is in progress
-bool UART_DMA::startTX(char *buf, uint32_t length) {
-  if (isTxInProgress()) {
+bool UartDma::StartTX(char *buf, uint32_t length) {
+  if (TxInProgress()) {
     return false;
   }
 
-  dma->channel[txCh].config.enable = 0; // Disable channel before config
+  dma->channel[tx_channel_].config.enable = 0; // Disable channel before config
   // data sink
-  dma->channel[txCh].pAddr = &(uart->txDat);
+  dma->channel[tx_channel_].peripheral_address = &(uart->tx_data);
   // data source
-  dma->channel[txCh].mAddr = buf;
+  dma->channel[tx_channel_].memory_address = buf;
   // data length
-  dma->channel[txCh].count = length & 0x0000FFFF;
+  dma->channel[tx_channel_].count = length & 0x0000FFFF;
 
-  dma->channel[txCh].config.enable = 1; // go!
+  dma->channel[tx_channel_].config.enable = 1; // go!
 
-  tx_in_progress = true;
+  tx_in_progress_ = true;
 
   return true;
 }
 
-void UART_DMA::stopTX() {
-  if (isTxInProgress()) {
+void UartDma::StopTX() {
+  if (TxInProgress()) {
     // Disable DMA channel
-    dma->channel[1].config.enable = 0;
+    dma->channel[tx_channel_].config.enable = 0;
     // TODO thread safety
-    tx_in_progress = 0;
+    tx_in_progress_ = 0;
   }
 }
 
@@ -153,129 +168,137 @@ void UART_DMA::stopTX() {
 // setup. Returns true if no reception is in progress and new reception
 // was setup.
 
-bool UART_DMA::startRX(char *buf, uint32_t length, uint32_t timeout) {
+bool UartDma::StartRX(char *buf, uint32_t length, uint32_t timeout) {
   // UART3 reception happens on DMA1 channel 3
-  if (isRxInProgress()) {
+  if (RxInProgress()) {
     return false;
   }
 
-  dma->channel[rxCh].config.enable = 0; // don't enable yet
+  dma->channel[rx_channel_].config.enable = 0; // don't enable yet
 
   // data source
-  dma->channel[rxCh].pAddr = &(uart->rxDat);
+  dma->channel[rx_channel_].peripheral_address = &(uart->rx_data);
   // data sink
-  dma->channel[rxCh].mAddr = buf;
+  dma->channel[rx_channel_].memory_address = buf;
   // data length
-  dma->channel[rxCh].count = length;
+  dma->channel[rx_channel_].count = length;
 
   // setup rx timeout
   // max timeout is 24 bit
-  uart->timeout.s.rto = timeout & 0x00FFFFFF;
-  uart->intClear.s.rtocf = 1; // Clear rx timeout flag
-  uart->request.s.rxfrq = 1;  // Clear RXNE flag
-  uart->ctrl1.s.rtoie = 1;    // Enable receive timeout interrupt
+  uart->timeout.bitfield.rx_timeout = timeout & 0x00FFFFFF;
+  uart->interrupt_clear.bitfield.rx_timeout_clear = 1; // Clear rx timeout flag
+  uart->request.bitfield.flush_rx = 1;                 // Clear RXNE flag
+  uart->control_reg1.bitfield.rx_timeout_interrupt =
+      1; // Enable receive timeout interrupt
 
-  dma->channel[rxCh].config.enable = 1; // go!
+  dma->channel[rx_channel_].config.enable = 1; // go!
 
-  rx_in_progress = true;
+  rx_in_progress_ = true;
 
   return true;
 }
 
-uint32_t UART_DMA::getRxBytesLeft() { return dma->channel[2].count; }
+uint32_t UartDma::getRxBytesLeft() { return dma->channel[2].count; }
 
-void UART_DMA::stopRX() {
-  if (isRxInProgress()) {
-    uart->ctrl1.s.rtoie = 0;           // Disable receive timeout interrupt
+void UartDma::stopRX() {
+  if (RxInProgress()) {
+    uart->control_reg1.bitfield.rx_timeout_interrupt =
+        0;                             // Disable receive timeout interrupt
     dma->channel[2].config.enable = 0; // Disable DMA channel
     // TODO thread safety
-    rx_in_progress = false;
+    rx_in_progress_ = false;
   }
 }
 
-static bool isCharacterMatchInterrupt() {
-  return UART3_BASE->status.s.cmf != 0;
+static bool CharacterMatchInterrupt() {
+  return kUart3Base->status.bitfield.char_match != 0;
 }
 
-static bool isRxTimeout() {
+static bool RxTimeout() {
   // Timeout interrupt enable and RTOF - Receiver timeout
-  return UART3_BASE->ctrl1.s.rtoie && UART3_BASE->status.s.rtof;
+  return kUart3Base->control_reg1.bitfield.rx_timeout_interrupt &&
+         kUart3Base->status.bitfield.rx_timeout;
 }
 
-static bool isRxError() {
-  return isRxTimeout() || UART3_BASE->status.s.ore || // overrun error
-         UART3_BASE->status.s.fe;                     // frame error
+static bool GetRxError() {
+  return RxTimeout() ||
+         kUart3Base->status.bitfield.overrun_error || // overrun error
+         kUart3Base->status.bitfield.framing_error;   // frame error
 
   // TODO(miceuz): Enable these?
-  // UART3_BASE->status.s.pe || // parity error
-  // UART3_BASE->status.s.nf || // START bit noise detection flag
+  // kUart3Base->status.bitfield.parity_error || // parity error
+  // kUart3Base->status.bitfield.noise_detection || // START bit noise
+  // detection flag
 }
 
-void UART_DMA::UART_ISR() {
-  if (isRxError()) {
-    RxError_t e = RxError_t::RX_ERROR_UNKNOWN;
-    if (isRxTimeout()) {
-      e = RxError_t::RX_ERROR_TIMEOUT;
+void UartDma::UartISR() {
+  if (GetRxError()) {
+    RxError e = RxError::kRxUnknownError;
+    if (RxTimeout()) {
+      e = RxError::kRxTimeout;
     }
-    if (uart->status.s.ore) {
-      e = RxError_t::RX_ERROR_OVR;
+    if (uart->status.bitfield.overrun_error) {
+      e = RxError::kRxOverflow;
     }
-    if (uart->status.s.fe) {
-      e = RxError_t::RX_ERROR_FRAMING;
+    if (uart->status.bitfield.framing_error) {
+      e = RxError::kRxFramingError;
     }
 
-    uart->request.s.rxfrq = 1; // Clear RXNE flag before clearing other flags
+    uart->request.bitfield.flush_rx =
+        1; // Clear RXNE flag before clearing other flags
 
     // Clear error flags.
-    uart->intClear.s.fecf = 1;
-    uart->intClear.s.orecf = 1;
-    uart->intClear.s.rtocf = 1;
+    uart->interrupt_clear.bitfield.framing_error_clear = 1;
+    uart->interrupt_clear.bitfield.overrun_clear = 1;
+    uart->interrupt_clear.bitfield.rx_timeout_clear = 1;
 
     // TODO define logic if stopRX() has to be here
-    rxListener.onRxError(e);
+    rx_listener_->OnRxError(e);
   }
 
-  if (isCharacterMatchInterrupt()) {
-    uart->request.s.rxfrq = 1; // Clear RXNE flag before clearing other flags
-    uart->intClear.s.cmcf = 1; // Clear char match flag
+  if (CharacterMatchInterrupt()) {
+    uart->request.bitfield.flush_rx =
+        1; // Clear RXNE flag before clearing other flags
+    uart->interrupt_clear.bitfield.char_match_clear =
+        1; // Clear char match flag
     // TODO define logic if stopRX() has to be here
-    rxListener.onCharacterMatch();
+    rx_listener_->OnCharacterMatch();
   }
 }
 
-void UART_DMA::DMA_TX_ISR() {
-  if (dma->intStat.teif2) {
-    stopTX();
-    txListener.onTxError();
+void UartDma::DmaTxISR() {
+  if (dma->interrupt_status.teif2) {
+    StopTX();
+    tx_listener_->OnTxError();
   } else {
-    stopTX();
-    txListener.onTxComplete();
+    StopTX();
+    tx_listener_->OnTxComplete();
   }
 }
 
-void UART_DMA::DMA_RX_ISR() {
-  if (dma->intStat.teif3) {
-    stopRX();
-    rxListener.onRxError(RxError_t::RX_ERROR_DMA);
+void UartDma::DmaRxISR() {
+  if (dma->interrupt_status.teif3) {
+    StopRX();
+    rx_listener_->OnRxError(RxError_t::kRxDmaError);
   } else {
-    stopRX();
-    rxListener.onRxComplete();
+    StopRX();
+    rx_listener_->onRxComplete();
   }
 }
 
-void DMA1_CH2_ISR() {
-  DMA_Regs *dma = DMA1_BASE;
-  dmaUART.DMA_TX_ISR();
-  dma->intClr.gif2 = 1; // clear all channel 3 flags
+void DMA1Channel2ISR() {
+  DmaReg *dma = kDma1Base;
+  dma_uart.DmaTxISR();
+  dma->interrupt_clear.gif2 = 1; // clear all channel 3 flags
 }
 
-void DMA1_CH3_ISR() {
-  DMA_Regs *dma = DMA1_BASE;
-  dmaUART.DMA_RX_ISR();
-  dma->intClr.gif3 = 1; // clear all channel 2 flags
+void DMA1Channel3ISR() {
+  DmaReg *dma = kDma1Base;
+  dma_uart.DmaRxISR();
+  dma->interrupt_clear.gif3 = 1; // clear all channel 2 flags
 }
 
 // This is the interrupt handler for the UART.
-void UART3_ISR() { dmaUART.UART_ISR(); }
+void Uart3ISR() { dma_uart.UartISR(); }
 
 #endif

--- a/software/controller/lib/hal/uart_dma.cpp
+++ b/software/controller/lib/hal/uart_dma.cpp
@@ -287,13 +287,13 @@ void UartDma::DmaRxISR() {
 }
 
 void DMA1Channel2ISR() {
-  DmaReg *dma = kDma1Base;
+  DmaReg *dma = Dma1Base;
   dma_uart.DmaTxISR();
   dma->interrupt_clear.gif2 = 1; // clear all channel 3 flags
 }
 
 void DMA1Channel3ISR() {
-  DmaReg *dma = kDma1Base;
+  DmaReg *dma = Dma1Base;
   dma_uart.DmaRxISR();
   dma->interrupt_clear.gif3 = 1; // clear all channel 2 flags
 }

--- a/software/controller/lib/hal/uart_dma.h
+++ b/software/controller/lib/hal/uart_dma.h
@@ -14,83 +14,76 @@ limitations under the License.
 
 */
 
-#ifndef __UART_DMA
-#define __UART_DMA
+#ifndef UART_DMA_H
+#define UART_DMA_H
 #include "hal_stm32_regs.h"
 
-enum RxError_t {
-  RX_ERROR_UNKNOWN,
-  RX_ERROR_OVR,
-  RX_ERROR_FRAMING,
-  RX_ERROR_TIMEOUT,
-  RX_ERROR_DMA
+enum class RxError {
+  kRxUnknownError,
+  kRxOverflow,
+  kRxFramingError,
+  kRxTimeout,
+  kRxDmaError
 };
 
 // An interface that gets called back by the driver on rx, tx complete
 // and rx character match events.
 // NOTE: all callbacks are called from interrupt context!
-class UART_DMA_RxListener {
+class UartDmaRxListener {
 public:
   // Called on DMA RX complete
-  virtual void onRxComplete() = 0;
+  virtual void OnRxComplete() = 0;
   // Called on specified character reception
-  virtual void onCharacterMatch() = 0;
+  virtual void OnCharacterMatch() = 0;
   // Called on RX errors
-  virtual void onRxError(RxError_t) = 0;
+  virtual void OnRxError(RxError) = 0;
 };
 
-class UART_DMA_TxListener {
+class UartDmaTxListener {
 public:
   // Called on DMA TX complete
-  virtual void onTxComplete() = 0;
+  virtual void OnTxComplete() = 0;
   // Called on TX errors
-  virtual void onTxError() = 0;
+  virtual void OnTxError() = 0;
 };
 
 class DMACtrl {
-  DMA_Regs *const dma;
-
 public:
-  explicit DMACtrl(DMA_Regs *const dma) : dma(dma) {}
-  void init() {
+  explicit DMACtrl(DmaReg *const dma) : dma_(dma) {}
+  void Init() {
     // UART3 reception happens on DMA1 channel 3
-    dma->chanSel.c3s = 0b0010;
+    dma_->channel_select.c3s = 0b0010;
     // UART3 transmission happens on DMA1 channel 2
-    dma->chanSel.c2s = 0b0010;
+    dma_->channel_select.c2s = 0b0010;
   }
+
+private:
+  DmaReg *const dma_;
 };
 
-class UART_DMA {
-  UART_Regs *const uart;
-  DMA_Regs *const dma;
-  uint8_t txCh;
-  uint8_t rxCh;
-  UART_DMA_RxListener &rxListener;
-  UART_DMA_TxListener &txListener;
-  char matchChar;
-
+class UartDma {
 public:
-  UART_DMA(UART_Regs *const uart, DMA_Regs *const dma, uint8_t txCh,
-           uint8_t rxCh, UART_DMA_RxListener &rxl, UART_DMA_TxListener &txl,
-           char matchChar)
-      : uart(uart), dma(dma), txCh(txCh), rxCh(rxCh), rxListener(rxl),
-        txListener(txl), matchChar(matchChar) {}
+  UartDma(UartReg *const uart, DmaReg *const dma, uint8_t tx_chan,
+          uint8_t rx_chan, UartDmaRxListener *rxl, UartDmaTxListener *txl,
+          char match_char)
+      : uart_(uart), dma_(dma), tx_channel_(tx_chan), rx_channel_(rx_chan),
+        rx_listener_(rxl), tx_listener_(txl), match_char_(match_char) {}
 
-  void init(int baud);
+  void Init(int baud);
   // Returns true if DMA TX is in progress
-  bool isTxInProgress() const;
+  bool TxInProgress() const;
   // Returns true if DMA RX is in progress
-  bool isRxInProgress() const;
+  bool RxInProgress() const;
 
   // Sets up UART3 to transfer [length] characters from [buf]
   // Returns false if DMA transmission is in progress, does not
   // interrupt previous transmission.
   // Returns true if no transmission is in progress
-  bool startTX(char *buf, uint32_t length);
+  bool StartTX(char *buf, uint32_t length);
 
-  uint32_t getRxBytesLeft();
+  uint32_t GetRxBytesLeft();
 
-  void stopTX();
+  void StopTX();
 
   // Sets up reception of at least [length] chars from UART3 into [buf]
   // [timeout] is the number of baudrate bits for which RX line is
@@ -99,16 +92,23 @@ public:
   // setup. Returns true if no reception is in progress and new reception
   // was setup.
 
-  bool startRX(char *buf, uint32_t length, uint32_t timeout);
-  void stopRX();
-  void charMatchEnable();
+  bool StartRX(char *buf, uint32_t length, uint32_t timeout);
+  void StopRX();
+  void CharMatchEnable();
 
-  void UART_ISR();
-  void DMA_RX_ISR();
-  void DMA_TX_ISR();
+  void UartISR();
+  void DmaRxISR();
+  void DmaTxISR();
 
 private:
-  bool tx_in_progress;
-  bool rx_in_progress;
+  UartReg *const uart_;
+  DmaReg *const dma_;
+  uint8_t tx_channel_;
+  uint8_t rx_channel_;
+  UartDmaRxListener *rx_listener_;
+  UartDmaTxListener *tx_listener_;
+  char match_char_;
+  bool tx_in_progress_{false};
+  bool rx_in_progress_{false};
 };
 #endif

--- a/software/controller/lib/hal/uart_dma.h
+++ b/software/controller/lib/hal/uart_dma.h
@@ -19,11 +19,11 @@ limitations under the License.
 #include "hal_stm32_regs.h"
 
 enum class RxError {
-  kRxUnknownError,
-  kRxOverflow,
-  kRxFramingError,
-  kRxTimeout,
-  kRxDmaError
+  RxUnknownError,
+  RxOverflow,
+  RxFramingError,
+  RxTimeout,
+  RxDmaError
 };
 
 // An interface that gets called back by the driver on rx, tx complete

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -37,20 +37,20 @@ float PID::Compute(Time now, float input, float setpoint) {
 
   output_sum_ += (ki_ * error * delta_t);
 
-  if (p_term_ == ProportionalTerm::kOnMeasurement) {
+  if (p_term_ == ProportionalTerm::OnMeasurement) {
     output_sum_ -= kp_ * delta_input;
   }
 
   output_sum_ = std::clamp(output_sum_, out_min_, out_max_);
 
   float res = output_sum_;
-  if (p_term_ == ProportionalTerm::kOnError) {
+  if (p_term_ == ProportionalTerm::OnError) {
     res += kp_ * error;
   }
   // delta_t may be 0 (e.g. on the first call to Compute()), in which case we
   // simply skip using the derivative term.
   if (delta_t > 0) {
-    if (d_term_ == DifferentialTerm::kOnMeasurement) {
+    if (d_term_ == DifferentialTerm::OnMeasurement) {
       res -= kd_ * delta_input / delta_t;
     } else {
       res += kd_ * (error - last_error_) / delta_t;

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -29,31 +29,31 @@ float PID::Compute(Time now, float input, float setpoint) {
   }
 
   // Compute time between now and last sample.
-  float dt = (now - last_update_time_).seconds();
+  float delta_t = (now - last_update_time_).seconds();
 
   // Compute all the working error variables
   float error = setpoint - input;
-  float dInput = input - last_input_;
+  float delta_input = input - last_input_;
 
-  output_sum_ += (ki_ * error * dt);
+  output_sum_ += (ki_ * error * delta_t);
 
-  if (p_term_ == ProportionalTerm::ON_MEASUREMENT) {
-    output_sum_ -= kp_ * dInput;
+  if (p_term_ == ProportionalTerm::kOnMeasurement) {
+    output_sum_ -= kp_ * delta_input;
   }
 
   output_sum_ = std::clamp(output_sum_, out_min_, out_max_);
 
   float res = output_sum_;
-  if (p_term_ == ProportionalTerm::ON_ERROR) {
+  if (p_term_ == ProportionalTerm::kOnError) {
     res += kp_ * error;
   }
-  // dt may be 0 (e.g. on the first call to Compute()), in which case we simply
-  // skip using the derivative term.
-  if (dt > 0) {
-    if (d_term_ == DifferentialTerm::ON_MEASUREMENT) {
-      res -= kd_ * dInput / dt;
+  // delta_t may be 0 (e.g. on the first call to Compute()), in which case we
+  // simply skip using the derivative term.
+  if (delta_t > 0) {
+    if (d_term_ == DifferentialTerm::kOnMeasurement) {
+      res -= kd_ * delta_input / delta_t;
     } else {
-      res += kd_ * (error - last_error_) / dt;
+      res += kd_ * (error - last_error_) / delta_t;
     }
   }
 

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -22,13 +22,13 @@ limitations under the License.
 #include "units.h"
 
 enum class ProportionalTerm {
-  kOnError,
-  kOnMeasurement,
+  OnError,
+  OnMeasurement,
 };
 
 enum class DifferentialTerm {
-  kOnError,
-  kOnMeasurement,
+  OnError,
+  OnMeasurement,
 };
 
 class PID {

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -22,13 +22,13 @@ limitations under the License.
 #include "units.h"
 
 enum class ProportionalTerm {
-  ON_ERROR,
-  ON_MEASUREMENT,
+  kOnError,
+  kOnMeasurement,
 };
 
 enum class DifferentialTerm {
-  ON_ERROR,
-  ON_MEASUREMENT,
+  kOnError,
+  kOnMeasurement,
 };
 
 class PID {

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -64,14 +64,12 @@ static Debug::Command::VarHandler var_command;
 static Debug::Command::TraceHandler trace_command(&trace);
 static Debug::Command::EepromHandler eeprom_command(&eeprom);
 
-static Debug::Interface debug(&trace, 12, Debug::Command::Code::kMode,
-                              &mode_command, Debug::Command::Code::kPeek,
-                              &peek_command, Debug::Command::Code::kPoke,
-                              &poke_command, Debug::Command::Code::kVariable,
-                              &var_command, Debug::Command::Code::kTrace,
-                              &trace_command,
-                              Debug::Command::Code::kEepromAccess,
-                              &eeprom_command);
+static Debug::Interface
+    debug(&trace, 12, Debug::Command::Code::Mode, &mode_command,
+          Debug::Command::Code::Peek, &peek_command, Debug::Command::Code::Poke,
+          &poke_command, Debug::Command::Code::Variable, &var_command,
+          Debug::Command::Code::Trace, &trace_command,
+          Debug::Command::Code::EepromAccess, &eeprom_command);
 
 static SensorsProto AsSensorsProto(const SensorReadings &r,
                                    const ControllerState &c) {

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -92,20 +92,20 @@ static SensorsProto AsSensorsProto(const SensorReadings &r,
 //
 // NOTE - its important that anything being called from this function executes
 // quickly.  No busy waiting here.
-static void high_priority_task(void *arg) {
+static void HighPriorityTask(void *arg) {
 
   // Read the sensors
   SensorReadings sensor_readings = sensors.GetReadings();
 
   // Run our PID loop
   auto [actuators_state, controller_state] = controller.Run(
-      Hal.now(), controller_status.active_params, sensor_readings);
+      hal.Now(), controller_status.active_params, sensor_readings);
 
   // TODO update pb library to replace fan_power in ControllerStatus with
   // actuators_state, and remove pressure_setpoint_cm_h2o from ControllerStatus
 
   // Update the outputs from the PID
-  actuators_execute(actuators_state);
+  ActuatorsExecute(actuators_state);
 
   // Update controller_status.  This is periodically sent back to the GUI.
   controller_status.sensor_readings =
@@ -118,13 +118,13 @@ static void high_priority_task(void *arg) {
   debug.SampleTraceVars();
 
   // Pet the watchdog
-  Hal.watchdog_handler();
+  hal.WatchdogHandler();
 }
 
 // This function is the lower priority background loop which runs continuously
 // after some basic system init.  Pretty much everything not time critical
 // should go here.
-static void background_loop() {
+static void BackgroundLoop() {
   // Sleep for a few seconds.  In the current iteration of the PCB, the fan
   // briefly turns on when the device starts up.  If we don't wait for the fan
   // to spin down, the sensors will miscalibrate.  This is a hardware issue
@@ -133,16 +133,16 @@ static void background_loop() {
   //
   // Take this opportunity while we're sleeping to home the pinch valves.  This
   // way we're guaranteed that they're ready before we start ventilating.
-  Time sleepStart = Hal.now();
-  while (!AreActuatorsReady() || Hal.now() - sleepStart < seconds(10)) {
-    actuators_execute({
+  Time sleep_start = hal.Now();
+  while (!AreActuatorsReady() || hal.Now() - sleep_start < seconds(10)) {
+    ActuatorsExecute({
         .fio2_valve = 0,
         .blower_power = 0,
         .blower_valve = 1,
         .exhale_valve = 1,
     });
-    Hal.delay(milliseconds(10));
-    Hal.watchdog_handler();
+    hal.Delay(milliseconds(10));
+    hal.WatchdogHandler();
     debug.Poll();
   }
 
@@ -159,10 +159,10 @@ static void background_loop() {
 
   // After all initialization is done, ask the HAL
   // to start our high priority thread.
-  Hal.startLoopTimer(Controller::GetLoopPeriod(), high_priority_task, nullptr);
+  hal.StartLoopTimer(Controller::GetLoopPeriod(), HighPriorityTask, nullptr);
 
   while (true) {
-    controller_status.uptime_ms = Hal.now().microsSinceStartup() / 1000;
+    controller_status.uptime_ms = hal.Now().microsSinceStartup() / 1000;
 
     // Copy the current controller status with interrupts
     // disabled to ensure that the data we send to the
@@ -173,7 +173,7 @@ static void background_loop() {
       local_controller_status = controller_status;
     }
 
-    comms_handler(local_controller_status, &gui_status);
+    CommsHandler(local_controller_status, &gui_status);
 
     // Override received gui_status from the RPi with values from DebugVars iff
     // the gui_mode DebugVar has a legal value.
@@ -199,19 +199,19 @@ static void background_loop() {
     debug.Poll();
 
     // Update nv_params
-    nv_params.Update(Hal.now(), &gui_status.desired_params);
+    nv_params.Update(hal.Now(), &gui_status.desired_params);
   }
 }
 
 int main() {
-  // Initialize Hal first because it initializes the watchdog. See comment on
-  // HalApi::init().
-  Hal.init();
+  // Initialize hal first because it initializes the watchdog. See comment on
+  // HalApi::Init().
+  hal.Init();
 
   // Locate our non-volatile parameter block in flash
   nv_params.Init(&eeprom);
 
-  comms_init();
+  CommsInit();
 
-  background_loop();
+  BackgroundLoop();
 }

--- a/software/controller/src/pure_virtual.cpp
+++ b/software/controller/src/pure_virtual.cpp
@@ -28,5 +28,7 @@ limitations under the License.
 // We'd probably also need to remove the dependency on hal, so this could be
 // used from libraries that don't link with hal.
 #ifdef BARE_STM32
-extern "C" void __cxa_pure_virtual() { Hal.reset_device(); }
+// We don't control this function's name, silence the style check
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" void __cxa_pure_virtual() { hal.ResetDevice(); }
 #endif

--- a/software/controller/src_test/main.cpp
+++ b/software/controller/src_test/main.cpp
@@ -5,22 +5,22 @@
 
 char r[20];
 
-extern UART_DMA dmaUART;
+extern UartDma dma_uart;
 
-class DummyTxListener : public UART_DMA_TxListener {
-  void onTxComplete() { debugPrint("$"); }
-  void onTxError(){};
+class DummyTxListener : public UartDmaTxListener {
+  void OnTxComplete() override { debugPrint("$"); }
+  void OnTxError() override{};
 };
 
-class DummyRxListener : public UART_DMA_RxListener {
+class DummyRxListener : public UartDmaRxListener {
 public:
-  void onRxComplete() {
+  void OnRxComplete() override {
     debugPrint("&");
     debugPrint(r);
   }
-  void onCharacterMatch() { debugPrint("@"); }
-  void onRxError(RxError_t e) {
-    if (RX_ERROR_TIMEOUT == e) {
+  void OnCharacterMatch() override { debugPrint("@"); }
+  void OnRxError(RxError e) override {
+    if (kRxTimeout == e) {
       debugPrint("T");
     } else {
       debugPrint("#");
@@ -32,38 +32,38 @@ public:
 DummyRxListener rxlistener;
 DummyTxListener txlistener;
 
-DMACtrl dmaController(DMA1_BASE);
-constexpr uint8_t txCh = 1;
-constexpr uint8_t rxCh = 2;
-UART_DMA dmaUART(UART3_BASE, DMA1_BASE, txCh, rxCh, rxlistener, txlistener,
+DMACtrl dma_controller(kDma1Base);
+constexpr uint8_t kTxCh = 1;
+constexpr uint8_t kRxCh = 2;
+UartDma dma_uart(kUart3Base, kDma1Base, kTxCh, kRxCh, &rxlistener, &txlistener,
                  '.');
 
 int main() {
-  Hal.init();
-  dmaController.init();
+  hal.Init();
+  dma_controller.Init();
 
   debugPrint("*");
   char s[] = "ping ping ping ping ping ping ping ping ping ping ping ping\n";
-  bool dmaStarted = false;
+  bool dma_started = false;
 
-  dmaStarted = dmaUART.startTX(s, strlen(s));
-  if (dmaStarted) {
+  dma_started = dma_uart.StartTX(s, strlen(s));
+  if (dma_started) {
     debugPrint("!");
   }
 
-  dmaUART.charMatchEnable();
+  dma_uart.CharMatchEnable();
 
-  dmaStarted = dmaUART.startRX(r, 10, 115200 * 2);
-  if (dmaStarted) {
+  dma_started = dma_uart.StartRX(r, 10, 115200 * 2);
+  if (dma_started) {
     debugPrint("!");
   }
 
   while (true) {
-    Hal.watchdog_handler();
+    hal.WatchdogHandler();
     char i[1];
     if (1 == debugRead(i, 1)) {
-      Hal.reset_device();
+      hal.ResetDevice();
     }
-    Hal.delay(milliseconds(10));
+    hal.Delay(milliseconds(10));
   }
 }

--- a/software/controller/src_test/main.cpp
+++ b/software/controller/src_test/main.cpp
@@ -20,7 +20,7 @@ public:
   }
   void OnCharacterMatch() override { debugPrint("@"); }
   void OnRxError(RxError e) override {
-    if (kRxTimeout == e) {
+    if (RxTimeout == e) {
       debugPrint("T");
     } else {
       debugPrint("#");
@@ -32,10 +32,10 @@ public:
 DummyRxListener rxlistener;
 DummyTxListener txlistener;
 
-DMACtrl dma_controller(kDma1Base);
-constexpr uint8_t kTxCh = 1;
-constexpr uint8_t kRxCh = 2;
-UartDma dma_uart(kUart3Base, kDma1Base, kTxCh, kRxCh, &rxlistener, &txlistener,
+DMACtrl dma_controller(Dma1Base);
+constexpr uint8_t TxCh = 1;
+constexpr uint8_t RxCh = 2;
+UartDma dma_uart(kUart3Base, Dma1Base, TxCh, RxCh, &rxlistener, &txlistener,
                  '.');
 
 int main() {

--- a/software/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/software/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -30,7 +30,7 @@ constexpr BlowerFsmInputs inputs_zero = {
     .net_flow = ml_per_sec(0),
 };
 
-constexpr int64_t rise_time_us = kRiseTime.microseconds();
+constexpr int64_t rise_time_us = RiseTime.microseconds();
 static_assert(rise_time_us % 1000 == 0,
               "blower fsm tests assume rise time is a whole number of ms.");
 static_assert(rise_time_us % 5 == 0,

--- a/software/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/software/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -43,7 +43,7 @@ TEST(BlowerFsmTest, InitiallyOff) {
   VentParams p = VentParams_init_zero;
   BlowerSystemState s = fsm.DesiredState(hal.Now(), p, inputs_zero);
   EXPECT_TRUE(s.pressure_setpoint == std::nullopt);
-  EXPECT_EQ(s.flow_direction, FlowDirection::kExpiratory);
+  EXPECT_EQ(s.flow_direction, FlowDirection::Expiratory);
 }
 
 TEST(BlowerFsmTest, StaysOff) {
@@ -52,7 +52,7 @@ TEST(BlowerFsmTest, StaysOff) {
   hal.Delay(milliseconds(1000));
   BlowerSystemState s = fsm.DesiredState(hal.Now(), p, inputs_zero);
   EXPECT_TRUE(s.pressure_setpoint == std::nullopt);
-  EXPECT_EQ(s.flow_direction, FlowDirection::kExpiratory);
+  EXPECT_EQ(s.flow_direction, FlowDirection::Expiratory);
 }
 
 TEST(BlowerFsmTest, OffFsmDesiredPipPeep) {
@@ -170,76 +170,76 @@ TEST(BlowerFsmTest, PressureControl) {
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(1 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(12),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(2 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(14),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(3 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(16),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(4 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(18),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(5 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       // Plateau at PIP
       {.time = microsSinceStartup(1E6),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(199E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       // end of inhale ==> back to PEEP
       {.time = microsSinceStartup(201E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::kExpiratory}},
+                          .flow_direction = FlowDirection::Expiratory}},
       {.time = microsSinceStartup(299E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::kExpiratory}},
+                          .flow_direction = FlowDirection::Expiratory}},
       // Start of next breath
       {.time = microsSinceStartup(300E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(300E4 + rise_time_us / 2),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(15),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
       {.time = microsSinceStartup(300E4 + rise_time_us),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::kInspiratory}},
+                          .flow_direction = FlowDirection::Inspiratory}},
   });
 }
 
 struct FlowTraceResults {
   // Time relative to start of breath when flow direction switched from
-  // kInspiratory to kExpiratory.
+  // Inspiratory to Expiratory.
   std::optional<Duration> expire_start_time;
 
   // Time relative to start of breath when FSM indicated it was done.
@@ -274,14 +274,14 @@ RunFlowTrace(const VolumetricFlow *trace, size_t n, const VentParams &params,
     BlowerSystemState desired_state =
         fsm.DesiredState(hal.Now(), {.patient_volume = ml(0), .net_flow = f});
     FlowDirection dir = desired_state.flow_direction;
-    if (dir == FlowDirection::kExpiratory && !results.expire_start_time) {
+    if (dir == FlowDirection::Expiratory && !results.expire_start_time) {
       results.expire_start_time = hal.Now() - start;
     }
 
     if (results.expire_start_time == std::nullopt) {
-      EXPECT_EQ(FlowDirection::kInspiratory, dir);
+      EXPECT_EQ(FlowDirection::Inspiratory, dir);
     } else {
-      EXPECT_EQ(FlowDirection::kExpiratory, dir);
+      EXPECT_EQ(FlowDirection::Expiratory, dir);
     }
 
     if (check_it != setpoint_checks.end()) {

--- a/software/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/software/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -30,7 +30,7 @@ constexpr BlowerFsmInputs inputs_zero = {
     .net_flow = ml_per_sec(0),
 };
 
-constexpr int64_t rise_time_us = RISE_TIME.microseconds();
+constexpr int64_t rise_time_us = kRiseTime.microseconds();
 static_assert(rise_time_us % 1000 == 0,
               "blower fsm tests assume rise time is a whole number of ms.");
 static_assert(rise_time_us % 5 == 0,
@@ -41,18 +41,18 @@ static_assert(rise_time_us % 2 == 0,
 TEST(BlowerFsmTest, InitiallyOff) {
   BlowerFsm fsm;
   VentParams p = VentParams_init_zero;
-  BlowerSystemState s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+  BlowerSystemState s = fsm.DesiredState(hal.Now(), p, inputs_zero);
   EXPECT_TRUE(s.pressure_setpoint == std::nullopt);
-  EXPECT_EQ(s.flow_direction, FlowDirection::EXPIRATORY);
+  EXPECT_EQ(s.flow_direction, FlowDirection::kExpiratory);
 }
 
 TEST(BlowerFsmTest, StaysOff) {
   BlowerFsm fsm;
   VentParams p = VentParams_init_zero;
-  Hal.delay(milliseconds(1000));
-  BlowerSystemState s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+  hal.Delay(milliseconds(1000));
+  BlowerSystemState s = fsm.DesiredState(hal.Now(), p, inputs_zero);
   EXPECT_TRUE(s.pressure_setpoint == std::nullopt);
-  EXPECT_EQ(s.flow_direction, FlowDirection::EXPIRATORY);
+  EXPECT_EQ(s.flow_direction, FlowDirection::kExpiratory);
 }
 
 TEST(BlowerFsmTest, OffFsmDesiredPipPeep) {
@@ -64,7 +64,7 @@ TEST(BlowerFsmTest, OffFsmDesiredPipPeep) {
   p.peep_cm_h2o = 10;
   p.pip_cm_h2o = 20;
 
-  BlowerSystemState s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+  BlowerSystemState s = fsm.DesiredState(hal.Now(), p, inputs_zero);
   EXPECT_EQ(s.pip.cmH2O(), 0.f);
   EXPECT_EQ(s.peep.cmH2O(), 0.f);
 }
@@ -79,29 +79,29 @@ TEST(BlowerFsmTest, DesiredPipPeep) {
     p.pip_cm_h2o = 20;
     p.peep_cm_h2o = 10;
 
-    BlowerSystemState s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+    BlowerSystemState s = fsm.DesiredState(hal.Now(), p, inputs_zero);
     EXPECT_EQ(s.pip.cmH2O(), 20.f);
     EXPECT_EQ(s.peep.cmH2O(), 10.f);
 
-    Hal.delay(seconds(1));
+    hal.Delay(seconds(1));
     p.pip_cm_h2o = 25;
     p.peep_cm_h2o = 15;
 
     // pip/peep unchanged, because we haven't hit a breath boundary yet.
-    s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+    s = fsm.DesiredState(hal.Now(), p, inputs_zero);
     EXPECT_EQ(s.pip.cmH2O(), 20.f);
     EXPECT_EQ(s.peep.cmH2O(), 10.f);
 
     // We are at the breath boundary; the FSM will return the last desired state
     // for the just-completed breath; is_end_of_breath flag should be true
-    Hal.delay(seconds(2));
-    s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+    hal.Delay(seconds(2));
+    s = fsm.DesiredState(hal.Now(), p, inputs_zero);
     EXPECT_EQ(s.pip.cmH2O(), 20.f);
     EXPECT_EQ(s.peep.cmH2O(), 10.f);
     EXPECT_EQ(s.is_end_of_breath, true);
 
     // the next desired state should contain updated values
-    s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+    s = fsm.DesiredState(hal.Now(), p, inputs_zero);
     EXPECT_EQ(s.pip.cmH2O(), 25.f);
     EXPECT_EQ(s.peep.cmH2O(), 15.f);
     EXPECT_EQ(s.is_end_of_breath, false);
@@ -124,23 +124,23 @@ void testSequence(const std::vector<BlowerFsmTest> &seq) {
   }
 
   // Reset time to test's start time.
-  // TODO: Add a Hal.test_ResetClockToZero() command?
-  Hal.delay(seq.front().time - Hal.now());
+  // TODO: Add a hal.test_ResetClockToZero() command?
+  hal.Delay(seq.front().time - hal.Now());
 
   VentParams last_params;
   BlowerFsmInputs last_inputs;
   for (const auto &blower_fsm_test : seq) {
     SCOPED_TRACE("time = " + blower_fsm_test.time.microsSinceStartup() / 1000);
     // Move time forward to t in steps of Controller::GetLoopPeriod().
-    while (Hal.now() < blower_fsm_test.time) {
-      Hal.delay(Controller::GetLoopPeriod());
-      (void)fsm.DesiredState(Hal.now(), last_params, last_inputs);
+    while (hal.Now() < blower_fsm_test.time) {
+      hal.Delay(Controller::GetLoopPeriod());
+      (void)fsm.DesiredState(hal.Now(), last_params, last_inputs);
     }
     EXPECT_EQ(blower_fsm_test.time.microsSinceStartup(),
-              Hal.now().microsSinceStartup());
+              hal.Now().microsSinceStartup());
 
     BlowerSystemState state = fsm.DesiredState(
-        Hal.now(), blower_fsm_test.params, blower_fsm_test.inputs);
+        hal.Now(), blower_fsm_test.params, blower_fsm_test.inputs);
     EXPECT_EQ(state.pressure_setpoint.has_value(),
               blower_fsm_test.expected_state.pressure_setpoint.has_value());
     EXPECT_FLOAT_EQ(
@@ -165,81 +165,81 @@ TEST(BlowerFsmTest, PressureControl) {
   params.pip_cm_h2o = 20;
 
   testSequence({
-      // Pressure starts out at PEEP and rises to PIP over period RISE_TIME.
+      // Pressure starts out at PEEP and rises to PIP over period kRiseTime.
       {.time = microsSinceStartup(0),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(1 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(12),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(2 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(14),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(3 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(16),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(4 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(18),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(5 * rise_time_us / 5),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       // Plateau at PIP
       {.time = microsSinceStartup(1E6),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(199E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       // end of inhale ==> back to PEEP
       {.time = microsSinceStartup(201E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::EXPIRATORY}},
+                          .flow_direction = FlowDirection::kExpiratory}},
       {.time = microsSinceStartup(299E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::EXPIRATORY}},
+                          .flow_direction = FlowDirection::kExpiratory}},
       // Start of next breath
       {.time = microsSinceStartup(300E4),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(10),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(300E4 + rise_time_us / 2),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(15),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
       {.time = microsSinceStartup(300E4 + rise_time_us),
        .params = params,
        .inputs = inputs_zero,
        .expected_state = {.pressure_setpoint = cmH2O(20),
-                          .flow_direction = FlowDirection::INSPIRATORY}},
+                          .flow_direction = FlowDirection::kInspiratory}},
   });
 }
 
 struct FlowTraceResults {
   // Time relative to start of breath when flow direction switched from
-  // INSPIRATORY to EXPIRATORY.
+  // kInspiratory to kExpiratory.
   std::optional<Duration> expire_start_time;
 
   // Time relative to start of breath when FSM indicated it was done.
@@ -258,30 +258,30 @@ RunFlowTrace(const VolumetricFlow *trace, size_t n, const VentParams &params,
              std::vector<std::tuple</*time ms*/ uint64_t,
                                     /*setpoint pressure, cmH2O*/ float>>
                  setpoint_checks) {
-  FsmTy fsm(Hal.now(), params);
+  FsmTy fsm(hal.Now(), params);
 
-  Time start = Hal.now();
+  Time start = hal.Now();
   FlowTraceResults results;
   auto check_it = setpoint_checks.begin();
 
   for (size_t i = 0; i < n; i++) {
-    auto ms = (Hal.now() - start).microseconds() / 1000;
+    auto ms = (hal.Now() - start).microseconds() / 1000;
     SCOPED_TRACE("time = " + std::to_string(ms));
 
     VolumetricFlow f = trace[i];
 
     // Our traces don't contain volume measurements, but this is OK for now.
     BlowerSystemState desired_state =
-        fsm.DesiredState(Hal.now(), {.patient_volume = ml(0), .net_flow = f});
+        fsm.DesiredState(hal.Now(), {.patient_volume = ml(0), .net_flow = f});
     FlowDirection dir = desired_state.flow_direction;
-    if (dir == FlowDirection::EXPIRATORY && !results.expire_start_time) {
-      results.expire_start_time = Hal.now() - start;
+    if (dir == FlowDirection::kExpiratory && !results.expire_start_time) {
+      results.expire_start_time = hal.Now() - start;
     }
 
     if (results.expire_start_time == std::nullopt) {
-      EXPECT_EQ(FlowDirection::INSPIRATORY, dir);
+      EXPECT_EQ(FlowDirection::kInspiratory, dir);
     } else {
-      EXPECT_EQ(FlowDirection::EXPIRATORY, dir);
+      EXPECT_EQ(FlowDirection::kExpiratory, dir);
     }
 
     if (check_it != setpoint_checks.end()) {
@@ -297,11 +297,11 @@ RunFlowTrace(const VolumetricFlow *trace, size_t n, const VentParams &params,
     }
 
     if (desired_state.is_end_of_breath) {
-      results.finish_time = Hal.now() - start;
+      results.finish_time = hal.Now() - start;
       break;
     }
 
-    Hal.delay(trace_interval);
+    hal.Delay(trace_interval);
   }
 
   EXPECT_TRUE(check_it == setpoint_checks.end())

--- a/software/controller/test/checksum/checksum_test.cpp
+++ b/software/controller/test/checksum/checksum_test.cpp
@@ -10,36 +10,36 @@
 #include "gtest/gtest.h"
 
 TEST(Checksum, KnownValues) {
-  EXPECT_EQ(0, checksum_fletcher16(NULL, 0));
-  EXPECT_EQ(0, checksum_fletcher16("", 0));
-  EXPECT_EQ(24929, checksum_fletcher16("a", 1));
-  EXPECT_EQ(51440, checksum_fletcher16("abcde", 5));
-  EXPECT_EQ(8279, checksum_fletcher16("abcdef", 6));
-  EXPECT_EQ(1575, checksum_fletcher16("abcdefgh", 8));
-  EXPECT_EQ(0xfefe, checksum_fletcher16("\xff\xfe", 2));
+  EXPECT_EQ(0, ChecksumFletcher16(NULL, 0));
+  EXPECT_EQ(0, ChecksumFletcher16("", 0));
+  EXPECT_EQ(24929, ChecksumFletcher16("a", 1));
+  EXPECT_EQ(51440, ChecksumFletcher16("abcde", 5));
+  EXPECT_EQ(8279, ChecksumFletcher16("abcdef", 6));
+  EXPECT_EQ(1575, ChecksumFletcher16("abcdefgh", 8));
+  EXPECT_EQ(0xfefe, ChecksumFletcher16("\xff\xfe", 2));
 }
 
 TEST(Checksum32, KnownValues) {
-  EXPECT_EQ((uint32_t)0, soft_crc32(NULL, 0));
-  EXPECT_EQ((uint32_t)0, soft_crc32(reinterpret_cast<const uint8_t *>(""), 0));
+  EXPECT_EQ((uint32_t)0, SoftCRC32(NULL, 0));
+  EXPECT_EQ((uint32_t)0, SoftCRC32(reinterpret_cast<const uint8_t *>(""), 0));
   EXPECT_EQ((uint32_t)0xC808931C,
-            soft_crc32(reinterpret_cast<const uint8_t *>("a"), 1));
+            SoftCRC32(reinterpret_cast<const uint8_t *>("a"), 1));
   EXPECT_EQ((uint32_t)0x47A393F8,
-            soft_crc32(reinterpret_cast<const uint8_t *>("abcde"), 5));
+            SoftCRC32(reinterpret_cast<const uint8_t *>("abcde"), 5));
   EXPECT_EQ((uint32_t)0x9DBDD91C,
-            soft_crc32(reinterpret_cast<const uint8_t *>("abcdef"), 6));
+            SoftCRC32(reinterpret_cast<const uint8_t *>("abcdef"), 6));
   EXPECT_EQ((uint32_t)0x321FBEF4,
-            soft_crc32(reinterpret_cast<const uint8_t *>("abcdefgh"), 8));
+            SoftCRC32(reinterpret_cast<const uint8_t *>("abcdefgh"), 8));
 }
 
 TEST(Checksum, CheckBytes) {
-  uint16_t csum = checksum_fletcher16("abcde", 5);
+  uint16_t csum = ChecksumFletcher16("abcde", 5);
 
-  uint16_t checkBytes = check_bytes_fletcher16(csum);
+  uint16_t checkBytes = CheckBytesFletcher16(csum);
   char c0 = static_cast<char>(checkBytes >> 8);
   char c1 = static_cast<char>(checkBytes & 0xff);
-  csum = checksum_fletcher16(&c0, 1, csum);
-  csum = checksum_fletcher16(&c1, 1, csum);
+  csum = ChecksumFletcher16(&c0, 1, csum);
+  csum = ChecksumFletcher16(&c1, 1, csum);
   EXPECT_EQ(csum, 0);
 }
 
@@ -60,7 +60,7 @@ TEST(Checksum, BitFlips) {
   int32_t singleBitFlipCollisions = 0;
   std::map<uint16_t, uint32_t> collisions;
   for (int32_t i = 0; i < numTests; ++i) {
-    uint16_t checksum = checksum_fletcher16(data, sizeof(data));
+    uint16_t checksum = ChecksumFletcher16(data, sizeof(data));
     collisions[checksum]++;
     if (checksum == lastChecksum) {
       singleBitFlipCollisions++;
@@ -107,7 +107,7 @@ TEST(Checksum32, BitFlips) {
   int32_t singleBitFlipCollisions = 0;
   std::map<int32_t, int32_t> collisions;
   for (int32_t i = 0; i < numTests; ++i) {
-    uint32_t checksum = soft_crc32(data, sizeof(data));
+    uint32_t checksum = SoftCRC32(data, sizeof(data));
     collisions[checksum]++;
     if (checksum == lastChecksum) {
       singleBitFlipCollisions++;

--- a/software/controller/test/circ_buff/circ_buff_test.cpp
+++ b/software/controller/test/circ_buff/circ_buff_test.cpp
@@ -20,10 +20,10 @@ limitations under the License.
 
 // Test the buffer counts and rollover
 TEST(CircularBuffer, Counts) {
-  constexpr uint kBufferSize = 128;
-  CircularBuffer<uint8_t, kBufferSize> buff;
+  constexpr uint BufferSize = 128;
+  CircularBuffer<uint8_t, BufferSize> buff;
 
-  ASSERT_EQ(buff.FreeCount(), kBufferSize);
+  ASSERT_EQ(buff.FreeCount(), BufferSize);
   ASSERT_EQ(buff.FullCount(), 0);
 
   // Add/remove bytes from the buffer and check counts along the way.
@@ -32,7 +32,7 @@ TEST(CircularBuffer, Counts) {
   // that logic
   for (int i = 0; i < 100; i++) {
     int full = 0;
-    int free = kBufferSize;
+    int free = BufferSize;
     for (int j = 0; j < 20; j++) {
       // By putting j in the buffer, I can then check that it is stays a FIFO
       // even when it wraps around
@@ -60,25 +60,25 @@ TEST(CircularBuffer, Counts) {
 // Make sure the data we add to the buffer is the same
 // as the data we get out of it
 TEST(CircularBuffer, DataIO) {
-  constexpr uint kBufferSize = 256;
-  CircularBuffer<uint8_t, kBufferSize> buff;
+  constexpr uint BufferSize = 256;
+  CircularBuffer<uint8_t, BufferSize> buff;
 
-  uint8_t TestSet[kBufferSize + 20];
+  uint8_t TestSet[BufferSize + 20];
   for (uint32_t i = 0; i < sizeof(TestSet); i++)
     TestSet[i] = static_cast<uint8_t>(rand());
 
   // Add data to the buffer until failure - multiple failures should not affect
   // our test results: the buffer's content stays unchanged during failure to
   // put more data
-  for (int i = 0; i < kBufferSize + 20; i++) {
+  for (int i = 0; i < BufferSize + 20; i++) {
     bool ok = buff.Put(TestSet[i]);
-    if (i < kBufferSize) {
+    if (i < BufferSize) {
       ASSERT_EQ(ok, true);
       ASSERT_EQ(buff.FullCount(), i + 1);
-      ASSERT_EQ(buff.FreeCount(), kBufferSize - 1 - i);
+      ASSERT_EQ(buff.FreeCount(), BufferSize - 1 - i);
     } else {
       ASSERT_EQ(ok, false);
-      ASSERT_EQ(buff.FullCount(), kBufferSize);
+      ASSERT_EQ(buff.FullCount(), BufferSize);
       ASSERT_EQ(buff.FreeCount(), 0);
       break;
     }
@@ -86,18 +86,18 @@ TEST(CircularBuffer, DataIO) {
 
   // Retrieve all the data that was succesfully put in the buffer and check its
   // integrity
-  for (int i = 0; i < kBufferSize; i++) {
+  for (int i = 0; i < BufferSize; i++) {
     std::optional<uint8_t> x = buff.Get();
     ASSERT_EQ(*x, TestSet[i]);
   }
 
   // The buffer should be empty now
   ASSERT_EQ(buff.FullCount(), 0);
-  ASSERT_EQ(buff.FreeCount(), kBufferSize);
+  ASSERT_EQ(buff.FreeCount(), BufferSize);
   ASSERT_EQ(buff.Get(), std::nullopt);
   // failure to Get() has not changed anything
   ASSERT_EQ(buff.FullCount(), 0);
-  ASSERT_EQ(buff.FreeCount(), kBufferSize);
+  ASSERT_EQ(buff.FreeCount(), BufferSize);
   ASSERT_EQ(buff.Get(), std::nullopt);
 }
 
@@ -112,10 +112,10 @@ TEST(CircularBuffer, Size0) {
 }
 
 TEST(CircularBuffer, SmallBufferFullTest) {
-  constexpr uint kBufferSize = 5;
-  CircularBuffer<uint8_t, kBufferSize> buff;
+  constexpr uint BufferSize = 5;
+  CircularBuffer<uint8_t, BufferSize> buff;
   ASSERT_EQ(buff.FullCount(), 0);
-  ASSERT_EQ(buff.FreeCount(), kBufferSize);
+  ASSERT_EQ(buff.FreeCount(), BufferSize);
   ASSERT_EQ(buff.Get(), std::nullopt);
 
   // Put a first element in the buffer.  This allows the next part to be just
@@ -123,28 +123,28 @@ TEST(CircularBuffer, SmallBufferFullTest) {
   uint8_t elem = 0;
   ASSERT_EQ(buff.Put(elem++), true);
   ASSERT_EQ(buff.FullCount(), 1);
-  ASSERT_EQ(buff.FreeCount(), kBufferSize - 1);
+  ASSERT_EQ(buff.FreeCount(), BufferSize - 1);
 
   // This loop tests that for all configurations of a non-empty buffer,
   // we can put and get stuff as we want, and that stuff is properly handled.
-  for (int i = 0; i < kBufferSize + 1; i++) {
+  for (int i = 0; i < BufferSize + 1; i++) {
     // Fill the buffer and check the counts while we are at it.  Note there is
-    // already one elem in buffer so we only add kBufferSize - 1 new elements.
-    for (int j = 1; j < kBufferSize; j++) {
+    // already one elem in buffer so we only add BufferSize - 1 new elements.
+    for (int j = 1; j < BufferSize; j++) {
       ASSERT_EQ(buff.Put(elem++), true);
       ASSERT_EQ(buff.FullCount(), j + 1);
-      ASSERT_EQ(buff.FreeCount(), kBufferSize - j - 1);
+      ASSERT_EQ(buff.FreeCount(), BufferSize - j - 1);
     }
     // Buffer must now be full, we can't put any more data in.
     ASSERT_EQ(buff.Put(0), false);
     // Pop all but one element and check the counts.
     // Because we leave 1 element, the next loop will iterate
-    // with a different tail location: mod(tail - 1, kBufferSize).
-    for (int j = 1; j < kBufferSize; j++) {
+    // with a different tail location: mod(tail - 1, BufferSize).
+    for (int j = 1; j < BufferSize; j++) {
       std::optional<uint8_t> ch = buff.Get();
       ASSERT_EQ(*ch, static_cast<uint8_t>(
-                         elem - static_cast<uint8_t>(kBufferSize + 1 - j)));
-      ASSERT_EQ(buff.FullCount(), kBufferSize - j);
+                         elem - static_cast<uint8_t>(BufferSize + 1 - j)));
+      ASSERT_EQ(buff.FullCount(), BufferSize - j);
       ASSERT_EQ(buff.FreeCount(), j);
     }
   }
@@ -152,22 +152,22 @@ TEST(CircularBuffer, SmallBufferFullTest) {
   // Flush the buffer and go back to head=tail=0.
   buff.Flush();
   ASSERT_EQ(buff.FullCount(), 0);
-  ASSERT_EQ(buff.FreeCount(), kBufferSize);
+  ASSERT_EQ(buff.FreeCount(), BufferSize);
   ASSERT_EQ(buff.Get(), std::nullopt);
 
   // Fill in the gap left by the original loop to include empty buffers.
   for (int i = 0; i < 5; i++) {
     ASSERT_EQ(buff.Put(elem), true);
     ASSERT_EQ(buff.FullCount(), 1);
-    ASSERT_EQ(buff.FreeCount(), kBufferSize - 1);
+    ASSERT_EQ(buff.FreeCount(), BufferSize - 1);
     std::optional<uint8_t> ch = buff.Get();
     ASSERT_EQ(*ch, elem++);
     ASSERT_EQ(buff.FullCount(), 0);
-    ASSERT_EQ(buff.FreeCount(), kBufferSize);
+    ASSERT_EQ(buff.FreeCount(), BufferSize);
     // Trying to get an element from an empty buffer doesn't change anything,
     // whatever the head/tail
     ASSERT_EQ(buff.Get(), std::nullopt);
     ASSERT_EQ(buff.FullCount(), 0);
-    ASSERT_EQ(buff.FreeCount(), kBufferSize);
+    ASSERT_EQ(buff.FreeCount(), BufferSize);
   }
 }

--- a/software/controller/test/controller/controller_test.cpp
+++ b/software/controller/test/controller/controller_test.cpp
@@ -137,7 +137,7 @@ void actuatorsTestSequence(const std::vector<ActuatorsTest> &seq) {
     //  choose for now.
     return;
   }
-  constexpr float kValveStateTolerance{.001f};
+  constexpr float ValveStateTolerance{.001f};
 
   // Reset time to test's start time.
   hal.Delay(seq.front().time - hal.Now());
@@ -171,13 +171,13 @@ void actuatorsTestSequence(const std::vector<ActuatorsTest> &seq) {
     EXPECT_FLOAT_EQ(act_state.blower_power,
                     actuators_test.expected_state.blower_power);
     EXPECT_NEAR(act_state.fio2_valve, actuators_test.expected_state.fio2_valve,
-                kValveStateTolerance);
+                ValveStateTolerance);
     EXPECT_NEAR(act_state.blower_valve.value(),
                 actuators_test.expected_state.blower_valve.value(),
-                kValveStateTolerance);
+                ValveStateTolerance);
     EXPECT_NEAR(act_state.exhale_valve.value(),
                 actuators_test.expected_state.exhale_valve.value(),
-                kValveStateTolerance);
+                ValveStateTolerance);
     last_params = actuators_test.params;
     last_readings = actuators_test.readings;
   }
@@ -186,17 +186,17 @@ void actuatorsTestSequence(const std::vector<ActuatorsTest> &seq) {
 TEST(ControllerTest, ControlLaws) {
 
   // typical expected values
-  constexpr float kBlowerOn{1.0f};
-  constexpr float kBlowerOff{0};
-  constexpr float kValveOpen{1.0f};
-  constexpr float kAlmostClosed{0.05f};
-  constexpr float kValveClosed{0};
-  constexpr float kExhaleMaxOpen{0.6f};
+  constexpr float BlowerOn{1.0f};
+  constexpr float BlowerOff{0};
+  constexpr float ValveOpen{1.0f};
+  constexpr float AlmostClosed{0.05f};
+  constexpr float ValveClosed{0};
+  constexpr float ExhaleMaxOpen{0.6f};
   // typical 02 param/reading
-  constexpr float kAmbientAir{0.21f};
+  constexpr float AmbientAir{0.21f};
   // Very low pressure to make readings below desired PIP trigger a maximum
   // inflow with outlet valve closed or almost closed.
-  constexpr Pressure kVeryLowPressure{cmH2O(-500)};
+  constexpr Pressure VeryLowPressure{cmH2O(-500)};
 
   VentParams params = VentParams_init_zero;
   params.mode = VentMode::VentMode_PRESSURE_CONTROL;
@@ -205,7 +205,7 @@ TEST(ControllerTest, ControlLaws) {
   params.pip_cm_h2o = params.peep_cm_h2o;
   params.breaths_per_min = 15;
   params.inspiratory_expiratory_ratio = 1;
-  params.fio2 = kAmbientAir;
+  params.fio2 = AmbientAir;
 
   // Readings with patient pressure == Setpoint, should lead to inlet valve
   // almost closed and exhale valve in its max openness state.
@@ -213,7 +213,7 @@ TEST(ControllerTest, ControlLaws) {
       .patient_pressure = cmH2O(static_cast<float>(params.pip_cm_h2o)),
       .inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
-      .fio2 = kAmbientAir,
+      .fio2 = AmbientAir,
       .inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
@@ -223,10 +223,10 @@ TEST(ControllerTest, ControlLaws) {
   // (when using air) or fully closed (when using oxygen, in order not to waste
   // oxygen), whatever the controller gains and desired params are.
   SensorReadings readings_below_pip = {
-      .patient_pressure = kVeryLowPressure,
+      .patient_pressure = VeryLowPressure,
       .inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
-      .fio2 = kAmbientAir,
+      .fio2 = AmbientAir,
       .inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
@@ -235,42 +235,42 @@ TEST(ControllerTest, ControlLaws) {
   actuatorsTestSequence({{.time = microsSinceStartup(0),
                           .params = params,
                           .readings = readings_pip,
-                          .expected_state = {.fio2_valve = kValveClosed,
-                                             .blower_power = kBlowerOn,
-                                             .blower_valve = kAlmostClosed,
-                                             .exhale_valve = kExhaleMaxOpen}},
+                          .expected_state = {.fio2_valve = ValveClosed,
+                                             .blower_power = BlowerOn,
+                                             .blower_valve = AlmostClosed,
+                                             .exhale_valve = ExhaleMaxOpen}},
                          {.time = microsSinceStartup(1E6),
                           .params = params,
                           .readings = readings_below_pip,
-                          .expected_state = {.fio2_valve = kValveClosed,
-                                             .blower_power = kBlowerOn,
-                                             .blower_valve = kValveOpen,
-                                             .exhale_valve = kAlmostClosed}}});
+                          .expected_state = {.fio2_valve = ValveClosed,
+                                             .blower_power = BlowerOn,
+                                             .blower_valve = ValveOpen,
+                                             .exhale_valve = AlmostClosed}}});
 
   // pressure control oxygen test (same tests but with oxygen).
   params.fio2 = 1.0f;
   actuatorsTestSequence({{.time = microsSinceStartup(0),
                           .params = params,
                           .readings = readings_pip,
-                          .expected_state = {.fio2_valve = kAlmostClosed,
-                                             .blower_power = kBlowerOff,
-                                             .blower_valve = kValveClosed,
-                                             .exhale_valve = kExhaleMaxOpen}},
+                          .expected_state = {.fio2_valve = AlmostClosed,
+                                             .blower_power = BlowerOff,
+                                             .blower_valve = ValveClosed,
+                                             .exhale_valve = ExhaleMaxOpen}},
                          {.time = microsSinceStartup(1E6),
                           .params = params,
                           .readings = readings_below_pip,
-                          .expected_state = {.fio2_valve = kValveOpen,
-                                             .blower_power = kBlowerOff,
-                                             .blower_valve = kValveClosed,
-                                             .exhale_valve = kValveClosed}}});
+                          .expected_state = {.fio2_valve = ValveOpen,
+                                             .blower_power = BlowerOff,
+                                             .blower_valve = ValveClosed,
+                                             .exhale_valve = ValveClosed}}});
 
   // Off mode: blower is off, inhale valves are closed, exhale valve is open.
   params.mode = VentMode::VentMode_OFF;
   actuatorsTestSequence({{.time = microsSinceStartup(0),
                           .params = params,
                           .readings = readings_pip,
-                          .expected_state = {.fio2_valve = kValveClosed,
-                                             .blower_power = kBlowerOff,
-                                             .blower_valve = kValveClosed,
-                                             .exhale_valve = kValveOpen}}});
+                          .expected_state = {.fio2_valve = ValveClosed,
+                                             .blower_power = BlowerOff,
+                                             .blower_valve = ValveClosed,
+                                             .exhale_valve = ValveOpen}}});
 }

--- a/software/controller/test/controller/controller_test.cpp
+++ b/software/controller/test/controller/controller_test.cpp
@@ -140,7 +140,7 @@ void actuatorsTestSequence(const std::vector<ActuatorsTest> &seq) {
   constexpr float kValveStateTolerance{.001f};
 
   // Reset time to test's start time.
-  Hal.delay(seq.front().time - Hal.now());
+  hal.Delay(seq.front().time - hal.Now());
 
   Controller controller;
   VentParams last_params = VentParams_init_zero;
@@ -157,15 +157,15 @@ void actuatorsTestSequence(const std::vector<ActuatorsTest> &seq) {
 
     SCOPED_TRACE("time = " + actuators_test.time.microsSinceStartup() / 1000);
     // Move time forward to t in steps of Controller::GetLoopPeriod().
-    while (Hal.now() < actuators_test.time) {
-      Hal.delay(Controller::GetLoopPeriod());
-      (void)controller.Run(Hal.now(), last_params, last_readings);
+    while (hal.Now() < actuators_test.time) {
+      hal.Delay(Controller::GetLoopPeriod());
+      (void)controller.Run(hal.Now(), last_params, last_readings);
     }
     EXPECT_EQ(actuators_test.time.microsSinceStartup(),
-              Hal.now().microsSinceStartup());
+              hal.Now().microsSinceStartup());
 
     auto [act_state, unused_status] = controller.Run(
-        Hal.now(), actuators_test.params, actuators_test.readings);
+        hal.Now(), actuators_test.params, actuators_test.readings);
     (void)unused_status;
 
     EXPECT_FLOAT_EQ(act_state.blower_power,

--- a/software/controller/test/debug/eeprom_cmd_test.cpp
+++ b/software/controller/test/debug/eeprom_cmd_test.cpp
@@ -34,7 +34,7 @@ TEST(EepromHandler, ValidRead) {
   for (uint16_t read_length = 1; read_length <= kMaxRequestSize;
        ++read_length) {
     std::array<uint8_t, 6> read_command = {
-        static_cast<uint8_t>(EepromHandler::Subcommand::kRead)};
+        static_cast<uint8_t>(EepromHandler::Subcommand::Read)};
     // set command length
     u16_to_u8(read_length, &read_command[3]);
     for (uint16_t offset = 0; offset < kMemorySize + 1 - read_length;
@@ -51,7 +51,7 @@ TEST(EepromHandler, ValidRead) {
           .response_length = 0,
           .processed = &processed,
       };
-      EXPECT_EQ(ErrorCode::kNone, eeprom_handler.Process(&read_context));
+      EXPECT_EQ(ErrorCode::None, eeprom_handler.Process(&read_context));
       EXPECT_EQ(read_context.response_length, read_length);
       EXPECT_TRUE(processed);
 
@@ -74,7 +74,7 @@ TEST(EepromHandler, ValidWrite) {
   for (uint16_t write_length = 1; write_length <= kMaxWriteSize;
        ++write_length) {
     std::array<uint8_t, kMaxWriteSize + 3> write_command = {
-        static_cast<uint8_t>(EepromHandler::Subcommand::kWrite)};
+        static_cast<uint8_t>(EepromHandler::Subcommand::Write)};
     for (uint16_t offset = 0; offset < kMemorySize + 1 - write_length;
          ++offset) {
       // set command address
@@ -94,7 +94,7 @@ TEST(EepromHandler, ValidWrite) {
           .response_length = 0,
           .processed = &processed,
       };
-      EXPECT_EQ(ErrorCode::kNone, eeprom_handler.Process(&write_context));
+      EXPECT_EQ(ErrorCode::None, eeprom_handler.Process(&write_context));
       EXPECT_EQ(write_context.response_length, 0);
       EXPECT_TRUE(processed);
 
@@ -118,13 +118,13 @@ TEST(EepromHandler, Errors) {
   long_write[0] = 1;
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::kMissingData},           // Missing subcommand
-      {{0, 0, 0, 4, 0}, ErrorCode::kNoMemory}, // length > max response length
-      {{0, 0, 0, 0}, ErrorCode::kMissingData}, // Read missing length
-      {{1, 0, 0}, ErrorCode::kMissingData},    // Write missing data
-      {{1, 0xFF, 0xFF, 0}, ErrorCode::kInternalError}, // Write outside eeprom
-      {long_write, ErrorCode::kNoMemory},   // Write more than 1024 bytes
-      {{2, 0, 0}, ErrorCode::kInvalidData}, // Invalid subcommand
+      {{}, ErrorCode::MissingData},           // Missing subcommand
+      {{0, 0, 0, 4, 0}, ErrorCode::NoMemory}, // length > max response length
+      {{0, 0, 0, 0}, ErrorCode::MissingData}, // Read missing length
+      {{1, 0, 0}, ErrorCode::MissingData},    // Write missing data
+      {{1, 0xFF, 0xFF, 0}, ErrorCode::InternalError}, // Write outside eeprom
+      {long_write, ErrorCode::NoMemory},   // Write more than 1024 bytes
+      {{2, 0, 0}, ErrorCode::InvalidData}, // Invalid subcommand
   };
 
   for (auto &[request, error] : requests) {

--- a/software/controller/test/debug/interface_test.cpp
+++ b/software/controller/test/debug/interface_test.cpp
@@ -76,15 +76,15 @@ std::vector<uint8_t> ProcessCmd(Interface *serial, std::vector<uint8_t> req,
   full_req.push_back(crc_bytes[1]);
   full_req.push_back(static_cast<uint8_t>(SpecialChar::kEndTransfer));
 
-  Hal.test_debugPutIncomingData(reinterpret_cast<const char *>(full_req.data()),
-                                static_cast<uint16_t>(full_req.size()));
+  hal.TESTDebugPutIncomingData(reinterpret_cast<const char *>(full_req.data()),
+                               static_cast<uint16_t>(full_req.size()));
   for (int i = 0; i < 100 && !serial->Poll(); ++i) {
     // Wait for command to complete, advance sim time to allow timeout
-    Hal.delay(milliseconds(10));
+    hal.Delay(milliseconds(10));
   }
 
   std::vector<uint8_t> escaped_resp(500);
-  uint16_t resp_len = Hal.test_debugGetOutgoingData(
+  uint16_t resp_len = hal.TESTDebugGetOutgoingData(
       reinterpret_cast<char *>(escaped_resp.data()),
       static_cast<uint16_t>(escaped_resp.size()));
   escaped_resp.erase(escaped_resp.begin() + resp_len, escaped_resp.end());
@@ -222,14 +222,14 @@ TEST(Interface, Errors) {
   // Command too short - we can't use the helper function for this as it adds
   // all the necessary data
   req = {1, 0, static_cast<uint8_t>(SpecialChar::kEndTransfer)};
-  Hal.test_debugPutIncomingData(reinterpret_cast<const char *>(req.data()),
-                                static_cast<uint16_t>(req.size()));
+  hal.TESTDebugPutIncomingData(reinterpret_cast<const char *>(req.data()),
+                               static_cast<uint16_t>(req.size()));
   for (int i = 0; i < 5 && !serial.Poll(); ++i) {
     // Wait for command to complete
   }
   // In that case, we actually expect no response
   uint16_t resp_len =
-      Hal.test_debugGetOutgoingData(reinterpret_cast<char *>(resp.data()), 10);
+      hal.TESTDebugGetOutgoingData(reinterpret_cast<char *>(resp.data()), 10);
   EXPECT_EQ(resp_len, 0);
 }
 } // namespace Debug

--- a/software/controller/test/debug/interface_test.cpp
+++ b/software/controller/test/debug/interface_test.cpp
@@ -28,9 +28,9 @@ namespace Debug {
 std::vector<uint8_t> Escape(const std::vector<uint8_t> &data) {
   std::vector<uint8_t> res;
   for (uint8_t ch : data) {
-    if ((ch == static_cast<uint8_t>(SpecialChar::kEndTransfer)) ||
-        (ch == static_cast<uint8_t>(SpecialChar::kEscape))) {
-      res.push_back(static_cast<char>(SpecialChar::kEscape));
+    if ((ch == static_cast<uint8_t>(SpecialChar::EndTransfer)) ||
+        (ch == static_cast<uint8_t>(SpecialChar::Escape))) {
+      res.push_back(static_cast<char>(SpecialChar::Escape));
     }
     res.push_back(ch);
   }
@@ -46,7 +46,7 @@ std::vector<uint8_t> Unescape(const std::vector<uint8_t> &data) {
       escape_next_byte = false;
       continue;
     }
-    if (ch == static_cast<uint8_t>(SpecialChar::kEscape)) {
+    if (ch == static_cast<uint8_t>(SpecialChar::Escape)) {
       escape_next_byte = true;
       continue;
     }
@@ -60,11 +60,11 @@ std::vector<uint8_t> Unescape(const std::vector<uint8_t> &data) {
 // Returns the unframed command response payload, i.e. unescaped,
 // without the error code and crc.
 std::vector<uint8_t> ProcessCmd(Interface *serial, std::vector<uint8_t> req,
-                                ErrorCode expected_error = ErrorCode::kNone,
+                                ErrorCode expected_error = ErrorCode::None,
                                 uint16_t crc_offset = 0) {
   std::vector<uint8_t> full_req;
   full_req.reserve(/*ESC*/ 1 + req.size() + /*CRC*/ 2 + /*TERM*/ 1);
-  full_req.push_back(static_cast<uint8_t>(SpecialChar::kEscape));
+  full_req.push_back(static_cast<uint8_t>(SpecialChar::Escape));
   for (uint8_t ch : Escape(req)) {
     full_req.push_back(ch);
   }
@@ -74,7 +74,7 @@ std::vector<uint8_t> ProcessCmd(Interface *serial, std::vector<uint8_t> req,
   u16_to_u8(crc, &crc_bytes[0]);
   full_req.push_back(crc_bytes[0]);
   full_req.push_back(crc_bytes[1]);
-  full_req.push_back(static_cast<uint8_t>(SpecialChar::kEndTransfer));
+  full_req.push_back(static_cast<uint8_t>(SpecialChar::EndTransfer));
 
   hal.TESTDebugPutIncomingData(reinterpret_cast<const char *>(full_req.data()),
                                static_cast<uint16_t>(full_req.size()));
@@ -93,7 +93,7 @@ std::vector<uint8_t> ProcessCmd(Interface *serial, std::vector<uint8_t> req,
   // Unescape response
   std::vector<uint8_t> resp = Unescape(escaped_resp);
   EXPECT_GE(resp.size(), size_t{3} /* err code + crc */);
-  EXPECT_EQ(static_cast<uint8_t>(SpecialChar::kEndTransfer), resp.back());
+  EXPECT_EQ(static_cast<uint8_t>(SpecialChar::EndTransfer), resp.back());
   resp.pop_back();
 
   // Verify error code and CRC
@@ -117,9 +117,9 @@ std::vector<uint8_t> ProcessCmd(Interface *serial, std::vector<uint8_t> req,
 TEST(Interface, Mode) {
   Trace trace;
   Command::ModeHandler mode_command;
-  Interface serial(&trace, 2, Command::Code::kMode, &mode_command);
+  Interface serial(&trace, 2, Command::Code::Mode, &mode_command);
 
-  std::vector<uint8_t> req = {static_cast<uint8_t>(Command::Code::kMode)};
+  std::vector<uint8_t> req = {static_cast<uint8_t>(Command::Code::Mode)};
   std::vector<uint8_t> resp = ProcessCmd(&serial, req);
   EXPECT_THAT(resp, testing::ElementsAre(static_cast<uint8_t>(0)));
 }
@@ -129,9 +129,9 @@ uint32_t GetVarViaCmd(Interface *serial, uint16_t id) {
   u16_to_u8(id, &vid[0]);
 
   std::vector<uint8_t> req = {
-      static_cast<uint8_t>(Command::Code::kVariable), // Cmd code
-      uint8_t{1},                                     // GET
-      vid[0], vid[1],                                 // var id
+      static_cast<uint8_t>(Command::Code::Variable), // Cmd code
+      uint8_t{1},                                    // GET
+      vid[0], vid[1],                                // var id
   };
 
   std::vector<uint8_t> resp = ProcessCmd(serial, req);
@@ -146,7 +146,7 @@ TEST(Interface, GetVar) {
 
   Trace trace;
   Command::VarHandler var_command;
-  Interface serial(&trace, 2, Command::Code::kVariable, &var_command);
+  Interface serial(&trace, 2, Command::Code::Variable, &var_command);
   // Run a bunch of times with different expected results
   // to exercise buffer management.
   for (int i = 0; i < 100; ++i, ++foo, ++bar) {
@@ -159,10 +159,10 @@ TEST(Interface, AwaitingResponseState) {
   Trace trace;
   TestEeprom eeprom_test(0x50, 64, 4096);
   Command::EepromHandler eeprom_command(&eeprom_test);
-  Interface serial(&trace, 2, Command::Code::kEepromAccess, &eeprom_command);
+  Interface serial(&trace, 2, Command::Code::EepromAccess, &eeprom_command);
   // EEPROM read command needs time to be processed
   std::vector<uint8_t> req = {
-      static_cast<uint8_t>(Command::Code::kEepromAccess),
+      static_cast<uint8_t>(Command::Code::EepromAccess),
       0, // Read subcommand
       0, // address Least Significant Byte
       0, // address Most Significant Byte
@@ -172,14 +172,14 @@ TEST(Interface, AwaitingResponseState) {
 
   // The helper function quietly passes through the AwaitingResponse state since
   // the test EEPROM sets processed to true immediately if the address is valid.
-  std::vector<uint8_t> resp = ProcessCmd(&serial, req, ErrorCode::kNone);
+  std::vector<uint8_t> resp = ProcessCmd(&serial, req, ErrorCode::None);
   EXPECT_EQ(resp.size(), 1);
 
   // Requesting outside of memory leads to a timeout (test eeprom never sets
   // processed to true)
   req[3] = 0xFF;
   req[4] = 0xFF;
-  resp = ProcessCmd(&serial, req, ErrorCode::kTimeout);
+  resp = ProcessCmd(&serial, req, ErrorCode::Timeout);
   EXPECT_EQ(resp.size(), 0);
 }
 
@@ -193,35 +193,35 @@ TEST(Interface, Errors) {
   Command::TraceHandler trace_command(&trace);
   Command::EepromHandler eeprom_command(&eeprom_test);
 
-  Debug::Interface serial(
-      &trace, 12, Debug::Command::Code::kMode, &mode_command,
-      Debug::Command::Code::kPeek, &peek_command, Debug::Command::Code::kPoke,
-      &poke_command, Debug::Command::Code::kVariable, &var_command,
-      Debug::Command::Code::kTrace, &trace_command,
-      Debug::Command::Code::kEepromAccess, &eeprom_command);
+  Debug::Interface serial(&trace, 12, Debug::Command::Code::Mode, &mode_command,
+                          Debug::Command::Code::Peek, &peek_command,
+                          Debug::Command::Code::Poke, &poke_command,
+                          Debug::Command::Code::Variable, &var_command,
+                          Debug::Command::Code::Trace, &trace_command,
+                          Debug::Command::Code::EepromAccess, &eeprom_command);
   // Unknown command - If we ever develop new commands, make sure the command
   // code is too big.
   std::vector<uint8_t> req = {25};
   std::vector<uint8_t> resp =
-      ProcessCmd(&serial, req, ErrorCode::kUnknownCommand);
+      ProcessCmd(&serial, req, ErrorCode::UnknownCommand);
   EXPECT_EQ(resp.size(), 0);
 
   // CRC Error
   req = {25};
-  resp = ProcessCmd(&serial, req, ErrorCode::kCrcError, 1);
+  resp = ProcessCmd(&serial, req, ErrorCode::CrcError, 1);
   EXPECT_EQ(resp.size(), 0);
 
   // Error returned by Command Handler
   req = {
-      static_cast<uint8_t>(Command::Code::kVariable), // Cmd code
-      1, 0xFF, 0xFF,                                  // GET and var id
+      static_cast<uint8_t>(Command::Code::Variable), // Cmd code
+      1, 0xFF, 0xFF,                                 // GET and var id
   };
-  resp = ProcessCmd(&serial, req, ErrorCode::kUnknownVariable);
+  resp = ProcessCmd(&serial, req, ErrorCode::UnknownVariable);
   EXPECT_EQ(resp.size(), 0);
 
   // Command too short - we can't use the helper function for this as it adds
   // all the necessary data
-  req = {1, 0, static_cast<uint8_t>(SpecialChar::kEndTransfer)};
+  req = {1, 0, static_cast<uint8_t>(SpecialChar::EndTransfer)};
   hal.TESTDebugPutIncomingData(reinterpret_cast<const char *>(req.data()),
                                static_cast<uint16_t>(req.size()));
   for (int i = 0; i < 5 && !serial.Poll(); ++i) {

--- a/software/controller/test/debug/peek_cmd_test.cpp
+++ b/software/controller/test/debug/peek_cmd_test.cpp
@@ -52,7 +52,7 @@ TEST(PeekHandler, valid_peek) {
                               .max_response_length = std::size(response),
                               .response_length = 0,
                               .processed = &processed};
-      EXPECT_EQ(ErrorCode::kNone, peek_handler.Process(&peek_context));
+      EXPECT_EQ(ErrorCode::None, peek_handler.Process(&peek_context));
       EXPECT_TRUE(processed);
       EXPECT_EQ(
           peek_context.response_length,
@@ -75,7 +75,7 @@ TEST(PeekHandler, errors) {
                           .max_response_length = std::size(response),
                           .response_length = 0,
                           .processed = &processed};
-  EXPECT_EQ(ErrorCode::kMissingData, PeekHandler().Process(&peek_context));
+  EXPECT_EQ(ErrorCode::MissingData, PeekHandler().Process(&peek_context));
   EXPECT_FALSE(processed);
 }
 

--- a/software/controller/test/debug/poke_cmd_test.cpp
+++ b/software/controller/test/debug/poke_cmd_test.cpp
@@ -52,7 +52,7 @@ TEST(PokeHandler, valid_poke) {
                               .max_response_length = std::size(response),
                               .response_length = 0,
                               .processed = &processed};
-      EXPECT_EQ(ErrorCode::kNone, poke_handler.Process(&poke_context));
+      EXPECT_EQ(ErrorCode::None, poke_handler.Process(&poke_context));
       EXPECT_TRUE(processed);
       EXPECT_EQ(poke_context.response_length, 0);
       for (size_t offset = 0; offset < poke_length; ++offset) {
@@ -72,7 +72,7 @@ TEST(PokeHandler, errors) {
                           .max_response_length = std::size(response),
                           .response_length = 0,
                           .processed = &processed};
-  EXPECT_EQ(ErrorCode::kMissingData, PokeHandler().Process(&poke_context));
+  EXPECT_EQ(ErrorCode::MissingData, PokeHandler().Process(&poke_context));
   EXPECT_FALSE(processed);
 }
 } // namespace Debug::Command

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -41,10 +41,10 @@ TEST(TraceHandler, Flush) {
   // define some debug variables
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::kUInt32, "x", "", "", [&] { return i; },
+      VarType::UInt32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::kUInt32, "x", "", "", [&] { return i * 10; },
+      VarType::UInt32, "x", "", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler
@@ -61,7 +61,7 @@ TEST(TraceHandler, Flush) {
   EXPECT_TRUE(trace.GetStatus());
 
   std::array flush_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kFlush)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::Flush)};
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
   Context flush_context = {.request = flush_command.data(),
@@ -70,7 +70,7 @@ TEST(TraceHandler, Flush) {
                            .max_response_length = std::size(response),
                            .response_length = 0,
                            .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&flush_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&flush_context));
   EXPECT_TRUE(processed);
   EXPECT_FALSE(trace.GetStatus());
 
@@ -85,10 +85,10 @@ TEST(TraceHandler, Read) {
   // define some debug variables
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::kUInt32, "x", "", "", [&] { return i; },
+      VarType::UInt32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::kUInt32, "y", "", "", [&] { return i * 10; },
+      VarType::UInt32, "y", "", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler
@@ -97,7 +97,7 @@ TEST(TraceHandler, Read) {
 
   // read with no vars ==> nothing to report
   std::array read_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kDownload)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::Download)};
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
   Context read_context = {.request = read_command.data(),
@@ -106,7 +106,7 @@ TEST(TraceHandler, Read) {
                           .max_response_length = kResponseSize,
                           .response_length = 0,
                           .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&read_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(read_context.response_length, 0);
 
@@ -115,7 +115,7 @@ TEST(TraceHandler, Read) {
 
   // start the trace (using debug command)
   std::array start_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kStart)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::Start)};
   processed = false;
   Context start_context = {.request = start_command.data(),
                            .request_length = std::size(start_command),
@@ -123,13 +123,13 @@ TEST(TraceHandler, Read) {
                            .max_response_length = kResponseSize,
                            .response_length = 0,
                            .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&start_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&start_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(start_context.response_length, 0);
   EXPECT_EQ(trace.GetStatus(), 1);
 
   // trace with no samples (tracing active) ==> nothing to report
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&read_context));
   EXPECT_EQ(read_context.response_length, 0);
 
   // fill the buffer to a bigger size than the max response length
@@ -142,7 +142,7 @@ TEST(TraceHandler, Read) {
 
   // Take advantage of having a full buffer to test CountSamples command
   std::array num_samples_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kCountSamples)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::CountSamples)};
   processed = false;
   Context num_samples_context = {.request = num_samples_command.data(),
                                  .request_length =
@@ -151,13 +151,13 @@ TEST(TraceHandler, Read) {
                                  .max_response_length = kResponseSize,
                                  .response_length = 0,
                                  .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&num_samples_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&num_samples_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(num_samples_context.response_length, 4);
   EXPECT_EQ(trace.GetNumSamples(), u8_to_u32(response.data()));
 
   // issue a new read command
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&read_context));
   // we are only returning entire samples
   EXPECT_EQ(read_context.response_length,
             kResponseSize - kResponseSize % sample_size);
@@ -168,7 +168,7 @@ TEST(TraceHandler, Read) {
   // reset response pointer and response_length before issuing a new read
   read_context.response = response.data();
   read_context.response_length = 0;
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&read_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&read_context));
   EXPECT_EQ(read_context.response_length, kExtraSamples * sample_size);
   // check response
   CheckBufferOutput(response, read_context.response_length, sample_size,
@@ -190,7 +190,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Set trace var ID for var 1
   std::array<uint8_t, 4> set_var1_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kSetVarId), 1, 0, 0};
+      static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), 1, 0, 0};
   u16_to_u8(var_y.GetId(), &set_var1_command[2]);
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
@@ -200,7 +200,7 @@ TEST(TraceHandler, SettersAndGetters) {
                               .max_response_length = kResponseSize,
                               .response_length = 0,
                               .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&set_var1_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&set_var1_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(set_var1_context.response_length, 0);
   // check that the trace now points to desired var
@@ -208,7 +208,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace var ID for var 1
   std::array<uint8_t, 2> get_var1_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId), 1};
+      static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId), 1};
   processed = false;
   Context get_var1_context = {.request = get_var1_command.data(),
                               .request_length = std::size(get_var1_command),
@@ -216,7 +216,7 @@ TEST(TraceHandler, SettersAndGetters) {
                               .max_response_length = kResponseSize,
                               .response_length = 0,
                               .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_var1_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&get_var1_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(get_var1_context.response_length, 2);
 
@@ -224,7 +224,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace var ID for var 2 (un-associated)
   std::array<uint8_t, 2> get_var2_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId), 2};
+      static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId), 2};
   processed = false;
   Context get_var2_context = {.request = get_var2_command.data(),
                               .request_length = std::size(get_var2_command),
@@ -232,7 +232,7 @@ TEST(TraceHandler, SettersAndGetters) {
                               .max_response_length = kResponseSize,
                               .response_length = 0,
                               .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_var2_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&get_var2_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(get_var2_context.response_length, 2);
 
@@ -240,7 +240,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace var ID for var kMaxTraceVars (out of bounds)
   std::array<uint8_t, 2> get_var_max_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId),
+      static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId),
       static_cast<uint8_t>(kMaxTraceVars)};
   processed = false;
   Context get_var_max_context = {.request = get_var_max_command.data(),
@@ -250,14 +250,14 @@ TEST(TraceHandler, SettersAndGetters) {
                                  .max_response_length = kResponseSize,
                                  .response_length = 0,
                                  .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_var_max_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&get_var_max_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(get_var_max_context.response_length, 2);
   EXPECT_EQ(uint16_t(-1), u8_to_u16(response.data()));
 
   // Set trace period
   std::array<uint8_t, 5> set_period_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kSetPeriod)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::SetPeriod)};
   u32_to_u8(2, &set_period_command[1]);
   processed = false;
   Context set_period_context = {.request = set_period_command.data(),
@@ -266,7 +266,7 @@ TEST(TraceHandler, SettersAndGetters) {
                                 .max_response_length = kResponseSize,
                                 .response_length = 0,
                                 .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&set_period_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&set_period_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(set_period_context.response_length, 0);
 
@@ -274,7 +274,7 @@ TEST(TraceHandler, SettersAndGetters) {
 
   // Get trace period
   std::array get_period_command = {
-      static_cast<uint8_t>(TraceHandler::Subcommand::kGetPeriod)};
+      static_cast<uint8_t>(TraceHandler::Subcommand::GetPeriod)};
   processed = false;
   Context get_period_context = {.request = get_period_command.data(),
                                 .request_length = std::size(get_period_command),
@@ -282,7 +282,7 @@ TEST(TraceHandler, SettersAndGetters) {
                                 .max_response_length = kResponseSize,
                                 .response_length = 0,
                                 .processed = &processed};
-  EXPECT_EQ(ErrorCode::kNone, trace_handler.Process(&get_period_context));
+  EXPECT_EQ(ErrorCode::None, trace_handler.Process(&get_period_context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(get_period_context.response_length, 4);
 
@@ -303,25 +303,25 @@ TEST(TraceHandler, Errors) {
   trace.Start();
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::kMissingData},  // Missing subcommand
-      {{8}, ErrorCode::kInvalidData}, // Invalid subcommand
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kDownload)},
-       ErrorCode::kNoMemory},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kSetVarId), 1, 1},
-       ErrorCode::kMissingData},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kSetVarId),
-        kMaxTraceVars, 1, 0},
-       ErrorCode::kInvalidData},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId)},
-       ErrorCode::kMissingData},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kGetVarId), 1},
-       ErrorCode::kNoMemory},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kSetPeriod), 1, 1, 1},
-       ErrorCode::kMissingData},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kGetPeriod)},
-       ErrorCode::kNoMemory},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::kCountSamples)},
-       ErrorCode::kNoMemory},
+      {{}, ErrorCode::MissingData},  // Missing subcommand
+      {{8}, ErrorCode::InvalidData}, // Invalid subcommand
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::Download)},
+       ErrorCode::NoMemory},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), 1, 1},
+       ErrorCode::MissingData},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), kMaxTraceVars,
+        1, 0},
+       ErrorCode::InvalidData},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId)},
+       ErrorCode::MissingData},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId), 1},
+       ErrorCode::NoMemory},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetPeriod), 1, 1, 1},
+       ErrorCode::MissingData},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::GetPeriod)},
+       ErrorCode::NoMemory},
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::CountSamples)},
+       ErrorCode::NoMemory},
   };
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -41,10 +41,10 @@ TEST(TraceHandler, Flush) {
   // define some debug variables
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::UINT32, "x", "", "", [&] { return i; },
+      VarType::kUInt32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UINT32, "x", "", "", [&] { return i * 10; },
+      VarType::kUInt32, "x", "", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler
@@ -85,10 +85,10 @@ TEST(TraceHandler, Read) {
   // define some debug variables
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::UINT32, "x", "", "", [&] { return i; },
+      VarType::kUInt32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UINT32, "y", "", "", [&] { return i * 10; },
+      VarType::kUInt32, "y", "", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -241,7 +241,7 @@ TEST(TraceHandler, SettersAndGetters) {
   // Get trace var ID for var kMaxTraceVars (out of bounds)
   std::array<uint8_t, 2> get_var_max_command = {
       static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId),
-      static_cast<uint8_t>(kMaxTraceVars)};
+      static_cast<uint8_t>(MaxTraceVars)};
   processed = false;
   Context get_var_max_context = {.request = get_var_max_command.data(),
                                  .request_length =
@@ -309,7 +309,7 @@ TEST(TraceHandler, Errors) {
        ErrorCode::NoMemory},
       {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), 1, 1},
        ErrorCode::MissingData},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), kMaxTraceVars,
+      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), MaxTraceVars,
         1, 0},
        ErrorCode::InvalidData},
       {{static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId)},

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -25,10 +25,10 @@ using namespace Debug;
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::UINT32, "x", "", "", [&] { return i; },
+      VarType::kUInt32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UINT32, "y", "", "", [&] { return 10 * i; },
+      VarType::kUInt32, "y", "", "", [&] { return 10 * i; },
       [&](uint32_t value) { (void)value; });
 
   Trace trace;

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -25,10 +25,10 @@ using namespace Debug;
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::kUInt32, "x", "", "", [&] { return i; },
+      VarType::UInt32, "x", "", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::kUInt32, "y", "", "", [&] { return 10 * i; },
+      VarType::UInt32, "y", "", "", [&] { return 10 * i; },
       [&](uint32_t value) { (void)value; });
 
   Trace trace;

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -29,7 +29,7 @@ TEST(VarHandler, GetVarInfo) {
   DebugVar var(name, &value, help, format);
 
   // expected result is hand-built from format given in var_cmd.cpp
-  std::vector<uint8_t> expected = {static_cast<uint8_t>(VarType::UINT32),
+  std::vector<uint8_t> expected = {static_cast<uint8_t>(VarType::kUInt32),
                                    0,
                                    0,
                                    0,

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -29,7 +29,7 @@ TEST(VarHandler, GetVarInfo) {
   DebugVar var(name, &value, help, format);
 
   // expected result is hand-built from format given in var_cmd.cpp
-  std::vector<uint8_t> expected = {static_cast<uint8_t>(VarType::kUInt32),
+  std::vector<uint8_t> expected = {static_cast<uint8_t>(VarType::UInt32),
                                    0,
                                    0,
                                    0,
@@ -47,7 +47,7 @@ TEST(VarHandler, GetVarInfo) {
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
-      static_cast<uint8_t>(VarHandler::Subcommand::kGetInfo), id[0],
+      static_cast<uint8_t>(VarHandler::Subcommand::GetInfo), id[0],
       id[1], // Var id
   };
   std::array<uint8_t, 50> response;
@@ -59,7 +59,7 @@ TEST(VarHandler, GetVarInfo) {
                      .response_length = 0,
                      .processed = &processed};
 
-  EXPECT_EQ(ErrorCode::kNone, VarHandler().Process(&context));
+  EXPECT_EQ(ErrorCode::None, VarHandler().Process(&context));
   EXPECT_TRUE(processed);
   for (size_t i = 0; i < expected.size(); ++i) {
     EXPECT_EQ(context.response[i], expected[i]);
@@ -74,7 +74,7 @@ TEST(VarHandler, GetVar) {
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
-      static_cast<uint8_t>(VarHandler::Subcommand::kGet), id[0],
+      static_cast<uint8_t>(VarHandler::Subcommand::Get), id[0],
       id[1], // Var id
   };
   std::array<uint8_t, 4> response;
@@ -86,7 +86,7 @@ TEST(VarHandler, GetVar) {
                      .response_length = 0,
                      .processed = &processed};
 
-  EXPECT_EQ(ErrorCode::kNone, VarHandler().Process(&context));
+  EXPECT_EQ(ErrorCode::None, VarHandler().Process(&context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(4, context.response_length);
 
@@ -107,7 +107,7 @@ TEST(VarHandler, SetVar) {
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
-      static_cast<uint8_t>(VarHandler::Subcommand::kSet),
+      static_cast<uint8_t>(VarHandler::Subcommand::Set),
       id[0],
       id[1], // Var id
       new_bytes[0],
@@ -125,7 +125,7 @@ TEST(VarHandler, SetVar) {
                      .response_length = 0,
                      .processed = &processed};
 
-  EXPECT_EQ(ErrorCode::kNone, VarHandler().Process(&context));
+  EXPECT_EQ(ErrorCode::None, VarHandler().Process(&context));
   EXPECT_TRUE(processed);
   EXPECT_EQ(0, context.response_length);
 
@@ -139,17 +139,17 @@ TEST(VarHandler, Errors) {
   u16_to_u8(var.GetId(), id);
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::kMissingData},  // Missing subcommand
-      {{3}, ErrorCode::kInvalidData}, // Invalid subcommand
-      {{0, 0xFF, 0xFF}, ErrorCode::kUnknownVariable},
-      {{1, 0xFF, 0xFF}, ErrorCode::kUnknownVariable},
-      {{2, 0xFF, 0xFF}, ErrorCode::kUnknownVariable},
-      {{0, 1}, ErrorCode::kMissingData},
-      {{1, 1}, ErrorCode::kMissingData},
-      {{2, 1}, ErrorCode::kMissingData},
-      {{0, id[0], id[1]}, ErrorCode::kNoMemory},
-      {{1, id[0], id[1]}, ErrorCode::kNoMemory},
-      {{2, id[0], id[1], 0xCA, 0xFE, 0x00}, ErrorCode::kMissingData},
+      {{}, ErrorCode::MissingData},  // Missing subcommand
+      {{3}, ErrorCode::InvalidData}, // Invalid subcommand
+      {{0, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
+      {{1, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
+      {{2, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
+      {{0, 1}, ErrorCode::MissingData},
+      {{1, 1}, ErrorCode::MissingData},
+      {{2, 1}, ErrorCode::MissingData},
+      {{0, id[0], id[1]}, ErrorCode::NoMemory},
+      {{1, id[0], id[1]}, ErrorCode::NoMemory},
+      {{2, id[0], id[1], 0xCA, 0xFE, 0x00}, ErrorCode::MissingData},
   };
 
   for (auto &[request, error] : requests) {

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -23,7 +23,7 @@ TEST(DebugVar, DebugVarInt32) {
   DebugVar var("var", &value, "help", "fmt");
   EXPECT_EQ("var", var.GetName());
   EXPECT_EQ("help", var.GetHelp());
-  EXPECT_EQ(VarType::kInt32, var.GetType());
+  EXPECT_EQ(VarType::Int32, var.GetType());
   EXPECT_EQ("fmt", var.GetFormat());
   EXPECT_EQ(&var, DebugVar::FindVar(var.GetId()));
 
@@ -51,7 +51,7 @@ TEST(DebugVar, DebugVarUint32Defaults) {
   EXPECT_EQ(uint32_t{5}, var.GetValue());
   EXPECT_EQ("", var.GetHelp());
   EXPECT_EQ("%u", var.GetFormat());
-  EXPECT_EQ(VarType::kUInt32, var.GetType());
+  EXPECT_EQ(VarType::UInt32, var.GetType());
 }
 
 TEST(DebugVar, DebugVarFloatDefaults) {
@@ -61,7 +61,7 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 
   EXPECT_EQ("", var.GetHelp());
   EXPECT_EQ("%.3f", var.GetFormat());
-  EXPECT_EQ(VarType::kFloat, var.GetType());
+  EXPECT_EQ(VarType::Float, var.GetType());
 
   // Rountrip through uint32 should not change value.
   uint32_t uint_value = var.GetValue();

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -23,7 +23,7 @@ TEST(DebugVar, DebugVarInt32) {
   DebugVar var("var", &value, "help", "fmt");
   EXPECT_EQ("var", var.GetName());
   EXPECT_EQ("help", var.GetHelp());
-  EXPECT_EQ(VarType::INT32, var.GetType());
+  EXPECT_EQ(VarType::kInt32, var.GetType());
   EXPECT_EQ("fmt", var.GetFormat());
   EXPECT_EQ(&var, DebugVar::FindVar(var.GetId()));
 
@@ -51,7 +51,7 @@ TEST(DebugVar, DebugVarUint32Defaults) {
   EXPECT_EQ(uint32_t{5}, var.GetValue());
   EXPECT_EQ("", var.GetHelp());
   EXPECT_EQ("%u", var.GetFormat());
-  EXPECT_EQ(VarType::UINT32, var.GetType());
+  EXPECT_EQ(VarType::kUInt32, var.GetType());
 }
 
 TEST(DebugVar, DebugVarFloatDefaults) {
@@ -61,7 +61,7 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 
   EXPECT_EQ("", var.GetHelp());
   EXPECT_EQ("%.3f", var.GetFormat());
-  EXPECT_EQ(VarType::FLOAT, var.GetType());
+  EXPECT_EQ(VarType::kFloat, var.GetType());
 
   // Rountrip through uint32 should not change value.
   uint32_t uint_value = var.GetValue();

--- a/software/controller/test/i2c/i2c_test.cpp
+++ b/software/controller/test/i2c/i2c_test.cpp
@@ -29,7 +29,7 @@ TEST(I2C, RequestQueue) {
   for (int req = 0; req < kQueueLength + 5; ++req) {
     Request read_byte{
         .slave_address = 0,
-        .direction = ExchangeDirection::kRead,
+        .direction = ExchangeDirection::Read,
         .size = 1,
         .data = &read_data[req],
         .processed = &processed[req],
@@ -52,7 +52,7 @@ TEST(I2C, RequestQueue) {
   for (int req = kQueueLength + 1; req < kQueueLength + 5; ++req) {
     Request read_byte{
         .slave_address = 0,
-        .direction = ExchangeDirection::kRead,
+        .direction = ExchangeDirection::Read,
         .size = 1,
         .data = &read_data[req],
         .processed = &processed[req],
@@ -89,7 +89,7 @@ TEST(I2C, WriteBuffer) {
   for (int req = 0; req < kNumReq; ++req) {
     Request write_array{
         .slave_address = 0,
-        .direction = ExchangeDirection::kWrite,
+        .direction = ExchangeDirection::Write,
         .size = kRequestLength,
         .data = &test_array[req],
         .processed = &processed[req],
@@ -100,7 +100,7 @@ TEST(I2C, WriteBuffer) {
   // Check that a request of "remaining + 1" bytes request is rejected
   Request write_array{
       .slave_address = 0,
-      .direction = ExchangeDirection::kWrite,
+      .direction = ExchangeDirection::Write,
       .size = static_cast<uint16_t>(kWriteBufferLength - buffer_head + 1),
       .data = &test_array[kNumReq],
       .processed = &processed[kNumReq],
@@ -202,7 +202,7 @@ TEST(I2C, RetryOnError) {
   bool processed{false};
   Request long_read{
       .slave_address = 0,
-      .direction = ExchangeDirection::kRead,
+      .direction = ExchangeDirection::Read,
       .size = kRequestLength,
       .data = &read_data[0],
       .processed = &processed,
@@ -213,7 +213,7 @@ TEST(I2C, RetryOnError) {
   bool processed2{false};
   Request read_byte{
       .slave_address = 0,
-      .direction = ExchangeDirection::kRead,
+      .direction = ExchangeDirection::Read,
       .size = 1,
       .data = &read2,
       .processed = &processed2,

--- a/software/controller/test/i2c/i2c_test.cpp
+++ b/software/controller/test/i2c/i2c_test.cpp
@@ -42,7 +42,7 @@ TEST(I2C, RequestQueue) {
   }
 
   // Process the first request and check that this is done properly
-  i2c.TEST_QueueReceiveData(10);
+  i2c.TESTQueueReceiveData(10);
   i2c.I2CEventHandler();
   ASSERT_TRUE(processed[0]);
   ASSERT_FALSE(processed[1]);
@@ -62,7 +62,7 @@ TEST(I2C, RequestQueue) {
 
   // Process all requests in the queue and check they are processed in order
   for (int req = 1; req < kQueueLength + 2; ++req) {
-    i2c.TEST_QueueReceiveData(static_cast<uint8_t>(req + 10));
+    i2c.TESTQueueReceiveData(static_cast<uint8_t>(req + 10));
     i2c.I2CEventHandler();
     ASSERT_TRUE(processed[req]);
     ASSERT_FALSE(processed[req + 1]);
@@ -111,7 +111,7 @@ TEST(I2C, WriteBuffer) {
   // previous request (freeing is only done when a request is processed)
   for (int byte = 0; byte < kWriteBufferLength - buffer_head + 1; ++byte) {
     i2c.I2CEventHandler();
-    std::optional<uint8_t> data = i2c.TEST_GetSentData();
+    std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
     ASSERT_EQ(data, byte % 256);
   }
@@ -120,7 +120,7 @@ TEST(I2C, WriteBuffer) {
   // Free up to 256 bytes (one transfer, but not the full request), repeat
   for (int byte = kWriteBufferLength - buffer_head + 1; byte < 256; ++byte) {
     i2c.I2CEventHandler();
-    std::optional<uint8_t> data = i2c.TEST_GetSentData();
+    std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
     ASSERT_EQ(data, byte % 256);
   }
@@ -129,7 +129,7 @@ TEST(I2C, WriteBuffer) {
   // Finish processing the first request and this time it should work
   for (int byte = 256; byte < kRequestLength; ++byte) {
     i2c.I2CEventHandler();
-    std::optional<uint8_t> data = i2c.TEST_GetSentData();
+    std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
     ASSERT_EQ(data, byte % 256);
   }
@@ -145,7 +145,7 @@ TEST(I2C, WriteBuffer) {
   for (int req = 1; req < kNumReq; ++req) {
     for (int byte = 0; byte < kRequestLength; ++byte) {
       i2c.I2CEventHandler();
-      std::optional<uint8_t> data = i2c.TEST_GetSentData();
+      std::optional<uint8_t> data = i2c.TESTGetSentData();
       ASSERT_TRUE(data != std::nullopt);
       ASSERT_EQ(data, (byte + req) % 256);
     }
@@ -162,7 +162,7 @@ TEST(I2C, WriteBuffer) {
   // process the first -> frees the first write_array.size bytes of the buffer
   for (int byte = 0; byte < write_array.size; ++byte) {
     i2c.I2CEventHandler();
-    std::optional<uint8_t> data = i2c.TEST_GetSentData();
+    std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
     ASSERT_EQ(data, (byte + kNumReq) % 256);
   }
@@ -222,28 +222,28 @@ TEST(I2C, RetryOnError) {
 
   // Process the first transfer (255 bytes) + a few bytes of the next one
   for (int byte = 0; byte < 265; ++byte) {
-    i2c.TEST_QueueReceiveData(static_cast<uint8_t>(byte % 256));
+    i2c.TESTQueueReceiveData(static_cast<uint8_t>(byte % 256));
     i2c.I2CEventHandler();
     ASSERT_EQ(read_data[byte], byte % 256);
   }
 
   // Simulate a bus error and check the request is restarted from its first byte
   i2c.I2CErrorHandler();
-  i2c.TEST_QueueReceiveData(static_cast<uint8_t>(45));
+  i2c.TESTQueueReceiveData(static_cast<uint8_t>(45));
   i2c.I2CEventHandler();
   ASSERT_EQ(read_data[0], 45);
 
   // Simulate another kMaxRetries - 1 bus errors to the same effect
   for (int error = 1; error < kMaxRetries - 1; ++error) {
     i2c.I2CErrorHandler();
-    i2c.TEST_QueueReceiveData(static_cast<uint8_t>(error + 45));
+    i2c.TESTQueueReceiveData(static_cast<uint8_t>(error + 45));
     i2c.I2CEventHandler();
     ASSERT_EQ(read_data[0], error + 45);
   }
 
   // Simulate a NACK, and check this has the same effect except it doesn't check
   // the retry count
-  i2c.TEST_SimulateNack();
+  i2c.TESTSimulateNack();
   i2c.I2CEventHandler();
   i2c.I2CEventHandler();
   ASSERT_EQ(read_data[0], kMaxRetries - 2 + 45);
@@ -251,7 +251,7 @@ TEST(I2C, RetryOnError) {
   // this point... if I simulate another error, it will just start the next
   // request, which is not really satisfactory.
   i2c.I2CErrorHandler();
-  i2c.TEST_QueueReceiveData(20);
+  i2c.TESTQueueReceiveData(20);
   i2c.I2CEventHandler();
   ASSERT_EQ(read_data[0], kMaxRetries - 2 + 45);
   ASSERT_FALSE(processed);

--- a/software/controller/test/i2c/i2c_test.cpp
+++ b/software/controller/test/i2c/i2c_test.cpp
@@ -19,14 +19,14 @@ limitations under the License.
 using namespace I2C;
 
 TEST(I2C, RequestQueue) {
-  constexpr uint kQueueLength{80};
+  constexpr uint QueueLength{80};
 
   TestChannel i2c;
 
   // Queue kQueueLength+5 read requests
-  uint8_t read_data[kQueueLength + 5];
-  bool processed[kQueueLength + 5];
-  for (int req = 0; req < kQueueLength + 5; ++req) {
+  uint8_t read_data[QueueLength + 5];
+  bool processed[QueueLength + 5];
+  for (int req = 0; req < QueueLength + 5; ++req) {
     Request read_byte{
         .slave_address = 0,
         .direction = ExchangeDirection::Read,
@@ -37,7 +37,7 @@ TEST(I2C, RequestQueue) {
     // Note that the first request is only queued temporarily: because there is
     // no transfer in progress yet, it is dequeued immediately by a call to
     // StartTransfer in SendRequest.
-    ASSERT_EQ(i2c.SendRequest(read_byte), req <= kQueueLength);
+    ASSERT_EQ(i2c.SendRequest(read_byte), req <= QueueLength);
     ASSERT_FALSE(processed[req]);
   }
 
@@ -49,7 +49,7 @@ TEST(I2C, RequestQueue) {
   ASSERT_EQ(read_data[0], 10);
 
   // Attempt at queueing one new request should succeed, not the following ones
-  for (int req = kQueueLength + 1; req < kQueueLength + 5; ++req) {
+  for (int req = QueueLength + 1; req < QueueLength + 5; ++req) {
     Request read_byte{
         .slave_address = 0,
         .direction = ExchangeDirection::Read,
@@ -57,11 +57,11 @@ TEST(I2C, RequestQueue) {
         .data = &read_data[req],
         .processed = &processed[req],
     };
-    ASSERT_EQ(i2c.SendRequest(read_byte), req <= kQueueLength + 1);
+    ASSERT_EQ(i2c.SendRequest(read_byte), req <= QueueLength + 1);
   }
 
   // Process all requests in the queue and check they are processed in order
-  for (int req = 1; req < kQueueLength + 2; ++req) {
+  for (int req = 1; req < QueueLength + 2; ++req) {
     i2c.TESTQueueReceiveData(static_cast<uint8_t>(req + 10));
     i2c.I2CEventHandler();
     ASSERT_TRUE(processed[req]);
@@ -71,26 +71,26 @@ TEST(I2C, RequestQueue) {
 }
 
 TEST(I2C, WriteBuffer) {
-  constexpr uint16_t kWriteBufferLength{4096};
-  constexpr uint16_t kRequestLength{400};
+  constexpr uint16_t WriteBufferLength{4096};
+  constexpr uint16_t RequestLength{400};
   uint buffer_head{0};
   TestChannel i2c;
 
   // Initialize a long array to be sent over I2C
-  uint8_t test_array[kRequestLength + 50];
-  for (int i = 0; i < kRequestLength + 50; ++i) {
+  uint8_t test_array[RequestLength + 50];
+  for (int i = 0; i < RequestLength + 50; ++i) {
     test_array[i] = static_cast<uint8_t>(i % 256);
   }
 
-  constexpr int kNumReq{kWriteBufferLength / kRequestLength};
-  bool processed[kNumReq + 5];
+  constexpr int NumReq{WriteBufferLength / RequestLength};
+  bool processed[NumReq + 5];
 
   // Fill the buffer with requests of 400 bytes each
-  for (int req = 0; req < kNumReq; ++req) {
+  for (int req = 0; req < NumReq; ++req) {
     Request write_array{
         .slave_address = 0,
         .direction = ExchangeDirection::Write,
-        .size = kRequestLength,
+        .size = RequestLength,
         .data = &test_array[req],
         .processed = &processed[req],
     };
@@ -101,15 +101,15 @@ TEST(I2C, WriteBuffer) {
   Request write_array{
       .slave_address = 0,
       .direction = ExchangeDirection::Write,
-      .size = static_cast<uint16_t>(kWriteBufferLength - buffer_head + 1),
-      .data = &test_array[kNumReq],
-      .processed = &processed[kNumReq],
+      .size = static_cast<uint16_t>(WriteBufferLength - buffer_head + 1),
+      .data = &test_array[NumReq],
+      .processed = &processed[NumReq],
   };
   ASSERT_FALSE(i2c.SendRequest(write_array));
 
   // Process the first bytes of the first request, we should still reject
   // previous request (freeing is only done when a request is processed)
-  for (int byte = 0; byte < kWriteBufferLength - buffer_head + 1; ++byte) {
+  for (int byte = 0; byte < WriteBufferLength - buffer_head + 1; ++byte) {
     i2c.I2CEventHandler();
     std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
@@ -118,7 +118,7 @@ TEST(I2C, WriteBuffer) {
   ASSERT_FALSE(i2c.SendRequest(write_array));
 
   // Free up to 256 bytes (one transfer, but not the full request), repeat
-  for (int byte = kWriteBufferLength - buffer_head + 1; byte < 256; ++byte) {
+  for (int byte = WriteBufferLength - buffer_head + 1; byte < 256; ++byte) {
     i2c.I2CEventHandler();
     std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
@@ -127,7 +127,7 @@ TEST(I2C, WriteBuffer) {
   ASSERT_FALSE(i2c.SendRequest(write_array));
 
   // Finish processing the first request and this time it should work
-  for (int byte = 256; byte < kRequestLength; ++byte) {
+  for (int byte = 256; byte < RequestLength; ++byte) {
     i2c.I2CEventHandler();
     std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
@@ -142,8 +142,8 @@ TEST(I2C, WriteBuffer) {
   buffer_head = write_array.size;
 
   // process all of the initial requests (and check that it is done right)
-  for (int req = 1; req < kNumReq; ++req) {
-    for (int byte = 0; byte < kRequestLength; ++byte) {
+  for (int req = 1; req < NumReq; ++req) {
+    for (int byte = 0; byte < RequestLength; ++byte) {
       i2c.I2CEventHandler();
       std::optional<uint8_t> data = i2c.TESTGetSentData();
       ASSERT_TRUE(data != std::nullopt);
@@ -154,8 +154,8 @@ TEST(I2C, WriteBuffer) {
   }
 
   // queue another request (we should then have 2 requests queued)
-  write_array.data = &test_array[kNumReq + 1];
-  write_array.processed = &processed[kNumReq + 1];
+  write_array.data = &test_array[NumReq + 1];
+  write_array.processed = &processed[NumReq + 1];
   ASSERT_TRUE(i2c.SendRequest(write_array));
   buffer_head = buffer_head + write_array.size;
 
@@ -164,23 +164,22 @@ TEST(I2C, WriteBuffer) {
     i2c.I2CEventHandler();
     std::optional<uint8_t> data = i2c.TESTGetSentData();
     ASSERT_TRUE(data != std::nullopt);
-    ASSERT_EQ(data, (byte + kNumReq) % 256);
+    ASSERT_EQ(data, (byte + NumReq) % 256);
   }
-  ASSERT_TRUE(processed[kNumReq]);
-  ASSERT_FALSE(processed[kNumReq + 1]);
+  ASSERT_TRUE(processed[NumReq]);
+  ASSERT_FALSE(processed[NumReq + 1]);
 
   uint buffer_tail{write_array.size};
 
   // Check that we still can't send a request that would wrap around the buffer
-  uint8_t data[kWriteBufferLength - buffer_head + 1];
-  write_array.size =
-      static_cast<uint16_t>(kWriteBufferLength - buffer_head + 1);
+  uint8_t data[WriteBufferLength - buffer_head + 1];
+  write_array.size = static_cast<uint16_t>(WriteBufferLength - buffer_head + 1);
   write_array.data = &data;
   ASSERT_FALSE(i2c.SendRequest(write_array));
 
   // But we can send a request that fills the whole end of the buffer (ranging
-  // from buffer_head to kWriteBufferLength - 1)
-  write_array.size = static_cast<uint16_t>(kWriteBufferLength - buffer_head);
+  // from buffer_head to WriteBufferLength - 1)
+  write_array.size = static_cast<uint16_t>(WriteBufferLength - buffer_head);
   ASSERT_TRUE(i2c.SendRequest(write_array));
 
   // now check that the first buffer_tail -1 bytes are also usable
@@ -192,18 +191,18 @@ TEST(I2C, WriteBuffer) {
 }
 
 TEST(I2C, RetryOnError) {
-  constexpr uint kMaxRetries{5};
-  constexpr uint16_t kRequestLength{400};
+  constexpr uint MaxRetries{5};
+  constexpr uint16_t RequestLength{400};
 
   TestChannel i2c;
 
   // Queue a long read request
-  uint8_t read_data[kRequestLength];
+  uint8_t read_data[RequestLength];
   bool processed{false};
   Request long_read{
       .slave_address = 0,
       .direction = ExchangeDirection::Read,
-      .size = kRequestLength,
+      .size = RequestLength,
       .data = &read_data[0],
       .processed = &processed,
   };
@@ -234,7 +233,7 @@ TEST(I2C, RetryOnError) {
   ASSERT_EQ(read_data[0], 45);
 
   // Simulate another kMaxRetries - 1 bus errors to the same effect
-  for (int error = 1; error < kMaxRetries - 1; ++error) {
+  for (int error = 1; error < MaxRetries - 1; ++error) {
     i2c.I2CErrorHandler();
     i2c.TESTQueueReceiveData(static_cast<uint8_t>(error + 45));
     i2c.I2CEventHandler();
@@ -246,14 +245,14 @@ TEST(I2C, RetryOnError) {
   i2c.TESTSimulateNack();
   i2c.I2CEventHandler();
   i2c.I2CEventHandler();
-  ASSERT_EQ(read_data[0], kMaxRetries - 2 + 45);
+  ASSERT_EQ(read_data[0], MaxRetries - 2 + 45);
   // This is where I get stuck... the I2C design is currently not robust passed
   // this point... if I simulate another error, it will just start the next
   // request, which is not really satisfactory.
   i2c.I2CErrorHandler();
   i2c.TESTQueueReceiveData(20);
   i2c.I2CEventHandler();
-  ASSERT_EQ(read_data[0], kMaxRetries - 2 + 45);
+  ASSERT_EQ(read_data[0], MaxRetries - 2 + 45);
   ASSERT_FALSE(processed);
   ASSERT_EQ(read2, 20);
   ASSERT_TRUE(processed2);

--- a/software/controller/test/nvparams/nvparams_test.cpp
+++ b/software/controller/test/nvparams/nvparams_test.cpp
@@ -88,7 +88,7 @@ TEST_F(NVparamsTest, FirstInitEver) {
   // This should equate the flip param because Set was called while current
   // params are in flip, so power cycles are updated but not crc and counter.
   SCOPED_TRACE("Flip side check");
-  CompareParams(static_cast<uint16_t>(Address::kFlip), ref_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), ref_params, _nv_params,
                 _eeprom);
 
   // Increment count, then compute crc, this should get us in the state of
@@ -96,7 +96,7 @@ TEST_F(NVparamsTest, FirstInitEver) {
   ref_params.count++;
   ref_params.crc = ParamsCRC(&ref_params);
   SCOPED_TRACE("Flop side check");
-  CompareParams(static_cast<uint16_t>(Address::kFlop), ref_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, _nv_params,
                 _eeprom);
 
   SCOPED_TRACE("nv_param_ check");
@@ -121,10 +121,10 @@ TEST_F(NVparamsTest, Update) {
   ref_params.last_settings.mode = VentMode::VentMode_PRESSURE_CONTROL;
 
   Structure read_params;
-  _eeprom.ReadBytes(static_cast<uint16_t>(Address::kFlip), sizeof(Structure),
+  _eeprom.ReadBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                     &read_params, nullptr);
   SCOPED_TRACE("Flip side check after Update");
-  CompareParams(static_cast<uint16_t>(Address::kFlip), ref_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), ref_params, _nv_params,
                 _eeprom);
   // Keep flip params for reuse later on
   Structure flip_params = ref_params;
@@ -134,7 +134,7 @@ TEST_F(NVparamsTest, Update) {
   ref_params.crc = ParamsCRC(&ref_params);
 
   SCOPED_TRACE("Flop side check after Update");
-  CompareParams(static_cast<uint16_t>(Address::kFlop), ref_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, _nv_params,
                 _eeprom);
 
   SCOPED_TRACE("nv_param_ check after Update");
@@ -143,11 +143,11 @@ TEST_F(NVparamsTest, Update) {
   // Call to update with nothing to change changes nothing
   _nv_params.Update(microsSinceStartup(119E6), &ref_params.last_settings);
   SCOPED_TRACE("Flip side check after Update");
-  CompareParams(static_cast<uint16_t>(Address::kFlip), flip_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
                 _eeprom);
 
   SCOPED_TRACE("Flop side check after useless Update");
-  CompareParams(static_cast<uint16_t>(Address::kFlop), ref_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, _nv_params,
                 _eeprom);
 
   SCOPED_TRACE("nv_param_ check after useless Update");
@@ -238,7 +238,7 @@ TEST_F(NVparamsTest, InitValidFlip) {
           },
   };
   flip_params.crc = ParamsCRC(&flip_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::kFlip), sizeof(Structure),
+  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                      &flip_params, nullptr);
 
   Structure flop_params = {
@@ -263,7 +263,7 @@ TEST_F(NVparamsTest, InitValidFlip) {
           },
   };
   // leave crc = 0 to make them invalid
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::kFlop), sizeof(Structure),
+  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
                      &flop_params, nullptr);
 
   _nv_params.Init(&_eeprom);
@@ -279,14 +279,14 @@ TEST_F(NVparamsTest, InitValidFlip) {
 
   SCOPED_TRACE("Flip check after Init");
   flip_params.power_cycles = valid_params.power_cycles;
-  CompareParams(static_cast<uint16_t>(Address::kFlip), flip_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
                 _eeprom);
 
   SCOPED_TRACE("Flop check after Init");
   flop_params.count = valid_params.count;
   flop_params.power_cycles = valid_params.power_cycles;
   flop_params.crc = valid_params.crc;
-  CompareParams(static_cast<uint16_t>(Address::kFlop), flop_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, _nv_params,
                 _eeprom);
 
   // update _nv_params with new settings and check that the write affects the
@@ -300,7 +300,7 @@ TEST_F(NVparamsTest, InitValidFlip) {
   CompareParams(-1, valid_params, _nv_params, _eeprom);
 
   SCOPED_TRACE("Flip check after Update");
-  CompareParams(static_cast<uint16_t>(Address::kFlip), valid_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), valid_params, _nv_params,
                 _eeprom);
 }
 
@@ -328,7 +328,7 @@ TEST_F(NVparamsTest, InitValidFlop) {
           },
   };
   // leave crc = 0 to render them invalid
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::kFlip), sizeof(Structure),
+  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                      &flip_params, nullptr);
 
   Structure flop_params = {
@@ -353,8 +353,8 @@ TEST_F(NVparamsTest, InitValidFlop) {
           },
   };
   flop_params.crc = ParamsCRC(&flop_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::kFlop), sizeof(Structure),
-                     &flop_params, nullptr);
+  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
+                    &flop_params, nullptr);
 
   _nv_params.Init(&_eeprom);
   // update count, power cycles and crc: this is done by the init function and
@@ -371,12 +371,12 @@ TEST_F(NVparamsTest, InitValidFlop) {
   flip_params.count = valid_params.count;
   flip_params.power_cycles = valid_params.power_cycles;
   flip_params.crc = valid_params.crc;
-  CompareParams(static_cast<uint16_t>(Address::kFlip), flip_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
                 _eeprom);
 
   SCOPED_TRACE("Flop check after Init");
   flop_params.power_cycles = valid_params.power_cycles;
-  CompareParams(static_cast<uint16_t>(Address::kFlop), flop_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, _nv_params,
                 _eeprom);
 
   // update _nv_params with new settings and check that the write affects the
@@ -390,7 +390,7 @@ TEST_F(NVparamsTest, InitValidFlop) {
   CompareParams(-1, valid_params, _nv_params, _eeprom);
 
   SCOPED_TRACE("Flop check after Update");
-  CompareParams(static_cast<uint16_t>(Address::kFlop), valid_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), valid_params, _nv_params,
                 _eeprom);
 }
 
@@ -418,7 +418,7 @@ TEST_F(NVparamsTest, InitBothValid) {
           },
   };
   flip_params.crc = ParamsCRC(&flip_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::kFlip), sizeof(Structure),
+  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                      &flip_params, nullptr);
 
   Structure flop_params = {
@@ -443,7 +443,7 @@ TEST_F(NVparamsTest, InitBothValid) {
           },
   };
   flop_params.crc = ParamsCRC(&flop_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::kFlop), sizeof(Structure),
+  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
                      &flop_params, nullptr);
 
   _nv_params.Init(&_eeprom);
@@ -464,12 +464,12 @@ TEST_F(NVparamsTest, InitBothValid) {
   flip_params.power_cycles = valid_params.power_cycles;
   flip_params.crc = valid_params.crc;
   SCOPED_TRACE("Flip check after Init");
-  CompareParams(static_cast<uint16_t>(Address::kFlip), flip_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
                 _eeprom);
 
   // only update power_cycles in flop params
   flop_params.power_cycles = valid_params.power_cycles;
   SCOPED_TRACE("Flop check after Init");
-  CompareParams(static_cast<uint16_t>(Address::kFlop), flop_params, _nv_params,
+  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, _nv_params,
                 _eeprom);
 }

--- a/software/controller/test/nvparams/nvparams_test.cpp
+++ b/software/controller/test/nvparams/nvparams_test.cpp
@@ -63,7 +63,7 @@ static void CompareParams(int16_t address, const Structure &ref,
 
 uint32_t ParamsCRC(Structure *params) {
   uint8_t *ptr = reinterpret_cast<uint8_t *>(params);
-  return soft_crc32(ptr + 4, sizeof(Structure) - 4);
+  return SoftCRC32(ptr + 4, sizeof(Structure) - 4);
 }
 
 class NVparamsTest : public ::testing::Test {
@@ -177,7 +177,7 @@ TEST_F(NVparamsTest, Update) {
   };
   ref_params.crc = ParamsCRC(&ref_params);
 
-  _nv_params.NVparamsUpdate(last_settings, &ref_params.last_settings);
+  _nv_params.NV_PARAMS_UPDATE(last_settings, &ref_params.last_settings);
 
   SCOPED_TRACE("nv_param_ check after MACRO");
   CompareParams(-1, ref_params, _nv_params, _eeprom);
@@ -209,7 +209,7 @@ TEST_F(NVparamsTest, GetAndReadMacro) {
 
   VentParams settings = VentParams_init_zero;
   // get last_settings through macro and check first and last members
-  _nv_params.NVparamsRead(last_settings, &settings);
+  _nv_params.NV_PARAMS_READ(last_settings, &settings);
   EXPECT_EQ(settings.mode, VentMode::VentMode_PRESSURE_ASSIST);
   EXPECT_EQ(settings.fio2, 0.21f);
 }

--- a/software/controller/test/nvparams/nvparams_test.cpp
+++ b/software/controller/test/nvparams/nvparams_test.cpp
@@ -23,15 +23,15 @@ static constexpr uint32_t kMemSize{8192};
 
 // Helper function to compare params in memory (in RAM if address is negative)
 static void CompareParams(int16_t address, const Structure &ref,
-                          NVParams::Handler &_nv_params, TestEeprom &_eeprom) {
+                          NVParams::Handler &nv_params_, TestEeprom &eeprom_) {
 
   // Reminder to update this function when Structure changes size.
   static_assert(sizeof(Structure) == 52);
   Structure read;
   if (address < 0) {
-    _nv_params.Get(0, &read, sizeof(Structure));
+    nv_params_.Get(0, &read, sizeof(Structure));
   } else {
-    _eeprom.ReadBytes(static_cast<uint16_t>(address), sizeof(Structure), &read,
+    eeprom_.ReadBytes(static_cast<uint16_t>(address), sizeof(Structure), &read,
                       nullptr);
   }
 
@@ -68,13 +68,13 @@ uint32_t ParamsCRC(Structure *params) {
 
 class NVparamsTest : public ::testing::Test {
 public:
-  NVparamsTest() : _eeprom(0x50, 64, kMemSize) {
+  NVparamsTest() : eeprom_(0x50, 64, kMemSize) {
     // Simulated EEPROM is initialized with FF, representative of a new chip
-    _nv_params.Init(&_eeprom);
+    nv_params_.Init(&eeprom_);
   }
 
-  NVParams::Handler _nv_params;
-  TestEeprom _eeprom; // = TestEeprom(0x50, 64, kMemSize)
+  NVParams::Handler nv_params_;
+  TestEeprom eeprom_; // = TestEeprom(0x50, 64, kMemSize)
 };
 
 TEST_F(NVparamsTest, FirstInitEver) {
@@ -88,29 +88,29 @@ TEST_F(NVparamsTest, FirstInitEver) {
   // This should equate the flip param because Set was called while current
   // params are in flip, so power cycles are updated but not crc and counter.
   SCOPED_TRACE("Flip side check");
-  CompareParams(static_cast<uint16_t>(Address::Flip), ref_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), ref_params, nv_params_,
+                eeprom_);
 
   // Increment count, then compute crc, this should get us in the state of
   // flop and current params
   ref_params.count++;
   ref_params.crc = ParamsCRC(&ref_params);
   SCOPED_TRACE("Flop side check");
-  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, nv_params_,
+                eeprom_);
 
   SCOPED_TRACE("nv_param_ check");
-  CompareParams(-1, ref_params, _nv_params, _eeprom);
+  CompareParams(-1, ref_params, nv_params_, eeprom_);
 }
 
 TEST_F(NVparamsTest, Update) {
   Structure ref_params;
-  _nv_params.Get(0, &ref_params, sizeof(Structure));
+  nv_params_.Get(0, &ref_params, sizeof(Structure));
   ref_params.last_settings.mode = VentMode::VentMode_PRESSURE_CONTROL;
 
-  // Update _nv_params with new time and check that the write affected the flip
+  // Update nv_params_ with new time and check that the write affected the flip
   // and flop sides with different crc
-  _nv_params.Update(microsSinceStartup(60E6 + 1), &ref_params.last_settings);
+  nv_params_.Update(microsSinceStartup(60E6 + 1), &ref_params.last_settings);
 
   ref_params.count++;
   ref_params.cumulated_service = 60;
@@ -121,11 +121,11 @@ TEST_F(NVparamsTest, Update) {
   ref_params.last_settings.mode = VentMode::VentMode_PRESSURE_CONTROL;
 
   Structure read_params;
-  _eeprom.ReadBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
+  eeprom_.ReadBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                     &read_params, nullptr);
   SCOPED_TRACE("Flip side check after Update");
-  CompareParams(static_cast<uint16_t>(Address::Flip), ref_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), ref_params, nv_params_,
+                eeprom_);
   // Keep flip params for reuse later on
   Structure flip_params = ref_params;
 
@@ -134,34 +134,34 @@ TEST_F(NVparamsTest, Update) {
   ref_params.crc = ParamsCRC(&ref_params);
 
   SCOPED_TRACE("Flop side check after Update");
-  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, nv_params_,
+                eeprom_);
 
   SCOPED_TRACE("nv_param_ check after Update");
-  CompareParams(-1, ref_params, _nv_params, _eeprom);
+  CompareParams(-1, ref_params, nv_params_, eeprom_);
 
   // Call to update with nothing to change changes nothing
-  _nv_params.Update(microsSinceStartup(119E6), &ref_params.last_settings);
+  nv_params_.Update(microsSinceStartup(119E6), &ref_params.last_settings);
   SCOPED_TRACE("Flip side check after Update");
-  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, nv_params_,
+                eeprom_);
 
   SCOPED_TRACE("Flop side check after useless Update");
-  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), ref_params, nv_params_,
+                eeprom_);
 
   SCOPED_TRACE("nv_param_ check after useless Update");
-  CompareParams(-1, ref_params, _nv_params, _eeprom);
+  CompareParams(-1, ref_params, nv_params_, eeprom_);
 
   // Set vent serial number and check resulting params
   ref_params.count++;
   ref_params.vent_serial_number = 789;
   ref_params.crc = ParamsCRC(&ref_params);
 
-  _nv_params.Set(8, &ref_params.vent_serial_number, 4);
+  nv_params_.Set(8, &ref_params.vent_serial_number, 4);
 
   SCOPED_TRACE("nv_param_ check after Set");
-  CompareParams(-1, ref_params, _nv_params, _eeprom);
+  CompareParams(-1, ref_params, nv_params_, eeprom_);
 
   // Set last_settings using macro and check resulting params
   ref_params.count++;
@@ -177,12 +177,12 @@ TEST_F(NVparamsTest, Update) {
   };
   ref_params.crc = ParamsCRC(&ref_params);
 
-  _nv_params.NV_PARAMS_UPDATE(last_settings, &ref_params.last_settings);
+  nv_params_.NV_PARAMS_UPDATE(last_settings, &ref_params.last_settings);
 
   SCOPED_TRACE("nv_param_ check after MACRO");
-  CompareParams(-1, ref_params, _nv_params, _eeprom);
+  CompareParams(-1, ref_params, nv_params_, eeprom_);
 
-  ASSERT_FALSE(_nv_params.Set(4, &ref_params.count + 1, 1));
+  ASSERT_FALSE(nv_params_.Set(4, &ref_params.count + 1, 1));
 }
 
 TEST_F(NVparamsTest, GetAndReadMacro) {
@@ -200,16 +200,16 @@ TEST_F(NVparamsTest, GetAndReadMacro) {
   };
   ref_params.crc = ParamsCRC(&ref_params);
 
-  _nv_params.NVparamsUpdate(last_settings, &ref_params.last_settings);
+  nv_params_.NV_PARAMS_UPDATE(last_settings, &ref_params.last_settings);
 
   uint32_t var_32b{0};
   // power_cycles should be equal to 1 after previous test
-  _nv_params.Get(12, &var_32b, 4);
+  nv_params_.Get(12, &var_32b, 4);
   EXPECT_EQ(var_32b, 1);
 
   VentParams settings = VentParams_init_zero;
   // get last_settings through macro and check first and last members
-  _nv_params.NV_PARAMS_READ(last_settings, &settings);
+  nv_params_.NV_PARAMS_READ(last_settings, &settings);
   EXPECT_EQ(settings.mode, VentMode::VentMode_PRESSURE_ASSIST);
   EXPECT_EQ(settings.fio2, 0.21f);
 }
@@ -238,7 +238,7 @@ TEST_F(NVparamsTest, InitValidFlip) {
           },
   };
   flip_params.crc = ParamsCRC(&flip_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
+  eeprom_.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                      &flip_params, nullptr);
 
   Structure flop_params = {
@@ -263,10 +263,10 @@ TEST_F(NVparamsTest, InitValidFlip) {
           },
   };
   // leave crc = 0 to make them invalid
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
+  eeprom_.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
                      &flop_params, nullptr);
 
-  _nv_params.Init(&_eeprom);
+  nv_params_.Init(&eeprom_);
   // update count, power cycles and crc: this is done by the init function and
   // written to flop side, while only power cycle is written to the flip side
   Structure valid_params = flip_params;
@@ -275,33 +275,33 @@ TEST_F(NVparamsTest, InitValidFlip) {
   valid_params.crc = ParamsCRC(&valid_params);
 
   SCOPED_TRACE("nv_param_ check after Init");
-  CompareParams(-1, valid_params, _nv_params, _eeprom);
+  CompareParams(-1, valid_params, nv_params_, eeprom_);
 
   SCOPED_TRACE("Flip check after Init");
   flip_params.power_cycles = valid_params.power_cycles;
-  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, nv_params_,
+                eeprom_);
 
   SCOPED_TRACE("Flop check after Init");
   flop_params.count = valid_params.count;
   flop_params.power_cycles = valid_params.power_cycles;
   flop_params.crc = valid_params.crc;
-  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, nv_params_,
+                eeprom_);
 
-  // update _nv_params with new settings and check that the write affects the
+  // update nv_params_ with new settings and check that the write affects the
   // flip side, so the flip side is now identical to what is in RAM
   valid_params.last_settings = flop_params.last_settings;
-  _nv_params.Update(microsSinceStartup(0), &valid_params.last_settings);
+  nv_params_.Update(microsSinceStartup(0), &valid_params.last_settings);
   valid_params.count++;
   valid_params.crc = ParamsCRC(&valid_params);
 
   SCOPED_TRACE("nv_param_ check after Update");
-  CompareParams(-1, valid_params, _nv_params, _eeprom);
+  CompareParams(-1, valid_params, nv_params_, eeprom_);
 
   SCOPED_TRACE("Flip check after Update");
-  CompareParams(static_cast<uint16_t>(Address::Flip), valid_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), valid_params, nv_params_,
+                eeprom_);
 }
 
 TEST_F(NVparamsTest, InitValidFlop) {
@@ -328,7 +328,7 @@ TEST_F(NVparamsTest, InitValidFlop) {
           },
   };
   // leave crc = 0 to render them invalid
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
+  eeprom_.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                      &flip_params, nullptr);
 
   Structure flop_params = {
@@ -353,10 +353,10 @@ TEST_F(NVparamsTest, InitValidFlop) {
           },
   };
   flop_params.crc = ParamsCRC(&flop_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
-                    &flop_params, nullptr);
+  eeprom_.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
+                     &flop_params, nullptr);
 
-  _nv_params.Init(&_eeprom);
+  nv_params_.Init(&eeprom_);
   // update count, power cycles and crc: this is done by the init function and
   // written to flip side
   Structure valid_params = flop_params;
@@ -365,33 +365,33 @@ TEST_F(NVparamsTest, InitValidFlop) {
   valid_params.crc = ParamsCRC(&valid_params);
 
   SCOPED_TRACE("nv_param_ check after Init");
-  CompareParams(-1, valid_params, _nv_params, _eeprom);
+  CompareParams(-1, valid_params, nv_params_, eeprom_);
 
   SCOPED_TRACE("Flip check after Init");
   flip_params.count = valid_params.count;
   flip_params.power_cycles = valid_params.power_cycles;
   flip_params.crc = valid_params.crc;
-  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, nv_params_,
+                eeprom_);
 
   SCOPED_TRACE("Flop check after Init");
   flop_params.power_cycles = valid_params.power_cycles;
-  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, nv_params_,
+                eeprom_);
 
-  // update _nv_params with new settings and check that the write affects the
+  // update nv_params_ with new settings and check that the write affects the
   // flop side
   valid_params.last_settings = flip_params.last_settings;
-  _nv_params.Update(microsSinceStartup(0), &valid_params.last_settings);
+  nv_params_.Update(microsSinceStartup(0), &valid_params.last_settings);
   valid_params.count++;
   valid_params.crc = ParamsCRC(&valid_params);
 
   SCOPED_TRACE("nv_param_ check after Update");
-  CompareParams(-1, valid_params, _nv_params, _eeprom);
+  CompareParams(-1, valid_params, nv_params_, eeprom_);
 
   SCOPED_TRACE("Flop check after Update");
-  CompareParams(static_cast<uint16_t>(Address::Flop), valid_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), valid_params, nv_params_,
+                eeprom_);
 }
 
 TEST_F(NVparamsTest, InitBothValid) {
@@ -418,7 +418,7 @@ TEST_F(NVparamsTest, InitBothValid) {
           },
   };
   flip_params.crc = ParamsCRC(&flip_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
+  eeprom_.WriteBytes(static_cast<uint16_t>(Address::Flip), sizeof(Structure),
                      &flip_params, nullptr);
 
   Structure flop_params = {
@@ -443,10 +443,10 @@ TEST_F(NVparamsTest, InitBothValid) {
           },
   };
   flop_params.crc = ParamsCRC(&flop_params);
-  _eeprom.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
+  eeprom_.WriteBytes(static_cast<uint16_t>(Address::Flop), sizeof(Structure),
                      &flop_params, nullptr);
 
-  _nv_params.Init(&_eeprom);
+  nv_params_.Init(&eeprom_);
   // Should result in using flop params since count is higher.
   // Update count, power cycles and crc: this is done by the init function and
   // written to flip side
@@ -456,7 +456,7 @@ TEST_F(NVparamsTest, InitBothValid) {
   valid_params.crc = ParamsCRC(&valid_params);
 
   SCOPED_TRACE("nv_param_ check after Init");
-  CompareParams(-1, valid_params, _nv_params, _eeprom);
+  CompareParams(-1, valid_params, nv_params_, eeprom_);
 
   // update those values in flip_params, the rest was kept in its previous
   // state
@@ -464,12 +464,12 @@ TEST_F(NVparamsTest, InitBothValid) {
   flip_params.power_cycles = valid_params.power_cycles;
   flip_params.crc = valid_params.crc;
   SCOPED_TRACE("Flip check after Init");
-  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flip), flip_params, nv_params_,
+                eeprom_);
 
   // only update power_cycles in flop params
   flop_params.power_cycles = valid_params.power_cycles;
   SCOPED_TRACE("Flop check after Init");
-  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, _nv_params,
-                _eeprom);
+  CompareParams(static_cast<uint16_t>(Address::Flop), flop_params, nv_params_,
+                eeprom_);
 }

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -47,8 +47,8 @@ TEST(PidTest, Proportional) {
   const float input = setpoint - 10;
 
   // Create PID and run once
-  PID pid(Kp, /*ki=*/0, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(Kp, /*ki=*/0, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Ki and Kd = 0 therefore output = Kp*error, nothing more
@@ -63,8 +63,8 @@ TEST(PidTest, IntegralBasic) {
   const float setpoint = 25;
   const float input = setpoint - 10;
 
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // on first call, integral = error * 0, output = 0.
@@ -84,8 +84,8 @@ TEST(PidTest, IntegralSaturationMax) {
   const float setpoint = 25;
   const float input = setpoint - 10;
 
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   float output = 0;
@@ -113,8 +113,8 @@ TEST(PidTest, IntegralSaturationMin) {
   const float input = setpoint + 10;
 
   // Create PID and run once
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   float output = 0;
@@ -147,15 +147,15 @@ TEST(PidTest, DerivativeOnMeasure) {
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
   const float input2 = setpoint2 - 13;
-  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::kOnMeasurement,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::OnMeasurement,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Expect no derivative on first call
   EXPECT_OUTPUT(pid.Compute(ticks(t++), input1, setpoint1), 0);
 
-  // Note that DifferentialTerm::kOnMeasurement actually works with
-  // -1*Kd to allow using the same parameters as DifferentialTerm::kOnError
+  // Note that DifferentialTerm::OnMeasurement actually works with
+  // -1*Kd to allow using the same parameters as DifferentialTerm::OnError
   EXPECT_OUTPUT(pid.Compute(ticks(t++), input2, setpoint2),
                 -1 * Kd * (input2 - input1) / sample_period.seconds());
 }
@@ -166,8 +166,8 @@ TEST(PidTest, DerivativeOnError) {
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
   const float input2 = setpoint2 - 13;
-  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::kOnMeasurement,
-          DifferentialTerm::kOnError, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::OnMeasurement,
+          DifferentialTerm::OnError, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Expect no derivative on first call
@@ -184,8 +184,8 @@ TEST(PidTest, TaskJitter) {
   const float Ki = 0.5f;
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   Time now = base;
 
   float integral = (setpoint - input) * sample_period.seconds();
@@ -212,8 +212,8 @@ TEST(PidTest, MissedSample) {
   const float Ki = 0.2f;
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   Time now = base;
 
   float integral = (setpoint - input) * (sample_period.seconds());
@@ -242,8 +242,8 @@ TEST(PidTest, Observe) {
   float Ki = 1;
   float setpoint = 25;
   float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
-          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError,
+          DifferentialTerm::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Run PID a few times
@@ -270,7 +270,7 @@ TEST(PidTest, Observe) {
 
 TEST(PidTest, Reset) {
 
-  PID pid(0, 0, 0, ProportionalTerm::kOnError, DifferentialTerm::kOnError,
+  PID pid(0, 0, 0, ProportionalTerm::OnError, DifferentialTerm::OnError,
           MIN_OUTPUT, MAX_OUTPUT);
 
   // Run one cycle to set last error

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -47,8 +47,8 @@ TEST(PidTest, Proportional) {
   const float input = setpoint - 10;
 
   // Create PID and run once
-  PID pid(Kp, /*ki=*/0, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(Kp, /*ki=*/0, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Ki and Kd = 0 therefore output = Kp*error, nothing more
@@ -63,8 +63,8 @@ TEST(PidTest, IntegralBasic) {
   const float setpoint = 25;
   const float input = setpoint - 10;
 
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // on first call, integral = error * 0, output = 0.
@@ -84,8 +84,8 @@ TEST(PidTest, IntegralSaturationMax) {
   const float setpoint = 25;
   const float input = setpoint - 10;
 
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   float output = 0;
@@ -113,8 +113,8 @@ TEST(PidTest, IntegralSaturationMin) {
   const float input = setpoint + 10;
 
   // Create PID and run once
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   float output = 0;
@@ -147,15 +147,15 @@ TEST(PidTest, DerivativeOnMeasure) {
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
   const float input2 = setpoint2 - 13;
-  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::ON_MEASUREMENT,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::kOnMeasurement,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Expect no derivative on first call
   EXPECT_OUTPUT(pid.Compute(ticks(t++), input1, setpoint1), 0);
 
-  // Note that DifferentialTerm::ON_MEASUREMENT actually works with
-  // -1*Kd to allow using the same parameters as DifferentialTerm::ON_ERROR
+  // Note that DifferentialTerm::kOnMeasurement actually works with
+  // -1*Kd to allow using the same parameters as DifferentialTerm::kOnError
   EXPECT_OUTPUT(pid.Compute(ticks(t++), input2, setpoint2),
                 -1 * Kd * (input2 - input1) / sample_period.seconds());
 }
@@ -166,8 +166,8 @@ TEST(PidTest, DerivativeOnError) {
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
   const float input2 = setpoint2 - 13;
-  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::ON_MEASUREMENT,
-          DifferentialTerm::ON_ERROR, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::kOnMeasurement,
+          DifferentialTerm::kOnError, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Expect no derivative on first call
@@ -184,8 +184,8 @@ TEST(PidTest, TaskJitter) {
   const float Ki = 0.5f;
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   Time now = base;
 
   float integral = (setpoint - input) * sample_period.seconds();
@@ -212,8 +212,8 @@ TEST(PidTest, MissedSample) {
   const float Ki = 0.2f;
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   Time now = base;
 
   float integral = (setpoint - input) * (sample_period.seconds());
@@ -242,8 +242,8 @@ TEST(PidTest, Observe) {
   float Ki = 1;
   float setpoint = 25;
   float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, MIN_OUTPUT, MAX_OUTPUT);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::kOnError,
+          DifferentialTerm::kOnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Run PID a few times
@@ -270,7 +270,7 @@ TEST(PidTest, Observe) {
 
 TEST(PidTest, Reset) {
 
-  PID pid(0, 0, 0, ProportionalTerm::ON_ERROR, DifferentialTerm::ON_ERROR,
+  PID pid(0, 0, 0, ProportionalTerm::kOnError, DifferentialTerm::kOnError,
           MIN_OUTPUT, MAX_OUTPUT);
 
   // Run one cycle to set last error

--- a/software/controller/test/psol/psol_test.cpp
+++ b/software/controller/test/psol/psol_test.cpp
@@ -17,4 +17,4 @@ limitations under the License.
 #include "gtest/gtest.h"
 
 // Not really a test, just silencing code coverage warning for native build
-TEST(PSol, TestStubs) { PSOL_Value(0.0); }
+TEST(PSol, TestStubs) { PSolValue(0.0); }

--- a/software/controller/test/sensor_tests/sensors_test.cpp
+++ b/software/controller/test/sensor_tests/sensors_test.cpp
@@ -70,14 +70,14 @@ static SensorReadings update_readings(Duration dt, Pressure patient_pressure,
                                       Pressure inflow_pressure,
                                       Pressure outflow_pressure, Pressure p_amb,
                                       float fio2, Sensors *sensors) {
-  Hal.test_setAnalogPin(AnalogPin::kPatientPressure,
-                        MPXV5004_PressureToVoltage(patient_pressure));
-  Hal.test_setAnalogPin(AnalogPin::kInflowPressureDiff,
-                        MPXV5004_PressureToVoltage(inflow_pressure));
-  Hal.test_setAnalogPin(AnalogPin::kOutflowPressureDiff,
-                        MPXV5004_PressureToVoltage(outflow_pressure));
-  Hal.test_setAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(fio2, p_amb));
-  Hal.delay(dt);
+  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure,
+                       MPXV5004_PressureToVoltage(patient_pressure));
+  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff,
+                       MPXV5004_PressureToVoltage(inflow_pressure));
+  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff,
+                       MPXV5004_PressureToVoltage(outflow_pressure));
+  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(fio2, p_amb));
+  hal.Delay(dt);
   return sensors->GetReadings();
 }
 
@@ -94,11 +94,11 @@ TEST(SensorTests, FullScalePressureReading) {
 
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
-  Hal.test_setAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
   // Set fio2 signal to allow calibration
-  Hal.test_setAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();
@@ -107,20 +107,20 @@ TEST(SensorTests, FullScalePressureReading) {
   // versus what the original pressure waveform was
   for (auto p : pressures) {
     SCOPED_TRACE("Pressure " + std::to_string(p.kPa()));
-    Hal.test_setAnalogPin(AnalogPin::kPatientPressure,
-                          MPXV5004_PressureToVoltage(p));
+    hal.TESTSetAnalogPin(AnalogPin::kPatientPressure,
+                         MPXV5004_PressureToVoltage(p));
     EXPECT_PRESSURE_NEAR(sensors.GetReadings().patient_pressure, p);
   }
 }
 
 TEST(SensorTests, FiO2Reading) {
   // calibrate O2 sensor at 21% fio2, 1atm
-  Hal.test_setAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
   // Set the other sensors to reasonable values to allow calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));
-  Hal.test_setAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
 
   Sensors sensors;
   sensors.Calibrate();
@@ -131,7 +131,7 @@ TEST(SensorTests, FiO2Reading) {
   // sweep all fio2 settings and 1 atm pressure
   for (auto fio2 : fio2_settings) {
     SCOPED_TRACE("fio2 " + std::to_string(fio2));
-    Hal.test_setAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(fio2, atm(1.0f)));
+    hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(fio2, atm(1.0f)));
     EXPECT_NEAR(sensors.GetReadings().fio2, fio2, kComparisonToleranceFIO2);
   }
   // TODO: check the effect of ambient pressure once the system has a way to
@@ -166,20 +166,20 @@ TEST(SensorTests, TotalFlowCalculation) {
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0)); //[V]
-  Hal.test_setAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
   // Set fio2 signal to allow calibration
-  Hal.test_setAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();
 
   for (auto p_in : pressures) {
     for (auto p_out : pressures) {
-      auto readings =
-          update_readings(/*dt=*/seconds(0.0f), /*patient_pressure=*/kPa(0.0f),
-                          p_in, p_out, atm(1.0f), /*fio2=*/0.21f, &sensors);
+      auto readings = update_readings(
+          /*dt=*/seconds(0.0f), /*patient_pressure=*/kPa(0.0f), p_in, p_out,
+          atm(1.0f), /*fio2=*/0.21f, &sensors);
       EXPECT_FLOW_NEAR(readings.inflow, Sensors::PressureDeltaToFlow(p_in));
       EXPECT_FLOW_NEAR(readings.outflow, Sensors::PressureDeltaToFlow(p_out));
     }
@@ -190,16 +190,16 @@ TEST(SensorTests, Calibration) {
   // First set the simulated analog signals to randomly chosen signals
   // corresponding to conditions during calibration
   Pressure init_pressure = kPa(0.23f);
-  Hal.test_setAnalogPin(AnalogPin::kPatientPressure,
-                        MPXV5004_PressureToVoltage(init_pressure));
+  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure,
+                       MPXV5004_PressureToVoltage(init_pressure));
   Pressure init_inflow_delta = kPa(0.15f);
-  Hal.test_setAnalogPin(AnalogPin::kInflowPressureDiff,
-                        MPXV5004_PressureToVoltage(init_inflow_delta));
+  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff,
+                       MPXV5004_PressureToVoltage(init_inflow_delta));
   Pressure init_outflow_delta = kPa(-0.13f);
-  Hal.test_setAnalogPin(AnalogPin::kOutflowPressureDiff,
-                        MPXV5004_PressureToVoltage(init_outflow_delta));
+  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff,
+                       MPXV5004_PressureToVoltage(init_outflow_delta));
   float init_fio2 = 0.15f;
-  Hal.test_setAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(init_fio2, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(init_fio2, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();

--- a/software/controller/test/sensor_tests/sensors_test.cpp
+++ b/software/controller/test/sensor_tests/sensors_test.cpp
@@ -70,13 +70,13 @@ static SensorReadings update_readings(Duration dt, Pressure patient_pressure,
                                       Pressure inflow_pressure,
                                       Pressure outflow_pressure, Pressure p_amb,
                                       float fio2, Sensors *sensors) {
-  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure,
+  hal.TESTSetAnalogPin(AnalogPin::PatientPressure,
                        MPXV5004_PressureToVoltage(patient_pressure));
-  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff,
+  hal.TESTSetAnalogPin(AnalogPin::InflowPressureDiff,
                        MPXV5004_PressureToVoltage(inflow_pressure));
-  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff,
+  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff,
                        MPXV5004_PressureToVoltage(outflow_pressure));
-  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(fio2, p_amb));
+  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(fio2, p_amb));
   hal.Delay(dt);
   return sensors->GetReadings();
 }
@@ -94,11 +94,11 @@ TEST(SensorTests, FullScalePressureReading) {
 
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
-  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::InflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, voltage_at_0kPa);
   // Set fio2 signal to allow calibration
-  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();
@@ -107,7 +107,7 @@ TEST(SensorTests, FullScalePressureReading) {
   // versus what the original pressure waveform was
   for (auto p : pressures) {
     SCOPED_TRACE("Pressure " + std::to_string(p.kPa()));
-    hal.TESTSetAnalogPin(AnalogPin::kPatientPressure,
+    hal.TESTSetAnalogPin(AnalogPin::PatientPressure,
                          MPXV5004_PressureToVoltage(p));
     EXPECT_PRESSURE_NEAR(sensors.GetReadings().patient_pressure, p);
   }
@@ -115,12 +115,12 @@ TEST(SensorTests, FullScalePressureReading) {
 
 TEST(SensorTests, FiO2Reading) {
   // calibrate O2 sensor at 21% fio2, 1atm
-  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
   // Set the other sensors to reasonable values to allow calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));
-  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::InflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, voltage_at_0kPa);
 
   Sensors sensors;
   sensors.Calibrate();
@@ -131,7 +131,7 @@ TEST(SensorTests, FiO2Reading) {
   // sweep all fio2 settings and 1 atm pressure
   for (auto fio2 : fio2_settings) {
     SCOPED_TRACE("fio2 " + std::to_string(fio2));
-    hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(fio2, atm(1.0f)));
+    hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(fio2, atm(1.0f)));
     EXPECT_NEAR(sensors.GetReadings().fio2, fio2, kComparisonToleranceFIO2);
   }
   // TODO: check the effect of ambient pressure once the system has a way to
@@ -166,11 +166,11 @@ TEST(SensorTests, TotalFlowCalculation) {
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0)); //[V]
-  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::InflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, voltage_at_0kPa);
   // Set fio2 signal to allow calibration
-  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();
@@ -190,16 +190,16 @@ TEST(SensorTests, Calibration) {
   // First set the simulated analog signals to randomly chosen signals
   // corresponding to conditions during calibration
   Pressure init_pressure = kPa(0.23f);
-  hal.TESTSetAnalogPin(AnalogPin::kPatientPressure,
+  hal.TESTSetAnalogPin(AnalogPin::PatientPressure,
                        MPXV5004_PressureToVoltage(init_pressure));
   Pressure init_inflow_delta = kPa(0.15f);
-  hal.TESTSetAnalogPin(AnalogPin::kInflowPressureDiff,
+  hal.TESTSetAnalogPin(AnalogPin::InflowPressureDiff,
                        MPXV5004_PressureToVoltage(init_inflow_delta));
   Pressure init_outflow_delta = kPa(-0.13f);
-  hal.TESTSetAnalogPin(AnalogPin::kOutflowPressureDiff,
+  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff,
                        MPXV5004_PressureToVoltage(init_outflow_delta));
   float init_fio2 = 0.15f;
-  hal.TESTSetAnalogPin(AnalogPin::kFIO2, FIO2ToVoltage(init_fio2, atm(1.0f)));
+  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(init_fio2, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();

--- a/software/controller/test/sensor_tests/sensors_test.cpp
+++ b/software/controller/test/sensor_tests/sensors_test.cpp
@@ -32,16 +32,16 @@ limitations under the License.
 #include <string>
 
 // Maximum allowable delta between calculated sensor readings and the input.
-static const Pressure kComparisonTolerancePressure{kPa(0.005f)};
-static const VolumetricFlow kComparisonToleranceFlow{ml_per_sec(50)};
-static const float kComparisonToleranceFIO2{0.001f};
+static const Pressure ComparisonTolerancePressure{kPa(0.005f)};
+static const VolumetricFlow ComparisonToleranceFlow{ml_per_sec(50)};
+static const float ComparisonToleranceFIO2{0.001f};
 
 #define EXPECT_PRESSURE_NEAR(a, b)                                             \
-  EXPECT_NEAR((a).kPa(), (b).kPa(), kComparisonTolerancePressure.kPa())
+  EXPECT_NEAR((a).kPa(), (b).kPa(), ComparisonTolerancePressure.kPa())
 
 #define EXPECT_FLOW_NEAR(a, b)                                                 \
   EXPECT_NEAR((a).ml_per_sec(), (b).ml_per_sec(),                              \
-              kComparisonToleranceFlow.ml_per_sec())
+              ComparisonToleranceFlow.ml_per_sec())
 
 //@TODO: Finish writing more specific unit tests for this module
 
@@ -132,7 +132,7 @@ TEST(SensorTests, FiO2Reading) {
   for (auto fio2 : fio2_settings) {
     SCOPED_TRACE("fio2 " + std::to_string(fio2));
     hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(fio2, atm(1.0f)));
-    EXPECT_NEAR(sensors.GetReadings().fio2, fio2, kComparisonToleranceFIO2);
+    EXPECT_NEAR(sensors.GetReadings().fio2, fio2, ComparisonToleranceFIO2);
   }
   // TODO: check the effect of ambient pressure once the system has a way to
   // know
@@ -211,7 +211,7 @@ TEST(SensorTests, Calibration) {
   EXPECT_PRESSURE_NEAR(readings.patient_pressure, kPa(0.0f));
   EXPECT_FLOW_NEAR(readings.inflow, ml_per_sec(0.0f));
   EXPECT_FLOW_NEAR(readings.outflow, ml_per_sec(0.0f));
-  EXPECT_NEAR(readings.fio2, 0.21f, kComparisonToleranceFIO2);
+  EXPECT_NEAR(readings.fio2, 0.21f, ComparisonToleranceFIO2);
 
   // set measured signals to 0 and expect -1*init values (plus 0.21 for fio2)
   readings = update_readings(/*dt=*/seconds(0), /*patient_pressure=*/kPa(0),
@@ -226,7 +226,7 @@ TEST(SensorTests, Calibration) {
                    -1 * Sensors::PressureDeltaToFlow(init_inflow_delta));
   EXPECT_FLOW_NEAR(readings.outflow,
                    -1 * Sensors::PressureDeltaToFlow(init_outflow_delta));
-  EXPECT_NEAR(readings.fio2, 0.21f - init_fio2, kComparisonToleranceFIO2);
+  EXPECT_NEAR(readings.fio2, 0.21f - init_fio2, ComparisonToleranceFIO2);
 
   // set measured signals to some random values + init values and expect init
   // value to be removed from the readings (once again, except for fio2, which
@@ -241,5 +241,5 @@ TEST(SensorTests, Calibration) {
   EXPECT_PRESSURE_NEAR(readings.patient_pressure, kPa(-0.5f));
   EXPECT_FLOW_NEAR(readings.inflow, Sensors::PressureDeltaToFlow(kPa(1.1f)));
   EXPECT_FLOW_NEAR(readings.outflow, Sensors::PressureDeltaToFlow(kPa(0.01f)));
-  EXPECT_NEAR(readings.fio2, 0.25f + 0.21f, kComparisonToleranceFIO2);
+  EXPECT_NEAR(readings.fio2, 0.25f + 0.21f, ComparisonToleranceFIO2);
 }

--- a/software/controller/test/stepper/stepper_test.cpp
+++ b/software/controller/test/stepper/stepper_test.cpp
@@ -19,12 +19,12 @@ limitations under the License.
 // Not really tests, just silencing code coverage warning for native build
 TEST(Stepper, TestStubs) {
   StepMotor step_motor;
-  EXPECT_EQ(StepMtrErr::OK, step_motor.HardDisable());
-  EXPECT_EQ(StepMtrErr::OK, step_motor.SetAmpAll(0.0));
-  EXPECT_EQ(StepMtrErr::OK, step_motor.SetMaxSpeed(0.0));
-  EXPECT_EQ(StepMtrErr::OK, step_motor.SetAccel(0.0));
-  EXPECT_EQ(StepMtrErr::OK, step_motor.MoveRel(0.0));
-  EXPECT_EQ(StepMtrErr::OK, step_motor.ClearPosition());
-  EXPECT_EQ(StepMtrErr::OK, step_motor.GotoPos(0.0));
-  EXPECT_EQ(StepMtrErr::OK, step_motor.HardStop());
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.HardDisable());
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.SetAmpAll(0.0));
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.SetMaxSpeed(0.0));
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.SetAccel(0.0));
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.MoveRel(0.0));
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.ClearPosition());
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.GotoPos(0.0));
+  EXPECT_EQ(StepMtrErr::kOk, step_motor.HardStop());
 }

--- a/software/controller/test/stepper/stepper_test.cpp
+++ b/software/controller/test/stepper/stepper_test.cpp
@@ -19,12 +19,12 @@ limitations under the License.
 // Not really tests, just silencing code coverage warning for native build
 TEST(Stepper, TestStubs) {
   StepMotor step_motor;
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.HardDisable());
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.SetAmpAll(0.0));
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.SetMaxSpeed(0.0));
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.SetAccel(0.0));
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.MoveRel(0.0));
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.ClearPosition());
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.GotoPos(0.0));
-  EXPECT_EQ(StepMtrErr::kOk, step_motor.HardStop());
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.HardDisable());
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.SetAmpAll(0.0));
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.SetMaxSpeed(0.0));
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.SetAccel(0.0));
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.MoveRel(0.0));
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.ClearPosition());
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.GotoPos(0.0));
+  EXPECT_EQ(StepMtrErr::Ok, step_motor.HardStop());
 }

--- a/software/controller/test/units/units_test.cpp
+++ b/software/controller/test/units/units_test.cpp
@@ -47,7 +47,7 @@ void checkArithmeticOperators(T (*unit)(NumTy), NumTy (T::*get)() const) {
   // x / y is defined only for Ts backed by floats (in practice, everything
   // other than Duration).
   constexpr bool is_fp_based =
-      std::is_base_of_v<units_detail::ArithScalar<T, float>, T>;
+      std::is_base_of_v<UnitsDetail::ArithScalar<T, float>, T>;
 
   // Make t const to check that these operators work with const operands.
   const T t = unit(2.1f);

--- a/software/gui/src/breath_signals.h
+++ b/software/gui/src/breath_signals.h
@@ -28,7 +28,7 @@ public:
       current_peep_ = pressure;
 
       recent_breath_starts_.push_back(now);
-      if (recent_breath_starts_.size() > kMaxRecentBreathStarts) {
+      if (recent_breath_starts_.size() > MaxRecentBreathStarts) {
         recent_breath_starts_.pop_front();
       }
       return;
@@ -44,7 +44,7 @@ public:
   std::optional<float> pip() const { return latest_pip_; }
   std::optional<float> peep() const { return latest_peep_; }
   std::optional<float> rr() const {
-    if (recent_breath_starts_.size() < kMinRecentBreathStarts) {
+    if (recent_breath_starts_.size() < MinRecentBreathStarts) {
       return std::nullopt;
     }
     SteadyInstant newest = recent_breath_starts_.back();
@@ -66,8 +66,8 @@ private:
 
   uint64_t latest_breath_id_ = 0;
 
-  static constexpr int kMinRecentBreathStarts = 3;
-  static constexpr int kMaxRecentBreathStarts = 5;
+  static constexpr int MinRecentBreathStarts = 3;
+  static constexpr int MaxRecentBreathStarts = 5;
   std::deque<SteadyInstant> recent_breath_starts_;
 };
 


### PR DESCRIPTION
# Description

Add clang-tidy rules that enforce google style to controller static-tests.
Since we still have other warnings in clang-tidy, the checks are not-blocking in CI

Updates #117

Tested on my own pizza-build.

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
