### PR TITLE
Jtravert/enhance debug variables

### DIFF
--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # This script is designed for local unix usage.
-# ./gui.sh --help
+# ./controller.sh --help
 
 # Use this script during development to have a good approximation
 # of whether your PR will pass tests on CircleCI:
 #
-# $ ./test.sh
+# $ ./controller.sh --test
 #
 # CircleCI runs this script (via .circleci/config.yml), but might have some
 # environment differences, so the approximation is not perfect. For
@@ -15,7 +15,7 @@
 # Feel free to add more checks here, but keep in mind that:
 # - They have to pass on CircleCI
 # - They have to have a very good chance of passing for other
-#   developers if they run via ./test.sh
+#   developers if they run via ./controller.sh --test
 
 # Fail if any command fails
 set -e

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -52,11 +52,15 @@
 #include "vars.h"
 
 static DebugUInt32 dbg_addr_before("eeprom_before",
-                                   "address of eeprom contents at startup", 0);
-static DebugUInt32 dbg_write_data("write_data", "address of write data", 0);
+                                   "address of eeprom contents at startup",
+                                   VarAccess::ReadOnly);
+static DebugUInt32 dbg_write_data("write_data", "address of write data",
+                                  VarAccess::ReadOnly);
 static DebugUInt32 dbg_addr_after("eeprom_after",
-                                  "address of eeprom contents after write", 0);
-static DebugUInt32 dbg_test_result("result", "result of the test", 0);
+                                  "address of eeprom contents after write",
+                                  VarAccess::ReadOnly);
+static DebugUInt32 dbg_test_result("result", "result of the test",
+                                   VarAccess::ReadOnly);
 
 // test parameters
 static constexpr uint16_t Address{TEST_PARAM_1};

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -24,8 +24,8 @@ limitations under the License.
 
 // TODO: This should be configurable from the GUI.
 static DebugFloat dbg_pa_flow_trigger("pa_flow_trigger",
-                                      "pressure assist flow trigger (ml/s)",
-                                      200);
+                                      "pressure assist flow trigger",
+                                      VarAccess::ReadWrite, 200, "ml/s");
 
 // TODO: Is 250ms right?  Or can it be a fixed value at all; should it depend
 // on the RR or something?
@@ -33,7 +33,7 @@ static DebugFloat
     dbg_pa_min_expire_ms("pa_min_expire_ms",
                          "minimum amount of time after ventilator exits PIP "
                          "before we're eligible to trigger a breath",
-                         250);
+                         VarAccess::ReadWrite, 250, "ms");
 
 // fast_flow_avg_alpha and slow_flow_avg_alpha were tuned for a control loop
 // that runs at a particular frequency.
@@ -46,17 +46,21 @@ static DebugFloat dbg_fast_flow_avg_alpha(
     "fast_flow_avg_alpha",
     "alpha term in pressure assist mode's fast-updating "
     "exponentially-weighted average of flow",
+    VarAccess::ReadWrite,
     0.2f * (Controller::GetLoopPeriod() / milliseconds(10)));
 static DebugFloat dbg_slow_flow_avg_alpha(
     "slow_flow_avg_alpha",
     "alpha term in pressure assist mode's slow-updating "
     "exponentially-weighted average of flow",
+    VarAccess::ReadWrite,
     0.01f * (Controller::GetLoopPeriod() / milliseconds(10)));
 
 static DebugFloat dbg_fast_flow_avg("fast_flow_avg",
-                                    "fast-updating flow average (ml/s)", 0.f);
+                                    "fast-updating flow average",
+                                    VarAccess::ReadOnly);
 static DebugFloat dbg_slow_flow_avg("slow_flow_avg",
-                                    "slow-updating flow average (ml/s)", 0.f);
+                                    "slow-updating flow average",
+                                    VarAccess::ReadOnly);
 
 // Given t = secs_per_breath and r = I:E ratio, calculate inspiration and
 // expiration durations (I and E).

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -23,42 +23,47 @@ static DebugFloat dbg_forced_blower_power(
     "forced_blower_power",
     "Force the blower fan to a particular power [0,1].  Specify a value "
     "outside this range to let the controller control it.",
-    -1.f);
+    VarAccess::ReadWrite, -1.f);
 static DebugFloat dbg_forced_exhale_valve_pos(
     "forced_exhale_valve_pos",
     "Force the exhale valve to a particular position [0,1].  Specify a value "
     "outside this range to let the controller control it.",
-    -1.f);
+    VarAccess::ReadWrite, -1.f);
 static DebugFloat dbg_forced_blower_valve_pos(
     "forced_blower_valve_pos",
     "Force the blower valve to a particular position [0,1].  Specify a value "
     "outside this range to let the controller control it.",
-    -1.f);
+    VarAccess::ReadWrite, -1.f);
 static DebugFloat dbg_forced_psol_pos(
     "forced_psol_pos",
     "Force the O2 psol to a particular position [0,1].  (Note that psol.cpp "
     "scales this further; see psol_pwm_closed and psol_pwm_open.)  Specify a "
     "value outside this range to let the controller control the psol.",
-    -1.f);
+    VarAccess::ReadWrite, -1.f);
 
 // Unchanging outputs - read from external debug program, never modified here.
-static DebugUInt32 dbg_per("loop_period", "Loop period, read-only (usec)",
-                           static_cast<uint32_t>(LoopPeriod.microseconds()));
+static DebugUInt32 dbg_per("loop_period", "Loop period", VarAccess::ReadOnly,
+                           static_cast<uint32_t>(LoopPeriod.microseconds()),
+                           "usec");
 
 // Outputs - read from external debug program, modified here.
-static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint (cmH2O)");
-static DebugFloat dbg_net_flow("net_flow", "Net flow rate, cc/sec");
-static DebugFloat dbg_volume("volume", "Patient volume, ml");
-static DebugFloat
-    dbg_net_flow_uncorrected("net_flow_uncorrected",
-                             "Net flow rate w/o correction, cc/sec");
+static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint",
+                         VarAccess::ReadOnly, 0.0f, "cmH2O");
+static DebugFloat dbg_net_flow("net_flow", "Net flow rate", VarAccess::ReadOnly,
+                               0.0f, "ml/sec");
+static DebugFloat dbg_volume("volume", "Patient volume", VarAccess::ReadOnly,
+                             0.0f, "ml");
+static DebugFloat dbg_net_flow_uncorrected("net_flow_uncorrected",
+                                           "Net flow rate w/o correction",
+                                           VarAccess::ReadOnly, 0.0f, "ml/sec");
 static DebugFloat dbg_volume_uncorrected("uncorrected_volume",
-                                         "Patient volume w/o correction, ml");
-static DebugFloat dbg_flow_correction("flow_correction",
-                                      "Correction to flow, cc/sec");
+                                         "Patient volume w/o correction",
+                                         VarAccess::ReadOnly, 0.0f, "ml");
+static DebugFloat dbg_flow_correction("flow_correction", "Correction to flow",
+                                      VarAccess::ReadOnly, 0.0f, "ml/sec");
 
-static DebugUInt32 dbg_breath_id("breath_id",
-                                 "ID of the current breath, read-only", 0);
+static DebugUInt32 dbg_breath_id("breath_id", "ID of the current breath",
+                                 VarAccess::ReadOnly);
 
 /*static*/ Duration Controller::GetLoopPeriod() { return LoopPeriod; }
 

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -54,20 +54,20 @@ struct ControllerState {
 // modified by controller.
 static DebugFloat dbg_blower_valve_ki("blower_valve_ki",
                                       "Integral gain for blower valve PID",
-                                      -1.0f);
-
+                                      VarAccess::ReadWrite, -1.0f);
 static DebugFloat dbg_blower_valve_kp("blower_valve_kp",
                                       "Proportional gain for blower valve PID",
-                                      0.04f);
+                                      VarAccess::ReadWrite, 0.04f);
 static DebugFloat dbg_blower_valve_kd("blower_valve_kd",
                                       "Derivative gain for blower valve PID");
 
 // TODO: These need to be tuned.
 static DebugFloat dbg_psol_kp("psol_kp", "Proportional gain for O2 psol PID",
-                              0.04f);
+                              VarAccess::ReadWrite, 0.04f);
 static DebugFloat dbg_psol_ki("psol_ki", "Integral gain for O2 psol PID",
-                              20.0f);
-static DebugFloat dbg_psol_kd("psol_kd", "Derivative gain for O2 psol PID", 0);
+                              VarAccess::ReadWrite, 20.0f);
+static DebugFloat dbg_psol_kd("psol_kd", "Derivative gain for O2 psol PID",
+                              VarAccess::ReadWrite, 0);
 
 // TODO: If we had a notion of read-only DebugVars, we could call this
 // blower_valve_ki, which would be kind of nice?  Alternatively, if we had a
@@ -76,9 +76,9 @@ static DebugFloat dbg_psol_kd("psol_kd", "Derivative gain for O2 psol PID", 0);
 // it, in which case, use that value.
 static DebugFloat
     dbg_blower_valve_computed_ki("blower_valve_computed_ki",
-                                 "Integral gain for blower valve PID.  READ "
-                                 "ONLY - This value is gain-scheduled.",
-                                 10.0f);
+                                 "Integral gain for blower valve PID. "
+                                 "This value is gain-scheduled.",
+                                 VarAccess::ReadOnly, 10.0f);
 
 // This class is here to allow integration of our controller into Modelica
 // software and run closed-loop tests in a simulated physical environment

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -32,12 +32,13 @@ limitations under the License.
 
 static DebugUInt32
     dbg_reinit("nvparams_reinit",
-               "Set to 1 to request a reinit of NV params on next boot.", 0);
+               "Set to 1 to request a reinit of NV params on next boot.");
 
 static DebugUInt32 dbg_serial("serial_number",
-                              "Serial number of the ventilator, in EEPROM", 0);
+                              "Serial number of the ventilator, in EEPROM");
 
-static DebugUInt32 dbg_nvparams("nvparams_address", "Address of nv_params", 0);
+static DebugUInt32 dbg_nvparams("nvparams_address", "Address of nv_params",
+                                VarAccess::ReadOnly);
 
 namespace NVParams {
 

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -137,15 +137,18 @@ private:
 //
 //  Set - Set the variables value.
 //
+//  GetCount - Used to know how many debug variables are currently active
+//
 class VarHandler : public Handler {
 public:
   VarHandler() = default;
   ErrorCode Process(Context *context) override;
 
   enum class Subcommand : uint8_t {
-    GetInfo = 0x00, // get variable info (name, type, help string)
-    Get = 0x01,     // get variable value
-    Set = 0x02,     // set variable value
+    GetInfo = 0x00,  // get variable info (name, type, help string)
+    Get = 0x01,      // get variable value
+    Set = 0x02,      // set variable value
+    GetCount = 0x03, // get count of active vars
   };
 
 private:
@@ -159,6 +162,8 @@ private:
   ErrorCode GetVar(Context *context);
 
   ErrorCode SetVar(Context *context);
+
+  ErrorCode GetVarCount(Context *context);
 };
 
 // Eeprom command.

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -36,8 +36,8 @@ enum class ErrorCode : uint8_t {
   NoMemory = 0x04,        // Insufficient memory
   InternalError = 0x05,   // Some type of internal error (aka bug)
   UnknownVariable = 0x06, // The requested variable ID is invalid
-  InvalidData = 0x07,     // data is out of range
-  Timeout = 0x08,         // response timeout
+  InvalidData = 0x07,     // Data is out of range
+  Timeout = 0x08,         // Response timeout
 };
 
 namespace Command {

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -151,9 +151,10 @@ ErrorCode VarHandler::SetVar(Context *context) {
   if (count < 4)
     return ErrorCode::MissingData;
 
-  if (!var->SetValue(u8_to_u32(context->request + 3)))
+  if (!var->WriteAllowed())
     return ErrorCode::InternalError;
 
+  var->SetValue(u8_to_u32(context->request + 3));
   context->response_length = 0;
   *(context->processed) = true;
   return ErrorCode::None;

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -26,6 +26,12 @@ enum class VarType {
   Float = 3,
 };
 
+// Defines the possible access to variable
+enum class VarAccess {
+  ReadOnly = 0,
+  ReadWrite = 1,
+};
+
 // This class represents a variable that you can read/write using the
 // debug serial port.
 //
@@ -43,8 +49,10 @@ public:
   // @param fmt printf style format string.  This is a hint to the Python code
   // as to how the variable data should be displayed.
   DebugVarBase(VarType type, const char *name, const char *help,
-               const char *fmt)
-      : type_(type), name_(name), help_(help), fmt_(fmt), id_(var_count_) {
+               const char *fmt, const char *unit = "",
+               VarAccess access = VarAccess::ReadWrite)
+      : type_(type), name_(name), help_(help), fmt_(fmt), id_(var_count_),
+        unit_(unit), access_(access) {
     if (var_count_ < static_cast<uint16_t>(std::size(var_list_)))
       var_list_[id_] = this;
     var_count_++;
@@ -55,15 +63,19 @@ public:
       return nullptr;
     return var_list_[vid];
   }
+  static uint32_t GetVarCount() { return var_count_; }
 
   virtual uint32_t GetValue() = 0;
-  virtual void SetValue(uint32_t value) = 0;
+  virtual bool SetValue(uint32_t value) = 0;
 
   const char *GetName() const { return name_; }
   const char *GetFormat() const { return fmt_; }
   const char *GetHelp() const { return help_; }
+  const char *GetUnit() const { return unit_; }
   VarType GetType() const { return type_; }
   uint16_t GetId() const { return id_; }
+  const VarAccess GetAccess() const { return access_; }
+  const bool WriteAllowed() const { return (access_ == VarAccess::ReadWrite); }
 
 private:
   const VarType type_;
@@ -71,6 +83,8 @@ private:
   const char *const help_;
   const char *const fmt_;
   const uint16_t id_;
+  const char *const unit_;
+  const VarAccess access_;
 
   // List of all the variables in the system.
   // Increase size as necessary
@@ -82,11 +96,19 @@ template <typename GetFn, typename SetFn>
 class FnDebugVar : public DebugVarBase {
 public:
   FnDebugVar(VarType type, const char *name, const char *help, const char *fmt,
-             GetFn get_fn, SetFn set_fn)
-      : DebugVarBase(type, name, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {}
+             GetFn get_fn, SetFn set_fn, const char *unit = "",
+             VarAccess access = VarAccess::ReadWrite)
+      : DebugVarBase(type, name, help, fmt, unit, access), get_fn_(get_fn),
+        set_fn_(set_fn) {}
 
   uint32_t GetValue() override { return get_fn_(); }
-  void SetValue(uint32_t value) override { set_fn_(value); }
+  bool SetValue(uint32_t value) override {
+    if (!WriteAllowed())
+      return false;
+
+    set_fn_(value);
+    return true;
+  }
 
 private:
   GetFn get_fn_;
@@ -98,18 +120,21 @@ public:
   // 32-bit integer variable.
   // @param data Pointer to an actual variable in C++ code that this will access
   DebugVar(const char *name, int32_t *data, const char *help = "",
-           const char *fmt = "%d")
-      : DebugVar(VarType::Int32, name, data, help, fmt) {}
+           const char *fmt = "%d", const char *unit = "",
+           VarAccess access = VarAccess::ReadWrite)
+      : DebugVar(VarType::Int32, name, data, help, fmt, unit, access) {}
 
   // Like above, but unsigned
   DebugVar(const char *name, uint32_t *data, const char *help = "",
-           const char *fmt = "%u")
-      : DebugVar(VarType::UInt32, name, data, help, fmt) {}
+           const char *fmt = "%u", const char *unit = "",
+           VarAccess access = VarAccess::ReadWrite)
+      : DebugVar(VarType::UInt32, name, data, help, fmt, unit, access) {}
 
   // Like above, but float
   DebugVar(const char *name, float *data, const char *help = "",
-           const char *fmt = "%.3f")
-      : DebugVar(VarType::Float, name, data, help, fmt) {}
+           const char *fmt = "%.3f", const char *unit = "",
+           VarAccess access = VarAccess::ReadWrite)
+      : DebugVar(VarType::Float, name, data, help, fmt, unit, access) {}
 
   // Gets the current value of the variable as an uint32_t.
   uint32_t GetValue() override {
@@ -119,23 +144,37 @@ public:
   }
 
   // Sets the current value of the variable as an uint32_t.
-  void SetValue(uint32_t value) override { std::memcpy(addr_, &value, 4); }
+  bool SetValue(uint32_t value) override {
+    if (!WriteAllowed())
+      return false;
+
+    std::memcpy(addr_, &value, 4);
+    return true;
+  }
 
 private:
   void *addr_;
 
   DebugVar(VarType type, const char *name, void *data, const char *help,
-           const char *fmt)
-      : DebugVarBase(type, name, help, fmt), addr_(data) {}
+           const char *fmt, const char *unit = "",
+           VarAccess access = VarAccess::ReadWrite)
+      : DebugVarBase(type, name, help, fmt, unit, access), addr_(data) {}
 };
 
 class DebugInt32 : public DebugVar {
 public:
   explicit DebugInt32(const char *name, const char *help = "", int32_t init = 0,
-                      const char *fmt = "%d")
-      : DebugVar(name, &value_, help, fmt), value_(init) {}
+                      const char *fmt = "%d", const char *unit = "",
+                      VarAccess access = VarAccess::ReadWrite)
+      : DebugVar(name, &value_, help, fmt, unit, access), value_(init) {}
 
-  void Set(int32_t v) { value_ = v; }
+  bool Set(int32_t v) {
+    if (!WriteAllowed())
+      return false;
+
+    value_ = v;
+    return true;
+  }
   int32_t Get() const { return value_; }
 
 private:
@@ -145,10 +184,18 @@ private:
 class DebugUInt32 : public DebugVar {
 public:
   explicit DebugUInt32(const char *name, const char *help = "",
-                       uint32_t init = 0, const char *fmt = "%u")
-      : DebugVar(name, &value_, help, fmt), value_(init) {}
+                       uint32_t init = 0, const char *fmt = "%u",
+                       const char *unit = "",
+                       VarAccess access = VarAccess::ReadWrite)
+      : DebugVar(name, &value_, help, fmt, unit, access), value_(init) {}
 
-  void Set(uint32_t v) { value_ = v; }
+  bool Set(uint32_t v) {
+    if (!WriteAllowed())
+      return false;
+
+    value_ = v;
+    return true;
+  }
   uint32_t Get() const { return value_; }
 
 private:
@@ -158,10 +205,17 @@ private:
 class DebugFloat : public DebugVar {
 public:
   explicit DebugFloat(const char *name, const char *help = "", float init = 0,
-                      const char *fmt = "%.3f")
-      : DebugVar(name, &value_, help, fmt), value_(init) {}
+                      const char *fmt = "%.3f", const char *unit = "",
+                      VarAccess access = VarAccess::ReadWrite)
+      : DebugVar(name, &value_, help, fmt, unit, access), value_(init) {}
 
