### PR TITLE
Updated disclaimers and links in prep for v0.4 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,28 @@ If you can lend your skills towards achieving this goal, please contact us at
 [join-us@respira.works](mailto:join-us@respira.works?subject=[GitHub]%20Join%20request). A list of roles we are looking
 to fill is also on our [website](https://respira.works/join-us).
 
-## DISCLAIMERS
+## Project Status / Disclaimers
 
-**This is an incomplete, as yet untested design that is not yet intended to be used on patients.**
+**This is an incomplete, as yet untested design that is not intended to be used on patients.**
 
 **The repository contains live documents. There may be incomplete or contradictory information about various aspects
 of the design. Components may or may not connect and integrate as intended. Contents may also be out of date. If you
 decide to buy or build anything, do so at your own risk.**
 
+We are currently in the process of designing our v0.4 prototype, plans whereof are captured in some of our outstanding [Milestones](https://github.com/RespiraWorks/Ventilator/milestones). The `master` branch of this repository includes bleeding edge changes in electrical, mechanical and software aspects of the project. Browse at your own peril.
+
+For the latest stable and tested (but also likely obsolete) version of the design see the [Releases](https://github.com/RespiraWorks/Ventilator/releases) page.
+
 ## Repository Structure
 
-* [**System Requirements**](https://respiraworks.github.io/Ventilator/system/system_requirements.html) -
-  describes the requirement architecture, hierarchy, and process. Links to the releases of our system requirements,
-  hardware specifications, and software requirements
-* [**System Design**](design) -
-  describes the functional implementation and design theory of the system
-* [**Manufacturing Design**](manufacturing) - describes the physical design of the ventilator and its components.
-  Includes CAD models and notes on the manufacturing process
+* [**Documentation pages (outside of repository)**](https://respiraworks.github.io/Ventilator/index.html) - these auto-generated pages (should eventually) include:
+  * Requirements documentation
+  * Regulatory documentation
+  * Software documentation
+  * Bill of materials for manufacturing
+* [**Documentation source**](docs) - this directory contains the source files for the above pages
+* [**System Design**](design) - describes the functional implementation and design theory of the system
+* [**Manufacturing Design**](manufacturing) - describes the physical design of the ventilator and its components. Includes CAD models and notes on the manufacturing process
 * [**Main Circuit Board**](pcb) - design, materials, assembly instructions for the ventilator main circuit board
-* [**Software**](software) - Source code for cycle controller and user interface, debug tools, test scripts, and test data
+* [**Software**](software) - Source code for cycle controller and user interface, debug tools, test scripts, and test data. Software architecture documentation is also here.
 * [**Quality Assurance**](quality-assurance) - quality assurance strategy, testing plans, data

--- a/manufacturing/README.md
+++ b/manufacturing/README.md
@@ -10,7 +10,7 @@ components and fully assembled units.
 
 ## DISCLAIMERS
 
-**This is an incomplete, as yet untested design that is not yet intended to be used on patients.**
+**This is an incomplete, as yet untested design that is not intended to be used on patients.**
 
 **The repository contains live documents. All documentation here is on a "best effort" but no guarantee basis.
 Information is incomplete. Pictures, renderings, parts lists and fabrication instructions may contradict each other.
@@ -32,6 +32,8 @@ collaboration space.
 fittings and screws. These have been provided by various suppliers on their websites and may be intellectual
 property of the respective manufacturer. These models come with no guarantees and do **NOT** fall under the
 [Apache license](../LICENSE) which generally applies the rest of our project.
+
+We are currently in the process of designing our v0.4 prototype, plans whereof are captured in some of our outstanding [Milestones](https://github.com/RespiraWorks/Ventilator/milestones). The `master` branch of this repository includes bleeding edge changes. Browse at your own peril. For the latest stable and tested (but also likely obsolete) version of the design see the [Releases](https://github.com/RespiraWorks/Ventilator/releases) page.
 
 ## Contributing
 

--- a/pcb/README.md
+++ b/pcb/README.md
@@ -14,7 +14,7 @@ and is far more amenable to a quality fabrication process than hand-soldered com
 component to be hand-assembled, and engineering turnkey fabrication instructions have been generated as part of the
 submission; no assembly instructions are provided here.
 
-The original Rev 1 PCB was done in Alitum.  As of Rev A, this project has moved to KiCad for better accessibility.
+The original Rev 1 PCB was done in Altium.  As of Rev A, this project has moved to KiCad for better accessibility.
 
 ## Rev A
 


### PR DESCRIPTION
# Description

This:
* updates disclaimers on the main page to make it clear how `master` content may be inconsistent
* explicitly links to "Releases" page as something tested but obsolete
* links to the entirety of the github pages site where requirements reside

This is not related to any issue, should simply make it easier to merge "half-baked" solutions to specific issues prior to proper integration.

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers
