### PR TITLE
WIP: Oxygen venturi intake includes diameter transition

### DIFF
--- a/manufacturing/internals/venturi/README.md
+++ b/manufacturing/internals/venturi/README.md
@@ -1,8 +1,8 @@
 # Venturi Flow Sensor
 
-| Cross-section                   | Solid                    |
-|:--------------------------------:|:------------------------:|
-| ![](images/v1_cross_section.jpg) | ![](images/v1_solid.jpg) |
+| Cross-section                     | Solid                    |
+|:---------------------------------:|:------------------------:|
+| ![](images/v1_cross_section.jpg)  | ![](images/v1_solid.jpg) |
 
 ## Design basis
 
@@ -75,10 +75,10 @@ include transitions and barbs for different diameter tubing, as can be seen in t
 
 The venturi outline drawing and Inventor CAD can be found here:
 
-|File Type| Download Link |
-|:-----:|:-------:|
-|Outline Drawing PDF |[**venturi.pdf**](exports/venturi.pdf)|
-|Venturi Inventor CAD |[**venturi.ipt**](venturi.ipt)|
+|      File Type       |              Download Link              |
+|:--------------------:|:---------------------------------------:|
+| Outline Drawing PDF  | [**venturi.pdf**](exports/venturi.pdf)  |
+| Venturi Inventor CAD |     [**venturi.ipt**](venturi.ipt)      |
 
 **Note: the venturi configurations are saved as iPart Configurations, which can be acessed by expanding the "Tables" tab in the Feature Tree of the venturi .ipt part.**
 
@@ -96,26 +96,25 @@ Note that explicit clamp space may does not need to be provided when tubing diam
 of the main venturi flow sensor body. In such cases, additional clamping also adds to straight tubing length dictated
 by the two variables described above.
 
-|           | Generic | Air influx | Oxygen influx | Exhale sensor |
-|:---------:|:-------:|:----------:|:-------------:|:-------------:|
-| **Use**   | General testing / "Pizza build" | Enclosed build | Enclosed build | Enclosed build |
-| **Image** |![](images/venturi_generic.jpg) | ![](images/venturi_air_influx.jpg) | ![](images/venturi_oxygen_influx.jpg) | ![](images/venturi_exhale.jpg) |
-| diams_before_venturi          | 2.0      | 2.5      | 2.5      | 2.0      |
-| diams_after_venturi           | 0.5      | 1.0      | 1.0      | 1.0      |
-| input_outer_diameter          | 3/4"     | 3/8"     | 3/4"     | 3/4"     |
-| input_thk                     | 2mm      | 1.5mm    | 2mm      | 2mm      |
-| input_clamp_nominal_len       | 0mm      | 12mm     | 12mm     | 12mm     |
-| Straight output barb features | enabled  | disabled | disabled | enabled  |
-| output_outer_diameter         | 3/4"     | -        | -        | 3/8"     |
-| output_thk                    | 2mm      | -        | -        | 1.5mm    |
-| output_clamp_nominal_len      | 0mm      | -        | -        | 12mm     |
-| Left U-turn features          | disabled | enabled  | disabled | disabled |
-| Right U-turn features         | disabled | disabled | enabled  | disabled |
-| u_turn_parallel_distance      | -        | 10mm     | 10mm     | -        |
-| u_turn_output_tube_len        | -        | 30mm     | 30mm     | -        |
-| **STL file**  | [venturi_generic.stl](exports/venturi_generic.stl) | [venturi_air_influx.stl](exports/venturi_air_influx.stl) | [venturi_oxygen_influx.stl](exports/venturi_oxygen_influx.stl) | [venturi_exhale.jpg](exports/venturi_exhale.stl) |
-| **Total length** | 106.1mm | 143mm | 138mm | 142.5mm |
-| **Notes** | | | Requires discrete [1/4"-3/4" adapter](../reducer_3-4_1-4) upstream | |
+|                               |                      Generic                       |                        Air influx                        |                         Oxygen influx                          |                  Exhale sensor                   |
+|:-----------------------------:|:--------------------------------------------------:|:--------------------------------------------------------:|:--------------------------------------------------------------:|:------------------------------------------------:|
+|            **Use**            |          General testing / "Pizza build"           |                      Enclosed build                      |                         Enclosed build                         |                 Enclosed build                   |
+|           **Image**           |         ![](images/venturi_generic.jpg)            |           ![](images/venturi_air_influx.jpg)             |             ![](images/venturi_oxygen_influx.jpg)              |          ![](images/venturi_exhale.jpg)          |
+|     diams_before_venturi      |                        2.0                         |                           2.5                            |                              2.5                               |                       2.0                        |
+|      diams_after_venturi      |                        0.5                         |                           1.0                            |                              1.0                               |                       1.0                        |
+|     input_outer_diameter      |                        3/4"                        |                           3/8"                           |                              1/4"                              |                       3/4"                       |
+|           input_thk           |                        2mm                         |                          1.5mm                           |                             1.5mm                              |                       2mm                        |
+|    input_clamp_nominal_len    |                        0mm                         |                           12mm                           |                              12mm                              |                       12mm                       |
+| Straight output barb features |                      enabled                       |                         disabled                         |                            disabled                            |                     enabled                      |
+|     output_outer_diameter     |                        3/4"                        |                            -                             |                               -                                |                       3/8"                       |
+|          output_thk           |                        2mm                         |                            -                             |                               -                                |                      1.5mm                       |
+|   output_clamp_nominal_len    |                        0mm                         |                            -                             |                               -                                |                       12mm                       |
+|     Left U-turn features      |                      disabled                      |                         enabled                          |                            disabled                            |                     disabled                     |
+|     Right U-turn features     |                      disabled                      |                         disabled                         |                            enabled                             |                     disabled                     |
+|   u_turn_parallel_distance    |                         -                          |                           10mm                           |                              10mm                              |                        -                         |
+|    u_turn_output_tube_len     |                         -                          |                           30mm                           |                              30mm                              |                        -                         |
+|        **STL file**           | [venturi_generic.stl](exports/venturi_generic.stl) | [venturi_air_influx.stl](exports/venturi_air_influx.stl) | [venturi_oxygen_influx.stl](exports/venturi_oxygen_influx.stl) | [venturi_exhale.jpg](exports/venturi_exhale.stl) |
+|       **Total length**        |                      106.1mm                       |                          143mm                           |                            144.6mm                             |                     142.5mm                      |
 
 ## Parts
 
@@ -124,9 +123,9 @@ BEFORE purchasing any parts.**
 
 [ppg]: ../../purchasing_guidelines.md
 
-| Item | Quantity | Manufacturer  | Part #               | Price (USD) | Sources[*][ppg] | Notes |
-| ---- |---------:| ------------- | -------------------- | -----------:|:---------------:| ----- |
-|**A1**| 1        | RespiraWorks  | [Venturi body][a1rw] | ~1.00       | Rw              | 3D-printed venturi body |
+| Item | Quantity | Manufacturer  | Part #               | Price (USD) | Sources[*][ppg] | Notes                                              |
+| ---- |---------:| ------------- | -------------------- | -----------:|:---------------:|----------------------------------------------------|
+|**A1**| 1        | RespiraWorks  | [Venturi body][a1rw] | ~1.00       | Rw              | 3D-printed venturi body                            |
 |**A2**| 2        | McMaster-Carr | 5463K3               | 0.39        | [C][a2mcmc]     | Barbed fitting 3/32" UNF, nipple for sensor tubing |
 
 **Total assembly price:** USD 1.78
@@ -138,10 +137,10 @@ BEFORE purchasing any parts.**
 
 These may or may not be useful.
 
-| Item | Manufacturer  | Part #          | Price (USD) | Sources[*][ppg] | Notes |
-| ---- | ------------- | --------------- | -----------:|:---------------:| ----- |
-|**B1**| McMaster-Carr | 2636A251        | 6.76        | [C][b1mcmc]     | 10-32 UNF bottoming tap for threading nipple ports |
-|**B2**| McMaster-Carr | 2636A251        | 6.76        | [C][b2mcmc]     | 10-32 UNF tapered tap for threading nipple ports |
+| Item | Manufacturer  | Part #          | Price (USD) | Sources[*][ppg] | Notes                                                  |
+| ---- | ------------- | --------------- | -----------:|:---------------:|--------------------------------------------------------|
+|**B1**| McMaster-Carr | 2636A251        | 6.76        | [C][b1mcmc]     | 10-32 UNF bottoming tap for threading nipple ports     |
+|**B2**| McMaster-Carr | 2636A251        | 6.76        | [C][b2mcmc]     | 10-32 UNF tapered tap for threading nipple ports       |
 |**B3**| uxcell        | a19032000ux0738 | 6.89        | [Z][b3amzn]     | 5.5 reamer for ensuring venturi diameter, **optional** |
 |**B4**| DeWalt        | DWA1205         | 2.58        | [Z][b4amzn]     | 5/64" drill bit, should optimally be 2mm, **optional** |
 