-  void Set(float v) { value_ = v; }
+  bool Set(float v) {
+    if (!WriteAllowed())
+      return false;
+
+    value_ = v;
+    return true;
+  }
   float Get() const { return value_; }
 
 private:

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -372,12 +372,13 @@ void HalApi::StartLoopTimer(const Duration &period, void (*callback)(void *),
 }
 
 static float latency, max_latency, loop_time;
-static DebugVar d1("loop_latency", &latency, "Latency of loop function, usec",
-                   "%.2f");
+static DebugVar d1("loop_latency", &latency, "Latency of loop function",
+                   VarAccess::ReadOnly, "%.2f", "usec");
 static DebugVar d2("max_latency", &max_latency,
-                   "Maximum latency of loop function, usec", "%.2f");
-static DebugVar d3("loop_time", &loop_time, "Duration of loop function, usec",
-                   "%.2f");
+                   "Maximum latency of loop function", VarAccess::ReadOnly,
+                   "%.2f", "usec");
+static DebugVar d3("loop_time", &loop_time, "Duration of loop function",
+                   VarAccess::ReadOnly, "%.2f", "usec");
 
 static void Timer15ISR() {
   uint32_t start = Timer15Base->counter;

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -41,9 +41,11 @@ limitations under the License.
 // zero a bit above that) and fully open at 0.90.
 static DebugFloat dbg_psol_pwm_closed("psol_pwm_closed",
                                       "PWM power that closes the psol [0,1]",
+                                      VarAccess::ReadWrite,
                                       0.35f); // UFlow IBV19M value
 static DebugFloat dbg_psol_pwm_open("psol_pwm_open",
                                     "PWM power that opens the psol [0,1]",
+                                    VarAccess::ReadWrite,
                                     0.75f); // UFlow IBV19M value
 
 void HalApi::InitPSOL() {

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -36,16 +36,18 @@ static DebugUInt32
              "network_protocol.proto.  If this is out of range (e.g. set to "
              "-1), this and all of the other gui_foo DebugVars are ignored, "
              "and instead the controller takes orders from the GUI itself.",
-             std::numeric_limits<uint32_t>::max());
-static DebugUInt32 gui_bpm("gui_bpm", "Breaths/min for GUI-free testing", 15);
+             VarAccess::ReadWrite, std::numeric_limits<uint32_t>::max());
+static DebugUInt32 gui_bpm("gui_bpm", "Breaths/min for GUI-free testing",
+                           VarAccess::ReadWrite, 15);
 static DebugUInt32 gui_peep("gui_peep", "PEEP (cm/h2O) for GUI-free testing",
-                            5);
-static DebugUInt32 gui_pip("gui_pip", "PIP (cm/h2O) for GUI-free testing", 15);
+                            VarAccess::ReadWrite, 5);
+static DebugUInt32 gui_pip("gui_pip", "PIP (cm/h2O) for GUI-free testing",
+                           VarAccess::ReadWrite, 15);
 static DebugFloat gui_ie_ratio("gui_ie_ratio", "I/E ratio for GUI-free testing",
-                               0.66f);
+                               VarAccess::ReadWrite, 0.66f);
 static DebugFloat
     gui_fio2("gui_fio2", "Percent oxygen (range [21,100]) for GUI-free testing",
-             21);
+             VarAccess::ReadWrite, 21);
 
 static Controller controller;
 static ControllerStatus controller_status;

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -41,10 +41,10 @@ TEST(TraceHandler, Flush) {
   // define some debug variables
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::UInt32, "x", "", "", [&] { return i; },
+      VarType::UInt32, "x", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UInt32, "x", "", "", [&] { return i * 10; },
+      VarType::UInt32, "x", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler
@@ -82,10 +82,10 @@ TEST(TraceHandler, Read) {
   // define some debug variables
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::UInt32, "x", "", "", [&] { return i; },
+      VarType::UInt32, "x", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UInt32, "y", "", "", [&] { return i * 10; },
+      VarType::UInt32, "y", "", [&] { return i * 10; },
       [&](uint32_t value) { (void)value; });
 
   // define trace and trace handler

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -25,10 +25,10 @@ using namespace Debug;
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
   FnDebugVar var_x(
-      VarType::UInt32, "x", "", "", [&] { return i; },
+      VarType::UInt32, "x", "", [&] { return i; },
       [&](uint32_t value) { (void)value; });
   FnDebugVar var_y(
-      VarType::UInt32, "y", "", "", [&] { return 10 * i; },
+      VarType::UInt32, "y", "", [&] { return 10 * i; },
       [&](uint32_t value) { (void)value; });
 
   Trace trace;

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -27,7 +27,7 @@ TEST(VarHandler, GetVarInfo) {
   const char *help = "help string";
   const char *format = "format";
   const char *unit = "unit";
-  DebugVar var(name, &value, help, format, unit, VarAccess::ReadOnly);
+  DebugVar var(name, &value, help, VarAccess::ReadOnly, format, unit);
 
   // expected result is hand-built from format given in var_cmd.cpp
   std::vector<uint8_t> expected = {static_cast<uint8_t>(VarType::UInt32),
@@ -71,7 +71,7 @@ TEST(VarHandler, GetVarInfo) {
 
 TEST(VarHandler, GetVar) {
   uint32_t value = 0xDEADBEEF;
-  DebugVar var("name", &value, "help", "fmt");
+  DebugVar var("name", &value, "help", VarAccess::ReadWrite);
 
   // Test that a GET command obtains the variable's value.
   uint8_t id[2];
@@ -100,7 +100,7 @@ TEST(VarHandler, GetVar) {
 
 TEST(VarHandler, SetVar) {
   uint32_t value = 0xDEADBEEF;
-  DebugVar var("name", &value, "help", "fmt");
+  DebugVar var("name", &value, "help", VarAccess::ReadWrite);
 
   uint32_t new_value = 0xCAFEBABE;
   std::array<uint8_t, 4> new_bytes;
@@ -137,7 +137,7 @@ TEST(VarHandler, SetVar) {
 
 TEST(VarHandler, GetVarCount) {
   uint32_t value = 0xDEADBEEF;
-  DebugVar dummy("name", &value, "help", "fmt");
+  DebugVar dummy("name", &value);
 
   // Test that GetVarCount command obtains the number of defined variables
   std::array req = {static_cast<uint8_t>(VarHandler::Subcommand::GetCount)};
@@ -161,11 +161,10 @@ TEST(VarHandler, GetVarCount) {
 
 TEST(VarHandler, Errors) {
   uint32_t value = 0xDEADBEEF;
-  DebugUInt32 var("name", "help", value);
+  DebugUInt32 var("name", "help", VarAccess::ReadWrite, value);
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
-  DebugUInt32 var_readonly("name", "help", value, "format", "unit",
-                           VarAccess::ReadOnly);
+  DebugUInt32 var_readonly("name", "help", VarAccess::ReadOnly, value);
   uint8_t id_readonly[2];
   u16_to_u8(var_readonly.GetId(), id_readonly);
 

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -26,23 +26,26 @@ TEST(VarHandler, GetVarInfo) {
   const char *name = "name";
   const char *help = "help string";
   const char *format = "format";
-  DebugVar var(name, &value, help, format);
+  const char *unit = "unit";
+  DebugVar var(name, &value, help, format, unit, VarAccess::ReadOnly);
 
   // expected result is hand-built from format given in var_cmd.cpp
   std::vector<uint8_t> expected = {static_cast<uint8_t>(VarType::UInt32),
-                                   0,
+                                   static_cast<uint8_t>(VarAccess::ReadOnly),
                                    0,
                                    0,
                                    static_cast<uint8_t>(strlen(name)),
                                    static_cast<uint8_t>(strlen(format)),
                                    static_cast<uint8_t>(strlen(help)),
-                                   0};
+                                   static_cast<uint8_t>(strlen(unit))};
   for (size_t i = 0; i < strlen(name); ++i)
     expected.push_back(name[i]);
   for (size_t i = 0; i < strlen(format); ++i)
     expected.push_back(format[i]);
   for (size_t i = 0; i < strlen(help); ++i)
     expected.push_back(help[i]);
+  for (size_t i = 0; i < strlen(unit); ++i)
+    expected.push_back(unit[i]);
 
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
@@ -132,15 +135,43 @@ TEST(VarHandler, SetVar) {
   EXPECT_EQ(new_value, value);
 }
 
+TEST(VarHandler, GetVarCount) {
+  uint32_t value = 0xDEADBEEF;
+  DebugVar dummy("name", &value, "help", "fmt");
+
+  // Test that GetVarCount command obtains the number of defined variables
+  std::array req = {static_cast<uint8_t>(VarHandler::Subcommand::GetCount)};
+  std::array<uint8_t, 4> response;
+  bool processed{false};
+  Context context = {.request = req.data(),
+                     .request_length = std::size(req),
+                     .response = response.data(),
+                     .max_response_length = std::size(response),
+                     .response_length = 0,
+                     .processed = &processed};
+
+  EXPECT_EQ(ErrorCode::None, VarHandler().Process(&context));
+  EXPECT_TRUE(processed);
+  EXPECT_EQ(4, context.response_length);
+
+  std::array<uint8_t, 4> expected_result;
+  u32_to_u8(DebugVarBase::GetVarCount(), expected_result.data());
+  EXPECT_EQ(response, expected_result);
+}
+
 TEST(VarHandler, Errors) {
   uint32_t value = 0xDEADBEEF;
   DebugUInt32 var("name", "help", value);
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
+  DebugUInt32 var_readonly("name", "help", value, "format", "unit",
+                           VarAccess::ReadOnly);
+  uint8_t id_readonly[2];
+  u16_to_u8(var_readonly.GetId(), id_readonly);
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
       {{}, ErrorCode::MissingData},  // Missing subcommand
-      {{3}, ErrorCode::InvalidData}, // Invalid subcommand
+      {{4}, ErrorCode::InvalidData}, // Invalid subcommand
       {{0, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
       {{1, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
       {{2, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
@@ -149,7 +180,10 @@ TEST(VarHandler, Errors) {
       {{2, 1}, ErrorCode::MissingData},
       {{0, id[0], id[1]}, ErrorCode::NoMemory},
       {{1, id[0], id[1]}, ErrorCode::NoMemory},
+      {{3}, ErrorCode::NoMemory},
       {{2, id[0], id[1], 0xCA, 0xFE, 0x00}, ErrorCode::MissingData},
+      {{2, id_readonly[0], id_readonly[1], 0xCA, 0xFE, 0x00, 0x00},
+       ErrorCode::InternalError},
   };
 
   for (auto &[request, error] : requests) {

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -20,13 +20,13 @@ limitations under the License.
 
 TEST(DebugVar, DebugVarInt32) {
   int32_t value = 5;
-  DebugVar var("var", &value, "help", "fmt", "unit");
+  DebugVar var("var", &value, "help", VarAccess::ReadOnly, "fmt", "unit");
   EXPECT_EQ("var", var.GetName());
   EXPECT_EQ("help", var.GetHelp());
   EXPECT_EQ(VarType::Int32, var.GetType());
   EXPECT_EQ("fmt", var.GetFormat());
   EXPECT_EQ("unit", var.GetUnit());
-  EXPECT_EQ(VarAccess::ReadWrite, var.GetAccess());
+  EXPECT_EQ(VarAccess::ReadOnly, var.GetAccess());
   EXPECT_EQ(&var, DebugVar::FindVar(var.GetId()));
 
   EXPECT_EQ(uint32_t{5}, var.GetValue());
@@ -45,28 +45,7 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ("", var_default.GetHelp());
   EXPECT_EQ("%d", var_default.GetFormat());
   EXPECT_EQ("", var_default.GetUnit());
-}
-
-TEST(DebugVar, ReadOnlyDebugVar) {
-  int32_t value = 5;
-  // Attempting to SetValue (or Set) read only variables yields false and leave
-  // value unchanged
-  DebugVar var("var", &value, "help", "fmt", "unit", VarAccess::ReadOnly);
-  EXPECT_FALSE(var.SetValue(8));
-  EXPECT_EQ(value, var.GetValue());
-
-  DebugInt32 int32("var", "help", value, "fmt", "unit", VarAccess::ReadOnly);
-  EXPECT_FALSE(int32.Set(-8));
-  EXPECT_EQ(value, int32.GetValue());
-
-  DebugUInt32 uint32("var", "help", static_cast<uint32_t>(value), "fmt", "unit",
-                     VarAccess::ReadOnly);
-  EXPECT_FALSE(uint32.Set(8));
-  EXPECT_EQ(value, uint32.GetValue());
-
-  DebugFloat floatvar("var", "help", 5.0f, "fmt", "unit", VarAccess::ReadOnly);
-  EXPECT_FALSE(floatvar.Set(-8.0f));
-  EXPECT_EQ(5.0f, floatvar.Get());
+  EXPECT_EQ(VarAccess::ReadWrite, var_default.GetAccess());
 }
 
 TEST(DebugVar, DebugVarUint32Defaults) {


### PR DESCRIPTION
# Description

Per discussions with @martukas, improved the debug variables interface on controller side:
Added a var subcommand to get the number of active debug vars and for each variable: 
- a new `unit` string attribure
- a new `access` [ReadOnly | ReadWrite] attribute which makes calling `set` on a ReadOnly variable return an internal error

Updates #832

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