--- a/manufacturing/internals/venturi/images/venturi_oxygen_influx.jpg
+++ b/manufacturing/internals/venturi/images/venturi_oxygen_influx.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:498dd3aacd5dbb280365cb56b8160e98a78c2d273ace6a6d7bc259820b3ead7d
-size 32695
+oid sha256:c8c131e5da626c091337fee38b2c4beef7f1cd3d8601ee558ed53efc8cd74ba0
+size 35435

--- a/manufacturing/internals/venturi/venturi.ipt
+++ b/manufacturing/internals/venturi/venturi.ipt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f537c0d97e78d5cdce12732d3d3a9da5da04c832816348a6e5170d480388da6
-size 1421824
+oid sha256:92220605fd550d5f743d1d2f85ae8745fd1e059b2c240dadb9881a788c2349ae
+size 1466368

--- a/manufacturing/internals/venturi/venturi/venturi-exhale.ipt
+++ b/manufacturing/internals/venturi/venturi/venturi-exhale.ipt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8881be66de9fd1f65009a3cbdf30e9268bff13d832efa56d1fd998f8e454a05
-size 1255936
+oid sha256:e2230bd24c3b79e6340c570aef8d759f26fab3b80eb9dd3618a89f945ab0a16c
+size 1250304

--- a/manufacturing/internals/venturi/venturi/venturi-influx.ipt
+++ b/manufacturing/internals/venturi/venturi/venturi-influx.ipt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79ba6282090af93b6ae6ff5b664cc95e4161dc1f755d625a1776996c053ba040
-size 1296384
+oid sha256:05a17dcedc98d48b07bf48ac1c4b1ca2403a190eb52ad5718142fec716660322
+size 1290752

--- a/manufacturing/internals/venturi/venturi/venturi-o2.ipt
+++ b/manufacturing/internals/venturi/venturi/venturi-o2.ipt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c132d40583f1c4d3b66abcbe0422a153f198982853e2775effd9d023abba7e02
-size 1289216
+oid sha256:41c7659f4ac5a4613951c54edb29fb87729a9af6b766758e7d2f3052a93cebda
+size 1291776

--- a/manufacturing/internals/venturi/venturi/venturi-pizza.ipt
+++ b/manufacturing/internals/venturi/venturi/venturi-pizza.ipt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a10009032a53aee7c0f74e079db34bbfb892de015ccc13b88439de0defdfc36c
-size 1250304
+oid sha256:da8c171ad2a2b806388574f68c32f6efb69154e0218706aeebabe83f4e72d612
+size 1242624

--- a/manufacturing/internals/venturi/venturi_assembly.iam
+++ b/manufacturing/internals/venturi/venturi_assembly.iam
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba3963d4d28587733d0c05485e38119877f0405441ee90ffebdd5ba70f36e35d
-size 404992
+oid sha256:44aa63fb1a34144dac9a6b841519d5ff2640e909e6c2d38897b60e31d85e74ac
+size 483328

--- a/manufacturing/internals/venturi/venturi_assembly/Venturi Assembly-o2.iam
+++ b/manufacturing/internals/venturi/venturi_assembly/Venturi Assembly-o2.iam
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17d8fbf3fd98892c696b3f1ae3910a7f4e427ca5bcf4229286dfbb2b8458ac41
-size 452608
+oid sha256:52802a3b05fc6fc20f0944c56ee4db152c85f578597b75c9171a627caebbf66e
+size 441344


### PR DESCRIPTION
# Description

Oxygen venturi now includes a diameter transition for 1/4"ID tubing. This eliminates the need for an additional adapter/fitting in the pneumatic assembly and thus simplifies manufacturing.

As an additional bug fix, the exported STL for the oxygen sensor + overpressure relief valve manifold had a very poor resolution. A new STL has been exported with sufficient resolution.

Closes #1122

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [ ] I have tagged relevant reviewers
