### PR TITLE
Debug variable improvements, explicit registry singleton, PID improvements

### DIFF
--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -15,7 +15,7 @@ limitations under the License.
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <type_traits>
 
@@ -49,7 +49,7 @@ limitations under the License.
 //   printf("42 kPa - 10 cm_h20 is %f kPa or %f cm_h2o\n",
 //          diff.kPa(), diff.cmH2O());
 //
-// Observe that we create an instance of Pressure by calling the kPa() bare
+// observe that we create an instance of Pressure by calling the kPa() bare
 // function.  We provide the following bare functions
 //
 //   Pressure         kPa(float)

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -48,7 +48,7 @@ limitations under the License.
 //   printf("42 kPa - 10 cm_h20 is %f kPa or %f cm_h2o\n",
 //          diff.kPa(), diff.cmH2O());
 //
-// observe that we create an instance of Pressure by calling the kPa() bare
+// Observe that we create an instance of Pressure by calling the kPa() bare
 // function.  We provide the following bare functions
 //
 //   Pressure         kPa(float)

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -102,8 +102,9 @@ namespace UnitsDetail {
 //   class Length : public Scalar<Length, float> { ... };
 //
 // [1] https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
-template <class Q, class ValTy> class Scalar {
-public:
+template <class Q, class ValTy>
+class Scalar {
+ public:
   Scalar() : val_(0) {}
 
   constexpr bool operator<(const Scalar &s) const { return val_ < s.val_; }
@@ -113,7 +114,7 @@ public:
   constexpr bool operator>=(const Scalar &s) const { return val_ >= s.val_; }
   constexpr bool operator>(const Scalar &s) const { return val_ > s.val_; }
 
-protected:
+ protected:
   constexpr explicit Scalar(ValTy val) : val_(val) {}
   ValTy val_;
 };
@@ -131,36 +132,25 @@ protected:
 //   floating-point, these operators are not defined.
 //
 // Be aware that dividing by 0 yields Inf and needs to be protected.
-template <class Q, class ValTy> class ArithScalar : public Scalar<Q, ValTy> {
-public:
-  constexpr Q operator+(const ArithScalar &a) const {
-    return Q(this->val_ + a.val_);
-  }
-  Q &operator+=(const ArithScalar &a) {
-    return static_cast<Q &>(*this = *this + a);
-  }
+template <class Q, class ValTy>
+class ArithScalar : public Scalar<Q, ValTy> {
+ public:
+  constexpr Q operator+(const ArithScalar &a) const { return Q(this->val_ + a.val_); }
+  Q &operator+=(const ArithScalar &a) { return static_cast<Q &>(*this = *this + a); }
 
-  constexpr Q operator-(const ArithScalar &a) const {
-    return Q(this->val_ - a.val_);
-  }
-  Q &operator-=(const ArithScalar &a) {
-    return static_cast<Q &>(*this = *this - a);
-  }
+  constexpr Q operator-(const ArithScalar &a) const { return Q(this->val_ - a.val_); }
+  Q &operator-=(const ArithScalar &a) { return static_cast<Q &>(*this = *this - a); }
 
   constexpr Q operator*(const ValTy &a) const { return Q(this->val_ * a); }
-  constexpr friend Q operator*(const ValTy &a, const Q &b) {
-    return Q(b.val_ * a);
-  }
+  constexpr friend Q operator*(const ValTy &a, const Q &b) { return Q(b.val_ * a); }
   Q &operator*=(const ValTy &a) { return static_cast<Q &>(*this = *this * a); }
 
   // Division by a unitless scalar, defined only if ValTy is floating-point.
-  template <typename VT = ValTy,
-            std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
+  template <typename VT = ValTy, std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
   constexpr Q operator/(const ValTy &a) const {
     return Q(this->val_ / a);
   }
-  template <typename VT = ValTy,
-            std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
+  template <typename VT = ValTy, std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
   Q &operator/=(const ValTy &a) {
     return static_cast<Q &>(*this = *this / a);
   }
@@ -171,12 +161,12 @@ public:
     return static_cast<float>(this->val_) / static_cast<float>(a.val_);
   }
 
-protected:
+ protected:
   // Pull in base class's constructor.
   using Scalar<Q, ValTy>::Scalar;
 };
 
-} // namespace UnitsDetail
+}  // namespace UnitsDetail
 
 // Represents pressure, e.g. air pressure.
 //
@@ -189,12 +179,12 @@ protected:
 //
 // Native unit (implementation detail): kPa
 class Pressure : public UnitsDetail::ArithScalar<Pressure, float> {
-public:
+ public:
   [[nodiscard]] constexpr float kPa() const { return val_; }
   [[nodiscard]] constexpr float cmH2O() const { return val_ * KPaToCmH2O; }
   [[nodiscard]] constexpr float atm() const { return val_ / AtmToKPa; }
 
-private:
+ private:
   // https://www.google.com/search?q=kpa+to+cmh2o
   static constexpr float KPaToCmH2O{10.1972f};
   // https://www.google.com/search?q=atm+to+kPa
@@ -208,9 +198,7 @@ private:
 };
 
 constexpr Pressure kPa(float kpa) { return Pressure(kpa); }
-constexpr Pressure cmH2O(float cm_h2o) {
-  return Pressure(cm_h2o / Pressure::KPaToCmH2O);
-}
+constexpr Pressure cmH2O(float cm_h2o) { return Pressure(cm_h2o / Pressure::KPaToCmH2O); }
 constexpr Pressure atm(float atm) { return Pressure(atm * Pressure::AtmToKPa); }
 
 // Represents a length.
@@ -223,11 +211,11 @@ constexpr Pressure atm(float atm) { return Pressure(atm * Pressure::AtmToKPa); }
 //
 // Native unit (implementation detail): meters
 class Length : public UnitsDetail::ArithScalar<Length, float> {
-public:
+ public:
   [[nodiscard]] constexpr float meters() const { return val_; }
   [[nodiscard]] constexpr float millimeters() const { return val_ * 1000; }
 
-private:
+ private:
   constexpr friend Length meters(float meters);
   constexpr friend Length millimeters(float mm);
 
@@ -253,17 +241,13 @@ constexpr Length millimeters(float mm) { return Length(mm / 1000); }
 // Dividing a Volume by a Duration (see below) gives you a VolumetricFlow.
 // Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
 class VolumetricFlow : public UnitsDetail::ArithScalar<VolumetricFlow, float> {
-public:
+ public:
   [[nodiscard]] constexpr float cubic_m_per_sec() const { return val_; }
-  [[nodiscard]] constexpr float ml_per_min() const {
-    return val_ * 1000.0f * 1000.0f * 60.0f;
-  }
-  [[nodiscard]] constexpr float liters_per_sec() const {
-    return val_ * 1000.0f;
-  }
+  [[nodiscard]] constexpr float ml_per_min() const { return val_ * 1000.0f * 1000.0f * 60.0f; }
+  [[nodiscard]] constexpr float liters_per_sec() const { return val_ * 1000.0f; }
   [[nodiscard]] constexpr float ml_per_sec() const { return val_ * 1.0e6f; }
 
-private:
+ private:
   constexpr friend VolumetricFlow cubic_m_per_sec(float m3ps);
   constexpr friend VolumetricFlow ml_per_min(float ml_per_min);
   constexpr friend VolumetricFlow liters_per_sec(float lps);
@@ -272,18 +256,12 @@ private:
   using UnitsDetail::ArithScalar<VolumetricFlow, float>::ArithScalar;
 };
 
-constexpr VolumetricFlow cubic_m_per_sec(float m3ps) {
-  return VolumetricFlow(m3ps);
-}
+constexpr VolumetricFlow cubic_m_per_sec(float m3ps) { return VolumetricFlow(m3ps); }
 constexpr VolumetricFlow ml_per_min(float ml_per_min) {
   return VolumetricFlow(ml_per_min / (1000.0f * 1000.0f * 60.0f));
 }
-constexpr VolumetricFlow liters_per_sec(float lps) {
-  return VolumetricFlow(lps / (1000.0f));
-}
-constexpr VolumetricFlow ml_per_sec(float mlps) {
-  return VolumetricFlow(mlps / (1.0e6f));
-}
+constexpr VolumetricFlow liters_per_sec(float lps) { return VolumetricFlow(lps / (1000.0f)); }
+constexpr VolumetricFlow ml_per_sec(float mlps) { return VolumetricFlow(mlps / (1.0e6f)); }
 
 // Represents volume.
 //
@@ -299,11 +277,11 @@ constexpr VolumetricFlow ml_per_sec(float mlps) {
 // Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
 // Dividing a Volume by a Duration gives you a VolumetricFlow.
 class Volume : public UnitsDetail::ArithScalar<Volume, float> {
-public:
+ public:
   [[nodiscard]] constexpr float cubic_m() const { return val_; }
   [[nodiscard]] constexpr float ml() const { return val_ * 1000.0f * 1000.0f; }
 
-private:
+ private:
   constexpr friend Volume cubic_m(float m3);
   constexpr friend Volume ml(float ml);
 
@@ -319,10 +297,10 @@ constexpr Volume ml(float ml) { return Volume(ml / (1000.0f * 1000.0f)); }
 //
 // Units: Volts
 class Voltage : public UnitsDetail::ArithScalar<Voltage, float> {
-public:
+ public:
   [[nodiscard]] constexpr float volts() const { return val_; }
 
-private:
+ private:
   constexpr friend Voltage volts(float v);
 
   using UnitsDetail::ArithScalar<Voltage, float>::ArithScalar;
@@ -373,14 +351,10 @@ class Time;
 // milliseconds(int64_t) factory) is worse, because converting an int64
 // milliseconds to float may lose useful precision.
 class Duration : public UnitsDetail::ArithScalar<Duration, int64_t> {
-public:
+ public:
   [[nodiscard]] constexpr int64_t microseconds() const { return val_; }
-  [[nodiscard]] constexpr float milliseconds() const {
-    return static_cast<float>(val_) / 1000;
-  }
-  [[nodiscard]] constexpr float seconds() const {
-    return milliseconds() / 1000;
-  }
+  [[nodiscard]] constexpr float milliseconds() const { return static_cast<float>(val_) / 1000; }
+  [[nodiscard]] constexpr float seconds() const { return milliseconds() / 1000; }
   [[nodiscard]] constexpr float minutes() const { return seconds() / 60; }
 
   constexpr friend Time operator+(const Time &t, const Duration &dt);
@@ -388,24 +362,24 @@ public:
   constexpr friend Time operator-(const Time &t, const Duration &dt);
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
-private:
+ private:
   constexpr friend Duration microseconds(int64_t micros);
 
   using UnitsDetail::ArithScalar<Duration, int64_t>::ArithScalar;
 };
 
 constexpr Duration microseconds(int64_t micros) { return Duration(micros); }
-constexpr Duration milliseconds(int64_t millis) {
-  return microseconds(millis * 1000);
-}
+constexpr Duration milliseconds(int64_t millis) { return microseconds(millis * 1000); }
 
 // Add a dummy template to make these overloads have lower priority than the
 // int64_t version.  We need a `double` version otherwise passing a double
 // (even just a double constant, like "0.1") will prefer the int64_t version!
-template <int /*dummy*/ = 0> constexpr Duration milliseconds(float millis) {
+template <int /*dummy*/ = 0>
+constexpr Duration milliseconds(float millis) {
   return microseconds(static_cast<int64_t>(millis * 1000));
 }
-template <int /*dummy*/ = 0> constexpr Duration milliseconds(double millis) {
+template <int /*dummy*/ = 0>
+constexpr Duration milliseconds(double millis) {
   return microseconds(static_cast<int64_t>(millis * 1000));
 }
 
@@ -423,7 +397,7 @@ constexpr Duration minutes(float mins) { return seconds(mins * 60); }
 //
 // Native unit (implementation detail): uint64_t microseconds
 class Time : public UnitsDetail::Scalar<Time, uint64_t> {
-public:
+ public:
   [[nodiscard]] uint64_t microsSinceStartup() const { return val_; }
 
   constexpr friend Time operator+(const Time &t, const Duration &dt);
@@ -433,7 +407,7 @@ public:
   Time &operator+=(const Duration &dt) { return *this = *this + dt; }
   Time &operator-=(const Duration &dt) { return *this = *this - dt; }
 
-private:
+ private:
   constexpr friend Time microsSinceStartup(uint64_t micros);
 
   using UnitsDetail::Scalar<Time, uint64_t>::Scalar;

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -16,7 +16,6 @@ limitations under the License.
 #pragma once
 
 #include <cstdint>
-
 #include <type_traits>
 
 // Wrappers for measurements of different physical quantities [1] (length,

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -102,9 +102,8 @@ namespace UnitsDetail {
 //   class Length : public Scalar<Length, float> { ... };
 //
 // [1] https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
-template <class Q, class ValTy>
-class Scalar {
- public:
+template <class Q, class ValTy> class Scalar {
+public:
   Scalar() : val_(0) {}
 
   constexpr bool operator<(const Scalar &s) const { return val_ < s.val_; }
@@ -114,7 +113,7 @@ class Scalar {
   constexpr bool operator>=(const Scalar &s) const { return val_ >= s.val_; }
   constexpr bool operator>(const Scalar &s) const { return val_ > s.val_; }
 
- protected:
+protected:
   constexpr explicit Scalar(ValTy val) : val_(val) {}
   ValTy val_;
 };
@@ -132,25 +131,36 @@ class Scalar {
 //   floating-point, these operators are not defined.
 //
 // Be aware that dividing by 0 yields Inf and needs to be protected.
-template <class Q, class ValTy>
-class ArithScalar : public Scalar<Q, ValTy> {
- public:
-  constexpr Q operator+(const ArithScalar &a) const { return Q(this->val_ + a.val_); }
-  Q &operator+=(const ArithScalar &a) { return static_cast<Q &>(*this = *this + a); }
+template <class Q, class ValTy> class ArithScalar : public Scalar<Q, ValTy> {
+public:
+  constexpr Q operator+(const ArithScalar &a) const {
+    return Q(this->val_ + a.val_);
+  }
+  Q &operator+=(const ArithScalar &a) {
+    return static_cast<Q &>(*this = *this + a);
+  }
 
-  constexpr Q operator-(const ArithScalar &a) const { return Q(this->val_ - a.val_); }
-  Q &operator-=(const ArithScalar &a) { return static_cast<Q &>(*this = *this - a); }
+  constexpr Q operator-(const ArithScalar &a) const {
+    return Q(this->val_ - a.val_);
+  }
+  Q &operator-=(const ArithScalar &a) {
+    return static_cast<Q &>(*this = *this - a);
+  }
 
   constexpr Q operator*(const ValTy &a) const { return Q(this->val_ * a); }
-  constexpr friend Q operator*(const ValTy &a, const Q &b) { return Q(b.val_ * a); }
+  constexpr friend Q operator*(const ValTy &a, const Q &b) {
+    return Q(b.val_ * a);
+  }
   Q &operator*=(const ValTy &a) { return static_cast<Q &>(*this = *this * a); }
 
   // Division by a unitless scalar, defined only if ValTy is floating-point.
-  template <typename VT = ValTy, std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
+  template <typename VT = ValTy,
+            std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
   constexpr Q operator/(const ValTy &a) const {
     return Q(this->val_ / a);
   }
-  template <typename VT = ValTy, std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
+  template <typename VT = ValTy,
+            std::enable_if_t<std::is_floating_point_v<VT>, int> = 0>
   Q &operator/=(const ValTy &a) {
     return static_cast<Q &>(*this = *this / a);
   }
@@ -161,12 +171,12 @@ class ArithScalar : public Scalar<Q, ValTy> {
     return static_cast<float>(this->val_) / static_cast<float>(a.val_);
   }
 
- protected:
+protected:
   // Pull in base class's constructor.
   using Scalar<Q, ValTy>::Scalar;
 };
 
-}  // namespace UnitsDetail
+} // namespace UnitsDetail
 
 // Represents pressure, e.g. air pressure.
 //
@@ -179,12 +189,12 @@ class ArithScalar : public Scalar<Q, ValTy> {
 //
 // Native unit (implementation detail): kPa
 class Pressure : public UnitsDetail::ArithScalar<Pressure, float> {
- public:
+public:
   [[nodiscard]] constexpr float kPa() const { return val_; }
   [[nodiscard]] constexpr float cmH2O() const { return val_ * KPaToCmH2O; }
   [[nodiscard]] constexpr float atm() const { return val_ / AtmToKPa; }
 
- private:
+private:
   // https://www.google.com/search?q=kpa+to+cmh2o
   static constexpr float KPaToCmH2O{10.1972f};
   // https://www.google.com/search?q=atm+to+kPa
@@ -198,7 +208,9 @@ class Pressure : public UnitsDetail::ArithScalar<Pressure, float> {
 };
 
 constexpr Pressure kPa(float kpa) { return Pressure(kpa); }
-constexpr Pressure cmH2O(float cm_h2o) { return Pressure(cm_h2o / Pressure::KPaToCmH2O); }
+constexpr Pressure cmH2O(float cm_h2o) {
+  return Pressure(cm_h2o / Pressure::KPaToCmH2O);
+}
 constexpr Pressure atm(float atm) { return Pressure(atm * Pressure::AtmToKPa); }
 
 // Represents a length.
@@ -211,11 +223,11 @@ constexpr Pressure atm(float atm) { return Pressure(atm * Pressure::AtmToKPa); }
 //
 // Native unit (implementation detail): meters
 class Length : public UnitsDetail::ArithScalar<Length, float> {
- public:
+public:
   [[nodiscard]] constexpr float meters() const { return val_; }
   [[nodiscard]] constexpr float millimeters() const { return val_ * 1000; }
 
- private:
+private:
   constexpr friend Length meters(float meters);
   constexpr friend Length millimeters(float mm);
 
@@ -241,13 +253,17 @@ constexpr Length millimeters(float mm) { return Length(mm / 1000); }
 // Dividing a Volume by a Duration (see below) gives you a VolumetricFlow.
 // Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
 class VolumetricFlow : public UnitsDetail::ArithScalar<VolumetricFlow, float> {
- public:
+public:
   [[nodiscard]] constexpr float cubic_m_per_sec() const { return val_; }
-  [[nodiscard]] constexpr float ml_per_min() const { return val_ * 1000.0f * 1000.0f * 60.0f; }
-  [[nodiscard]] constexpr float liters_per_sec() const { return val_ * 1000.0f; }
+  [[nodiscard]] constexpr float ml_per_min() const {
+    return val_ * 1000.0f * 1000.0f * 60.0f;
+  }
+  [[nodiscard]] constexpr float liters_per_sec() const {
+    return val_ * 1000.0f;
+  }
   [[nodiscard]] constexpr float ml_per_sec() const { return val_ * 1.0e6f; }
 
- private:
+private:
   constexpr friend VolumetricFlow cubic_m_per_sec(float m3ps);
   constexpr friend VolumetricFlow ml_per_min(float ml_per_min);
   constexpr friend VolumetricFlow liters_per_sec(float lps);
@@ -256,12 +272,18 @@ class VolumetricFlow : public UnitsDetail::ArithScalar<VolumetricFlow, float> {
   using UnitsDetail::ArithScalar<VolumetricFlow, float>::ArithScalar;
 };
 
-constexpr VolumetricFlow cubic_m_per_sec(float m3ps) { return VolumetricFlow(m3ps); }
+constexpr VolumetricFlow cubic_m_per_sec(float m3ps) {
+  return VolumetricFlow(m3ps);
+}
 constexpr VolumetricFlow ml_per_min(float ml_per_min) {
   return VolumetricFlow(ml_per_min / (1000.0f * 1000.0f * 60.0f));
 }
-constexpr VolumetricFlow liters_per_sec(float lps) { return VolumetricFlow(lps / (1000.0f)); }
-constexpr VolumetricFlow ml_per_sec(float mlps) { return VolumetricFlow(mlps / (1.0e6f)); }
+constexpr VolumetricFlow liters_per_sec(float lps) {
+  return VolumetricFlow(lps / (1000.0f));
+}
+constexpr VolumetricFlow ml_per_sec(float mlps) {
+  return VolumetricFlow(mlps / (1.0e6f));
+}
 
 // Represents volume.
 //
@@ -277,11 +299,11 @@ constexpr VolumetricFlow ml_per_sec(float mlps) { return VolumetricFlow(mlps / (
 // Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
 // Dividing a Volume by a Duration gives you a VolumetricFlow.
 class Volume : public UnitsDetail::ArithScalar<Volume, float> {
- public:
+public:
   [[nodiscard]] constexpr float cubic_m() const { return val_; }
   [[nodiscard]] constexpr float ml() const { return val_ * 1000.0f * 1000.0f; }
 
- private:
+private:
   constexpr friend Volume cubic_m(float m3);
   constexpr friend Volume ml(float ml);
 
@@ -297,10 +319,10 @@ constexpr Volume ml(float ml) { return Volume(ml / (1000.0f * 1000.0f)); }
 //
 // Units: Volts
 class Voltage : public UnitsDetail::ArithScalar<Voltage, float> {
- public:
+public:
   [[nodiscard]] constexpr float volts() const { return val_; }
 
- private:
+private:
   constexpr friend Voltage volts(float v);
 
   using UnitsDetail::ArithScalar<Voltage, float>::ArithScalar;
@@ -351,10 +373,14 @@ class Time;
 // milliseconds(int64_t) factory) is worse, because converting an int64
 // milliseconds to float may lose useful precision.
 class Duration : public UnitsDetail::ArithScalar<Duration, int64_t> {
- public:
+public:
   [[nodiscard]] constexpr int64_t microseconds() const { return val_; }
-  [[nodiscard]] constexpr float milliseconds() const { return static_cast<float>(val_) / 1000; }
-  [[nodiscard]] constexpr float seconds() const { return milliseconds() / 1000; }
+  [[nodiscard]] constexpr float milliseconds() const {
+    return static_cast<float>(val_) / 1000;
+  }
+  [[nodiscard]] constexpr float seconds() const {
+    return milliseconds() / 1000;
+  }
   [[nodiscard]] constexpr float minutes() const { return seconds() / 60; }
 
   constexpr friend Time operator+(const Time &t, const Duration &dt);
@@ -362,24 +388,24 @@ class Duration : public UnitsDetail::ArithScalar<Duration, int64_t> {
   constexpr friend Time operator-(const Time &t, const Duration &dt);
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
- private:
+private:
   constexpr friend Duration microseconds(int64_t micros);
 
   using UnitsDetail::ArithScalar<Duration, int64_t>::ArithScalar;
 };
 
 constexpr Duration microseconds(int64_t micros) { return Duration(micros); }
-constexpr Duration milliseconds(int64_t millis) { return microseconds(millis * 1000); }
+constexpr Duration milliseconds(int64_t millis) {
+  return microseconds(millis * 1000);
+}
 
 // Add a dummy template to make these overloads have lower priority than the
 // int64_t version.  We need a `double` version otherwise passing a double
 // (even just a double constant, like "0.1") will prefer the int64_t version!
-template <int /*dummy*/ = 0>
-constexpr Duration milliseconds(float millis) {
+template <int /*dummy*/ = 0> constexpr Duration milliseconds(float millis) {
   return microseconds(static_cast<int64_t>(millis * 1000));
 }
-template <int /*dummy*/ = 0>
-constexpr Duration milliseconds(double millis) {
+template <int /*dummy*/ = 0> constexpr Duration milliseconds(double millis) {
   return microseconds(static_cast<int64_t>(millis * 1000));
 }
 
@@ -397,7 +423,7 @@ constexpr Duration minutes(float mins) { return seconds(mins * 60); }
 //
 // Native unit (implementation detail): uint64_t microseconds
 class Time : public UnitsDetail::Scalar<Time, uint64_t> {
- public:
+public:
   [[nodiscard]] uint64_t microsSinceStartup() const { return val_; }
 
   constexpr friend Time operator+(const Time &t, const Duration &dt);
@@ -407,7 +433,7 @@ class Time : public UnitsDetail::Scalar<Time, uint64_t> {
   Time &operator+=(const Duration &dt) { return *this = *this + dt; }
   Time &operator-=(const Duration &dt) { return *this = *this - dt; }
 
- private:
+private:
   constexpr friend Time microsSinceStartup(uint64_t micros);
 
   using UnitsDetail::Scalar<Time, uint64_t>::Scalar;

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -51,18 +51,14 @@
 #include "interface.h"
 #include "vars.h"
 
-static Debug::Variable::UInt32
-    dbg_addr_before("eeprom_before", Debug::Variable::Access::ReadOnly, 0, "",
-                    "address of eeprom contents at startup");
-static Debug::Variable::UInt32 dbg_write_data("write_data",
-                                              Debug::Variable::Access::ReadOnly,
-                                              0, "", "address of write data");
-static Debug::Variable::UInt32
-    dbg_addr_after("eeprom_after", Debug::Variable::Access::ReadOnly, 0, "",
-                   "address of eeprom contents after write");
-static Debug::Variable::UInt32
-    dbg_test_result("result", Debug::Variable::Access::ReadOnly, 0, "",
-                    "result of the test");
+static Debug::Variable::UInt32 dbg_addr_before("eeprom_before", Debug::Variable::Access::ReadOnly,
+                                               0, "", "address of eeprom contents at startup");
+static Debug::Variable::UInt32 dbg_write_data("write_data", Debug::Variable::Access::ReadOnly, 0,
+                                              "", "address of write data");
+static Debug::Variable::UInt32 dbg_addr_after("eeprom_after", Debug::Variable::Access::ReadOnly, 0,
+                                              "", "address of eeprom contents after write");
+static Debug::Variable::UInt32 dbg_test_result("result", Debug::Variable::Access::ReadOnly, 0, "",
+                                               "result of the test");
 
 // test parameters
 static constexpr uint16_t Address{TEST_PARAM_1};

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -103,9 +103,9 @@ void RunTest() {
 
   eeprom.ReadBytes(Address, Length, &eeprom_after, &second_read_finished);
 
-  dbg_addr_before.Set(reinterpret_cast<uint32_t>(&eeprom_before));
-  dbg_write_data.Set(reinterpret_cast<uint32_t>(&write_data));
-  dbg_addr_after.Set(reinterpret_cast<uint32_t>(&eeprom_after));
+  dbg_addr_before.set(reinterpret_cast<uint32_t>(&eeprom_before));
+  dbg_write_data.set(reinterpret_cast<uint32_t>(&write_data));
+  dbg_addr_after.set(reinterpret_cast<uint32_t>(&eeprom_after));
 
   // stall execution to give time for the actual sending of those requests
   // (through DMA and/or hardware interrupts), with a 500 ms timeout: our I2C
@@ -122,7 +122,7 @@ void RunTest() {
     }
   }
 
-  dbg_test_result.Set(!failed);
+  dbg_test_result.set(!failed);
 
   // Put the memory back in its initial state (note that if the initial read
   // failed, or the write method is broken, this will also fail and the eeprom

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -51,13 +51,18 @@
 #include "interface.h"
 #include "vars.h"
 
-static DebugUInt32 dbg_addr_before("eeprom_before", VarAccess::ReadOnly, 0, "",
-                                   "address of eeprom contents at startup");
-static DebugUInt32 dbg_write_data("write_data", VarAccess::ReadOnly, 0, "",
-                                  "address of write data");
-static DebugUInt32 dbg_addr_after("eeprom_after", VarAccess::ReadOnly, 0, "",
-                                  "address of eeprom contents after write");
-static DebugUInt32 dbg_test_result("result", VarAccess::ReadOnly, 0, "", "result of the test");
+static Debug::Variable::UInt32
+    dbg_addr_before("eeprom_before", Debug::Variable::Access::ReadOnly, 0, "",
+                    "address of eeprom contents at startup");
+static Debug::Variable::UInt32 dbg_write_data("write_data",
+                                              Debug::Variable::Access::ReadOnly,
+                                              0, "", "address of write data");
+static Debug::Variable::UInt32
+    dbg_addr_after("eeprom_after", Debug::Variable::Access::ReadOnly, 0, "",
+                   "address of eeprom contents after write");
+static Debug::Variable::UInt32
+    dbg_test_result("result", Debug::Variable::Access::ReadOnly, 0, "",
+                    "result of the test");
 
 // test parameters
 static constexpr uint16_t Address{TEST_PARAM_1};

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -120,8 +120,8 @@ PressureAssistFsm::PressureAssistFsm(Time now, const VentParams &params)
       start_time_(now),
       inspire_end_(start_time_ + InspireDuration(params)),
       expire_deadline_(inspire_end_ + ExpireDuration(params)) {
-  dbg_slow_flow_avg.Set(0.f);
-  dbg_fast_flow_avg.Set(0.f);
+  dbg_slow_flow_avg.set(0.f);
+  dbg_fast_flow_avg.set(0.f);
 }
 
 BlowerSystemState PressureAssistFsm::DesiredState(Time now, const BlowerFsmInputs &inputs) {
@@ -165,20 +165,20 @@ bool PressureAssistFsm::PatientInspiring(Time now, const BlowerFsmInputs &inputs
   //
   // If the fast average exceeds the slow average by a threshold, we trigger a
   // breath.
-  float slow_alpha = dbg_slow_flow_avg_alpha.Get();
-  float fast_alpha = dbg_fast_flow_avg_alpha.Get();
+  float slow_alpha = dbg_slow_flow_avg_alpha.get();
+  float fast_alpha = dbg_fast_flow_avg_alpha.get();
 
   // TODO: This could be encapsulated in an exponentially-weighted-average
   // class.
   slow_flow_avg_ =
       slow_alpha * inputs.net_flow + (1 - slow_alpha) * slow_flow_avg_.value_or(inputs.net_flow);
-  dbg_slow_flow_avg.Set(slow_flow_avg_->ml_per_sec());
+  dbg_slow_flow_avg.set(slow_flow_avg_->ml_per_sec());
   fast_flow_avg_ =
       fast_alpha * inputs.net_flow + (1 - fast_alpha) * fast_flow_avg_.value_or(inputs.net_flow);
-  dbg_fast_flow_avg.Set(fast_flow_avg_->ml_per_sec());
+  dbg_fast_flow_avg.set(fast_flow_avg_->ml_per_sec());
 
-  return now >= inspire_end_ + milliseconds(dbg_pa_min_expire_ms.Get()) &&
-         *fast_flow_avg_ > *slow_flow_avg_ + ml_per_sec(dbg_pa_flow_trigger.Get());
+  return now >= inspire_end_ + milliseconds(dbg_pa_min_expire_ms.get()) &&
+         *fast_flow_avg_ > *slow_flow_avg_ + ml_per_sec(dbg_pa_flow_trigger.get());
 }
 
 BlowerSystemState BlowerFsm::DesiredState(Time now, const VentParams &params,

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -25,14 +25,17 @@ limitations under the License.
 // These are read but never modified here.
 
 // TODO: This should be configurable from the GUI.
-static DebugFloat dbg_pa_flow_trigger("pa_flow_trigger", VarAccess::ReadWrite, 200, "mL/s",
-                                      "pressure assist flow trigger");
+static Debug::Variable::Float
+    dbg_pa_flow_trigger("pa_flow_trigger", Debug::Variable::Access::ReadWrite,
+                        200, "mL/s", "pressure assist flow trigger");
 
 // TODO: Is 250ms right?  Or can it be a fixed value at all; should it depend
 // on the RR or something?
-static DebugFloat dbg_pa_min_expire_ms("pa_min_expire_ms", VarAccess::ReadWrite, 250, "ms",
-                                       "minimum amount of time after ventilator exits PIP "
-                                       "before we're eligible to trigger a breath");
+static Debug::Variable::Float
+    dbg_pa_min_expire_ms("pa_min_expire_ms", Debug::Variable::Access::ReadWrite,
+                         250, "ms",
+                         "minimum amount of time after ventilator exits PIP "
+                         "before we're eligible to trigger a breath");
 
 // fast_flow_avg_alpha and slow_flow_avg_alpha were tuned for a control loop
 // that runs at a particular frequency.
@@ -41,21 +44,23 @@ static DebugFloat dbg_pa_min_expire_ms("pa_min_expire_ms", VarAccess::ReadWrite,
 // bigger, placing more weight on newer readings, and similarly if the control
 // loop gets faster, the alpha terms should get smaller.  We've tried to encode
 // this here, although it remains to be seen if it actually works.
-static DebugFloat dbg_fast_flow_avg_alpha("fast_flow_avg_alpha", VarAccess::ReadWrite,
-                                          0.2f * (Controller::GetLoopPeriod() / milliseconds(10)),
-                                          "",
-                                          "alpha term in pressure assist mode's fast-updating "
-                                          "exponentially-weighted average of flow");
-static DebugFloat dbg_slow_flow_avg_alpha("slow_flow_avg_alpha", VarAccess::ReadWrite,
-                                          0.01f * (Controller::GetLoopPeriod() / milliseconds(10)),
-                                          "",
-                                          "alpha term in pressure assist mode's slow-updating "
-                                          "exponentially-weighted average of flow");
+static Debug::Variable::Float dbg_fast_flow_avg_alpha(
+    "fast_flow_avg_alpha", Debug::Variable::Access::ReadWrite,
+    0.2f * (Controller::GetLoopPeriod() / milliseconds(10)), "",
+    "alpha term in pressure assist mode's fast-updating "
+    "exponentially-weighted average of flow");
+static Debug::Variable::Float dbg_slow_flow_avg_alpha(
+    "slow_flow_avg_alpha", Debug::Variable::Access::ReadWrite,
+    0.01f * (Controller::GetLoopPeriod() / milliseconds(10)), "",
+    "alpha term in pressure assist mode's slow-updating "
+    "exponentially-weighted average of flow");
 
-static DebugFloat dbg_fast_flow_avg("fast_flow_avg", VarAccess::ReadOnly, 0.0f, "mL/s",
-                                    "fast-updating flow average");
-static DebugFloat dbg_slow_flow_avg("slow_flow_avg", VarAccess::ReadOnly, 0.0f, "mL/s",
-                                    "slow-updating flow average");
+static Debug::Variable::Float
+    dbg_fast_flow_avg("fast_flow_avg", Debug::Variable::Access::ReadOnly, 0.0f,
+                      "mL/s", "fast-updating flow average");
+static Debug::Variable::Float
+    dbg_slow_flow_avg("slow_flow_avg", Debug::Variable::Access::ReadOnly, 0.0f,
+                      "mL/s", "slow-updating flow average");
 
 // Given t = secs_per_breath and r = I:E ratio, calculate inspiration and
 // expiration durations (I and E).

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -25,17 +25,16 @@ limitations under the License.
 // These are read but never modified here.
 
 // TODO: This should be configurable from the GUI.
-static Debug::Variable::Float
-    dbg_pa_flow_trigger("pa_flow_trigger", Debug::Variable::Access::ReadWrite,
-                        200, "mL/s", "pressure assist flow trigger");
+static Debug::Variable::Float dbg_pa_flow_trigger("pa_flow_trigger",
+                                                  Debug::Variable::Access::ReadWrite, 200, "mL/s",
+                                                  "pressure assist flow trigger");
 
 // TODO: Is 250ms right?  Or can it be a fixed value at all; should it depend
 // on the RR or something?
-static Debug::Variable::Float
-    dbg_pa_min_expire_ms("pa_min_expire_ms", Debug::Variable::Access::ReadWrite,
-                         250, "ms",
-                         "minimum amount of time after ventilator exits PIP "
-                         "before we're eligible to trigger a breath");
+static Debug::Variable::Float dbg_pa_min_expire_ms(
+    "pa_min_expire_ms", Debug::Variable::Access::ReadWrite, 250, "ms",
+    "minimum amount of time after ventilator exits PIP "
+    "before we're eligible to trigger a breath");
 
 // fast_flow_avg_alpha and slow_flow_avg_alpha were tuned for a control loop
 // that runs at a particular frequency.
@@ -55,12 +54,10 @@ static Debug::Variable::Float dbg_slow_flow_avg_alpha(
     "alpha term in pressure assist mode's slow-updating "
     "exponentially-weighted average of flow");
 
-static Debug::Variable::Float
-    dbg_fast_flow_avg("fast_flow_avg", Debug::Variable::Access::ReadOnly, 0.0f,
-                      "mL/s", "fast-updating flow average");
-static Debug::Variable::Float
-    dbg_slow_flow_avg("slow_flow_avg", Debug::Variable::Access::ReadOnly, 0.0f,
-                      "mL/s", "slow-updating flow average");
+static Debug::Variable::Float dbg_fast_flow_avg("fast_flow_avg", Debug::Variable::Access::ReadOnly,
+                                                0.0f, "mL/s", "fast-updating flow average");
+static Debug::Variable::Float dbg_slow_flow_avg("slow_flow_avg", Debug::Variable::Access::ReadOnly,
+                                                0.0f, "mL/s", "slow-updating flow average");
 
 // Given t = secs_per_breath and r = I:E ratio, calculate inspiration and
 // expiration durations (I and E).

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -85,7 +85,7 @@ std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentP
     // each new breath.
     breath_id_ = static_cast<uint32_t>(now.microsSinceStartup());
   }
-  dbg_breath_id.Set(breath_id_);
+  dbg_breath_id.set(breath_id_);
 
   ActuatorsState actuators_state;
   if (desired_state.pressure_setpoint == std::nullopt) {
@@ -162,16 +162,16 @@ std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentP
       .breath_id = breath_id_,
   };
 
-  dbg_pc_setpoint.Set(desired_state.pressure_setpoint.value_or(kPa(0)).cmH2O());
-  dbg_net_flow.Set(controller_state.net_flow.ml_per_sec());
-  dbg_net_flow_uncorrected.Set((sensor_readings.inflow - sensor_readings.outflow).ml_per_sec());
-  dbg_volume.Set(controller_state.patient_volume.ml());
-  dbg_volume_uncorrected.Set(uncorrected_flow_integrator_->GetVolume().ml());
-  dbg_flow_correction.Set(flow_integrator_->FlowCorrection().ml_per_sec());
+  dbg_pc_setpoint.set(desired_state.pressure_setpoint.value_or(kPa(0)).cmH2O());
+  dbg_net_flow.set(controller_state.net_flow.ml_per_sec());
+  dbg_net_flow_uncorrected.set((sensor_readings.inflow - sensor_readings.outflow).ml_per_sec());
+  dbg_volume.set(controller_state.patient_volume.ml());
+  dbg_volume_uncorrected.set(uncorrected_flow_integrator_->GetVolume().ml());
+  dbg_flow_correction.set(flow_integrator_->FlowCorrection().ml_per_sec());
 
   // Handle DebugVars that force the actuators.
   auto set_force = [](const Debug::Variable::Float &var, auto &state) {
-    float v = var.Get();
+    float v = var.get();
     if (v >= 0 && v <= 1) {
       state = v;
     }

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -85,11 +85,7 @@ std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentP
     // each new breath.
     breath_id_ = static_cast<uint32_t>(now.microsSinceStartup());
   }
-
   dbg_breath_id.Set(breath_id_);
-
-  blower_valve_pid_.update_vars();
-  psol_pid_.update_vars();
 
   ActuatorsState actuators_state;
   if (desired_state.pressure_setpoint == std::nullopt) {

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -57,7 +57,7 @@ class Controller {
  public:
   static Duration GetLoopPeriod();
 
-  Controller();
+  Controller() = default;
 
   std::pair<ActuatorsState, ControllerState> Run(Time now, const VentParams &params,
                                                  const SensorReadings &sensor_readings);
@@ -65,8 +65,25 @@ class Controller {
  private:
   uint64_t breath_id_{0};
   BlowerFsm fsm_;
-  PID blower_valve_pid_;
-  PID psol_pid_;
+
+  PID blower_valve_pid_{
+      "blower_valve_",    " for blower valve PID",
+      /*kp=*/0.04f,
+      /*ki=*/15.0f,
+      /*kd=*/0.0f,        ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
+      /*output_min=*/0.f,
+      /*output_max=*/1.0f};
+
+  // TODO: These params need to be tuned.
+  PID psol_pid_{"psol_",
+                " for O2 psol PID",
+                /*kp=*/0.04f,
+                /*ki=*/20.0f,
+                /*kd=*/0.0f,
+                ProportionalTerm::OnError,
+                DifferentialTerm::OnMeasurement,
+                /*output_min=*/0.f,
+                /*output_max=*/1.0f};
 
   // These objects accumulate flow to calculate volume.
   //

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -63,16 +63,18 @@ class Controller {
                                                  const SensorReadings &sensor_readings);
 
  private:
-  uint64_t breath_id_{0};
+  uint32_t breath_id_{0};
   BlowerFsm fsm_;
 
-  PID blower_valve_pid_{
-      "blower_valve_",    " for blower valve PID",
-      /*kp=*/0.04f,
-      /*ki=*/15.0f,
-      /*kd=*/0.0f,        ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-      /*output_min=*/0.f,
-      /*output_max=*/1.0f};
+  PID blower_valve_pid_{"blower_valve_",
+                        " for blower valve PID",
+                        /*kp=*/0.04f,
+                        /*ki=*/10.0f,
+                        /*kd=*/0.0f,
+                        /*p_term=*/PID::TermApplication::OnError,
+                        /*d_term=*/PID::TermApplication::OnMeasurement,
+                        /*output_min=*/0.f,
+                        /*output_max=*/1.0f};
 
   // TODO: These params need to be tuned.
   PID psol_pid_{"psol_",
@@ -80,8 +82,8 @@ class Controller {
                 /*kp=*/0.04f,
                 /*ki=*/20.0f,
                 /*kd=*/0.0f,
-                ProportionalTerm::OnError,
-                DifferentialTerm::OnMeasurement,
+                /*p_term=*/PID::TermApplication::OnError,
+                /*d_term=*/PID::TermApplication::OnMeasurement,
                 /*output_min=*/0.f,
                 /*output_max=*/1.0f};
 

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -61,7 +61,7 @@ static bool IsValid(Structure *param) { return param->crc == CRC(param); };
 // execution while it reads through the I2C EEPROM.
 void Handler::Init(I2Ceeprom *eeprom) {
 #ifndef TEST_MODE  // this leads to conversion error when compiling on native
-  dbg_nvparams.Set(reinterpret_cast<uint32_t>(&nv_param_));
+  dbg_nvparams.set(reinterpret_cast<uint32_t>(&nv_param_));
 #endif
   if (eeprom != nullptr) {
     eeprom_ = eeprom;
@@ -115,8 +115,8 @@ void Handler::Init(I2Ceeprom *eeprom) {
   }
   // set write access dbg_vars = nv_params to prevent the first pass in
   // handler to reset those to their default values in nv_params
-  dbg_reinit.Set(nv_param_.reinit);
-  dbg_serial.Set(nv_param_.vent_serial_number);
+  dbg_reinit.set(nv_param_.reinit);
+  dbg_serial.set(nv_param_.vent_serial_number);
   // increase power cycles counter in nv_params
   uint32_t counter = nv_param_.power_cycles + 1;
   Set(offsetof(Structure, power_cycles), &counter, 4);
@@ -195,11 +195,11 @@ void Handler::Update(const Time now, VentParams *params) {
   }
 
   // Update from debug variables
-  uint8_t reinit = static_cast<uint8_t>(dbg_reinit.Get());
+  uint8_t reinit = static_cast<uint8_t>(dbg_reinit.get());
   if (reinit != nv_param_.reinit) {
     Set(offsetof(Structure, reinit), &reinit, 1);
   }
-  uint32_t serial = dbg_serial.Get();
+  uint32_t serial = dbg_serial.get();
   if (serial != nv_param_.vent_serial_number) {
     Set(offsetof(Structure, vent_serial_number), &serial, 4);
   }

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -32,16 +32,14 @@ limitations under the License.
 #include "hal.h"
 #include "vars.h"
 
-static Debug::Variable::UInt32
-    dbg_reinit("nvparams_reinit", Debug::Variable::Access::ReadWrite, 0, "",
-               "Set to 1 to request a reinit of NV params on next boot.");
+static Debug::Variable::UInt32 dbg_reinit(
+    "nvparams_reinit", Debug::Variable::Access::ReadWrite, 0, "",
+    "Set to 1 to request a reinit of NV params on next boot.");
 
-static Debug::Variable::UInt32
-    dbg_serial("serial_number", Debug::Variable::Access::ReadWrite, 0, "",
-               "Serial number of the ventilator, in EEPROM");
+static Debug::Variable::UInt32 dbg_serial("serial_number", Debug::Variable::Access::ReadWrite, 0,
+                                          "", "Serial number of the ventilator, in EEPROM");
 
-static Debug::Variable::UInt32 dbg_nvparams("nvparams_address",
-                                            Debug::Variable::Access::ReadOnly,
+static Debug::Variable::UInt32 dbg_nvparams("nvparams_address", Debug::Variable::Access::ReadOnly,
                                             0, "", "Address of nv_params");
 
 namespace NVParams {

--- a/software/controller/lib/core/nvparams.cpp
+++ b/software/controller/lib/core/nvparams.cpp
@@ -32,14 +32,17 @@ limitations under the License.
 #include "hal.h"
 #include "vars.h"
 
-static DebugUInt32 dbg_reinit("nvparams_reinit", VarAccess::ReadWrite, 0, "",
-                              "Set to 1 to request a reinit of NV params on next boot.");
+static Debug::Variable::UInt32
+    dbg_reinit("nvparams_reinit", Debug::Variable::Access::ReadWrite, 0, "",
+               "Set to 1 to request a reinit of NV params on next boot.");
 
-static DebugUInt32 dbg_serial("serial_number", VarAccess::ReadWrite, 0, "",
-                              "Serial number of the ventilator, in EEPROM");
+static Debug::Variable::UInt32
+    dbg_serial("serial_number", Debug::Variable::Access::ReadWrite, 0, "",
+               "Serial number of the ventilator, in EEPROM");
 
-static DebugUInt32 dbg_nvparams("nvparams_address", VarAccess::ReadOnly, 0, "",
-                                "Address of nv_params");
+static Debug::Variable::UInt32 dbg_nvparams("nvparams_address",
+                                            Debug::Variable::Access::ReadOnly,
+                                            0, "", "Address of nv_params");
 
 namespace NVParams {
 

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -180,13 +180,13 @@ SensorReadings Sensors::GetReadings() const {
   VolumetricFlow uncorrected_flow = inflow - outflow;
 
   // Set debug variables.
-  dbg_dp_inhale.Set(inflow_delta.cmH2O());
-  dbg_dp_exhale.Set(outflow_delta.cmH2O());
-  dbg_pressure.Set(patient_pressure.cmH2O());
-  dbg_fio2.Set(fio2);
-  dbg_flow_inhale.Set(inflow.ml_per_sec());
-  dbg_flow_exhale.Set(outflow.ml_per_sec());
-  dbg_flow_uncorrected.Set(uncorrected_flow.ml_per_sec());
+  dbg_dp_inhale.set(inflow_delta.cmH2O());
+  dbg_dp_exhale.set(outflow_delta.cmH2O());
+  dbg_pressure.set(patient_pressure.cmH2O());
+  dbg_fio2.set(fio2);
+  dbg_flow_inhale.set(inflow.ml_per_sec());
+  dbg_flow_exhale.set(outflow.ml_per_sec());
+  dbg_flow_uncorrected.set(uncorrected_flow.ml_per_sec());
 
   return {
       .patient_pressure = patient_pressure,

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -22,22 +22,30 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 
 #include <cmath>
 
-#include "vars.h"
-
-static DebugFloat dbg_dp_inhale("dp_inhale", VarAccess::ReadOnly, 0.0f, "cmH2O",
-                                "Inhale diff pressure");
-static DebugFloat dbg_dp_exhale("dp_exhale", VarAccess::ReadOnly, 0.0f, "cmH2O",
-                                "Exhale diff pressure");
-static DebugFloat dbg_pressure("pressure", VarAccess::ReadOnly, 0.0f, "cmH2O", "Patient pressure");
-static DebugFloat dbg_flow_inhale("flow_inhale", VarAccess::ReadOnly, 0.0f, "mL/s",
-                                  "Inhale flow rate");
-static DebugFloat dbg_flow_exhale("flow_exhale", VarAccess::ReadOnly, 0.0f, "mL/s",
-                                  "Exhale flow rate");
-static DebugFloat dbg_fio2("fio2", VarAccess::ReadOnly, 0.0f, "ratio",
-                           "Fraction of inspired oxygen");
+static Debug::Variable::Float dbg_dp_inhale("dp_inhale",
+                                            Debug::Variable::Access::ReadOnly,
+                                            0.0f, "cmH2O",
+                                            "Inhale diff pressure");
+static Debug::Variable::Float dbg_dp_exhale("dp_exhale",
+                                            Debug::Variable::Access::ReadOnly,
+                                            0.0f, "cmH2O",
+                                            "Exhale diff pressure");
+static Debug::Variable::Float dbg_pressure("pressure",
+                                           Debug::Variable::Access::ReadOnly,
+                                           0.0f, "cmH2O", "Patient pressure");
+static Debug::Variable::Float dbg_flow_inhale("flow_inhale",
+                                              Debug::Variable::Access::ReadOnly,
+                                              0.0f, "mL/s", "Inhale flow rate");
+static Debug::Variable::Float dbg_flow_exhale("flow_exhale",
+                                              Debug::Variable::Access::ReadOnly,
+                                              0.0f, "mL/s", "Exhale flow rate");
+static Debug::Variable::Float dbg_fio2("fio2",
+                                       Debug::Variable::Access::ReadOnly, 0.0f,
+                                       "ratio", "Fraction of inspired oxygen");
 // Flow correction happens as part of volume computation, in the Controller.
-static DebugFloat dbg_flow_uncorrected("flow_uncorrected", VarAccess::ReadOnly, 0.0f, "mL/s",
-                                       "Uncorrected net flow rate");
+static Debug::Variable::Float
+    dbg_flow_uncorrected("flow_uncorrected", Debug::Variable::Access::ReadOnly,
+                         0.0f, "mL/s", "Uncorrected net flow rate");
 
 //@TODO: Potential Caution: Density of air slightly varies over temperature and
 // altitude - need mechanism to adjust based on delivery? Constant involving

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -22,30 +22,24 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 
 #include <cmath>
 
-static Debug::Variable::Float dbg_dp_inhale("dp_inhale",
-                                            Debug::Variable::Access::ReadOnly,
-                                            0.0f, "cmH2O",
-                                            "Inhale diff pressure");
-static Debug::Variable::Float dbg_dp_exhale("dp_exhale",
-                                            Debug::Variable::Access::ReadOnly,
-                                            0.0f, "cmH2O",
-                                            "Exhale diff pressure");
-static Debug::Variable::Float dbg_pressure("pressure",
-                                           Debug::Variable::Access::ReadOnly,
-                                           0.0f, "cmH2O", "Patient pressure");
-static Debug::Variable::Float dbg_flow_inhale("flow_inhale",
-                                              Debug::Variable::Access::ReadOnly,
+#include "vars.h"
+
+static Debug::Variable::Float dbg_dp_inhale("dp_inhale", Debug::Variable::Access::ReadOnly, 0.0f,
+                                            "cmH2O", "Inhale diff pressure");
+static Debug::Variable::Float dbg_dp_exhale("dp_exhale", Debug::Variable::Access::ReadOnly, 0.0f,
+                                            "cmH2O", "Exhale diff pressure");
+static Debug::Variable::Float dbg_pressure("pressure", Debug::Variable::Access::ReadOnly, 0.0f,
+                                           "cmH2O", "Patient pressure");
+static Debug::Variable::Float dbg_flow_inhale("flow_inhale", Debug::Variable::Access::ReadOnly,
                                               0.0f, "mL/s", "Inhale flow rate");
-static Debug::Variable::Float dbg_flow_exhale("flow_exhale",
-                                              Debug::Variable::Access::ReadOnly,
+static Debug::Variable::Float dbg_flow_exhale("flow_exhale", Debug::Variable::Access::ReadOnly,
                                               0.0f, "mL/s", "Exhale flow rate");
-static Debug::Variable::Float dbg_fio2("fio2",
-                                       Debug::Variable::Access::ReadOnly, 0.0f,
-                                       "ratio", "Fraction of inspired oxygen");
+static Debug::Variable::Float dbg_fio2("fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
+                                       "Fraction of inspired oxygen");
 // Flow correction happens as part of volume computation, in the Controller.
-static Debug::Variable::Float
-    dbg_flow_uncorrected("flow_uncorrected", Debug::Variable::Access::ReadOnly,
-                         0.0f, "mL/s", "Uncorrected net flow rate");
+static Debug::Variable::Float dbg_flow_uncorrected("flow_uncorrected",
+                                                   Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                                                   "Uncorrected net flow rate");
 
 //@TODO: Potential Caution: Density of air slightly varies over temperature and
 // altitude - need mechanism to adjust based on delivery? Constant involving

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -27,7 +27,8 @@ void Trace::Start() {
 
 // Sample all trace variables every "period" calls
 void Trace::MaybeSample() {
-  if (!running_) return;
+  if (!running_)
+    return;
 
   if (cycles_count_ == 0) {
     if (!SampleAllVars()) {
@@ -37,14 +38,15 @@ void Trace::MaybeSample() {
   }
 
   ++cycles_count_;
-  if (cycles_count_ >= period_) cycles_count_ = 0;
+  if (cycles_count_ >= period_)
+    cycles_count_ = 0;
 }
 
 bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
   if (index >= MaxTraceVars) {
     return false;
   }
-  traced_vars_[index] = DebugVarRegistry::singleton().FindVar(id);
+  traced_vars_[index] = Variable::Registry::singleton().FindVar(id);
   // like in the SetTraceVarId<int index> template, we need to flush the buffer
   // when the set of traced variables change.
   trace_buffer_.Flush();
@@ -58,8 +60,9 @@ int16_t Trace::GetTracedVarId(uint8_t index) {
   return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
 }
 
-[[nodiscard]] bool Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
-                                             size_t *count) {
+[[nodiscard]] bool
+Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
+                          size_t *count) {
   // Grab one sample with interrupts disabled.
   // There's a chance the trace is still running, so we could get interrupted
   // by the high priority thread that adds to the buffer.
@@ -67,9 +70,11 @@ int16_t Trace::GetTracedVarId(uint8_t index) {
   *count = 0;
   BlockInterrupts block;
   for (auto *var : traced_vars_) {
-    if (!var) continue;
+    if (!var)
+      continue;
     std::optional<uint32_t> dat = trace_buffer_.Get();
-    if (!dat) return false;
+    if (!dat)
+      return false;
     (*record)[(*count)++] = *dat;
   }
   return true;
@@ -83,11 +88,12 @@ bool Trace::SampleAllVars() {
   }
   // Sample each enabled variable and store the result to the buffer.
   for (auto *var : traced_vars_) {
-    if (!var) continue;
+    if (!var)
+      continue;
     // Can't fail as we've already checked for sufficient space above.
     (void)trace_buffer_.Put(var->GetValue());
   }
   return true;
 }
 
-}  // namespace Debug
+} // namespace Debug

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -44,7 +44,7 @@ bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
   if (index >= MaxTraceVars) {
     return false;
   }
-  traced_vars_[index] = Variable::Registry::singleton().FindVar(id);
+  traced_vars_[index] = Variable::Registry::singleton().find(id);
   // like in the SetTraceVarId<int index> template, we need to flush the buffer
   // when the set of traced variables change.
   trace_buffer_.Flush();
@@ -55,7 +55,7 @@ int16_t Trace::GetTracedVarId(uint8_t index) {
   if (index >= MaxTraceVars) {
     return -1;
   }
-  return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
+  return traced_vars_[index] ? traced_vars_[index]->id() : -1;
 }
 
 [[nodiscard]] bool Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
@@ -85,7 +85,7 @@ bool Trace::SampleAllVars() {
   for (auto *var : traced_vars_) {
     if (!var) continue;
     // Can't fail as we've already checked for sufficient space above.
-    (void)trace_buffer_.Put(var->GetValue());
+    (void)trace_buffer_.Put(var->get_value());
   }
   return true;
 }

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -27,8 +27,7 @@ void Trace::Start() {
 
 // Sample all trace variables every "period" calls
 void Trace::MaybeSample() {
-  if (!running_)
-    return;
+  if (!running_) return;
 
   if (cycles_count_ == 0) {
     if (!SampleAllVars()) {
@@ -38,8 +37,7 @@ void Trace::MaybeSample() {
   }
 
   ++cycles_count_;
-  if (cycles_count_ >= period_)
-    cycles_count_ = 0;
+  if (cycles_count_ >= period_) cycles_count_ = 0;
 }
 
 bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
@@ -60,9 +58,8 @@ int16_t Trace::GetTracedVarId(uint8_t index) {
   return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
 }
 
-[[nodiscard]] bool
-Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
-                          size_t *count) {
+[[nodiscard]] bool Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
+                                             size_t *count) {
   // Grab one sample with interrupts disabled.
   // There's a chance the trace is still running, so we could get interrupted
   // by the high priority thread that adds to the buffer.
@@ -70,11 +67,9 @@ Trace::GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record,
   *count = 0;
   BlockInterrupts block;
   for (auto *var : traced_vars_) {
-    if (!var)
-      continue;
+    if (!var) continue;
     std::optional<uint32_t> dat = trace_buffer_.Get();
-    if (!dat)
-      return false;
+    if (!dat) return false;
     (*record)[(*count)++] = *dat;
   }
   return true;
@@ -88,12 +83,11 @@ bool Trace::SampleAllVars() {
   }
   // Sample each enabled variable and store the result to the buffer.
   for (auto *var : traced_vars_) {
-    if (!var)
-      continue;
+    if (!var) continue;
     // Can't fail as we've already checked for sufficient space above.
     (void)trace_buffer_.Put(var->GetValue());
   }
   return true;
 }
 
-} // namespace Debug
+}  // namespace Debug

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -44,7 +44,7 @@ bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
   if (index >= MaxTraceVars) {
     return false;
   }
-  traced_vars_[index] = DebugVar::FindVar(id);
+  traced_vars_[index] = DebugVarRegistry::singleton().FindVar(id);
   // like in the SetTraceVarId<int index> template, we need to flush the buffer
   // when the set of traced variables change.
   trace_buffer_.Flush();

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -37,7 +37,7 @@ static constexpr uint32_t MaxTraceVars{4};
  * could be done using simple printouts over a serial port.
  */
 class Trace {
-public:
+ public:
   // Gets/sets the trace flags. At the moment, flags can only be 0 (disabled) or
   // 1 (enabled).
   bool GetStatus() const { return running_; }
@@ -56,20 +56,17 @@ public:
     trace_buffer_.Flush();
   }
 
-  size_t GetNumSamples() {
-    return trace_buffer_.FullCount() / GetNumActiveVars();
-  }
+  size_t GetNumSamples() { return trace_buffer_.FullCount() / GetNumActiveVars(); }
 
   uint32_t GetNumActiveVars() {
-    return static_cast<uint32_t>(
-        std::count_if(traced_vars_.begin(), traced_vars_.end(),
-                      [](const Variable::Base *var) { return (var); }));
+    return static_cast<uint32_t>(std::count_if(traced_vars_.begin(), traced_vars_.end(),
+                                               [](const Variable::Base *var) { return (var); }));
   }
 
-  template <int index> void SetTracedVarId(int32_t id) {
+  template <int index>
+  void SetTracedVarId(int32_t id) {
     static_assert(index >= 0 && index < MaxTraceVars);
-    traced_vars_[index] =
-        Variable::Registry::singleton().FindVar(static_cast<uint16_t>(id));
+    traced_vars_[index] = Variable::Registry::singleton().FindVar(static_cast<uint16_t>(id));
     // The layout of the trace buffer is just a bunch of uint32_t's one per
     // each variable of each sample cycle. In order to be able to interpret
     // the buffer unambiguously, the set of traced variables must be the same
@@ -77,7 +74,8 @@ public:
     trace_buffer_.Flush();
   }
 
-  template <int index> int32_t GetTracedVarId() {
+  template <int index>
+  int32_t GetTracedVarId() {
     static_assert(index >= 0 && index < MaxTraceVars);
     return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
   }
@@ -90,10 +88,9 @@ public:
   // variables - this should never happen.
   // Sets *count to the number of elements actually set in *record.
   // This will equal GetNumActiveVars() but is easier to use for testing.
-  [[nodiscard]] bool
-  GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record, size_t *count);
+  [[nodiscard]] bool GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record, size_t *count);
 
-private:
+ private:
   // This function is called at the end of the high priority loop function.
   // It captures any enabled data variables to the trace buffer.
   bool SampleAllVars();

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -66,7 +66,7 @@ class Trace {
   template <int index>
   void SetTracedVarId(int32_t id) {
     static_assert(index >= 0 && index < MaxTraceVars);
-    traced_vars_[index] = Variable::Registry::singleton().FindVar(static_cast<uint16_t>(id));
+    traced_vars_[index] = Variable::Registry::singleton().find(static_cast<uint16_t>(id));
     // The layout of the trace buffer is just a bunch of uint32_t's one per
     // each variable of each sample cycle. In order to be able to interpret
     // the buffer unambiguously, the set of traced variables must be the same
@@ -77,7 +77,7 @@ class Trace {
   template <int index>
   int32_t GetTracedVarId() {
     static_assert(index >= 0 && index < MaxTraceVars);
-    return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
+    return traced_vars_[index] ? traced_vars_[index]->id() : -1;
   }
 
   bool SetTracedVarId(uint8_t index, uint16_t id);

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -15,8 +15,7 @@ limitations under the License.
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <optional>
 
 #include "circular_buffer.h"
@@ -67,7 +66,7 @@ class Trace {
   template <int index>
   void SetTracedVarId(int32_t id) {
     static_assert(index >= 0 && index < MaxTraceVars);
-    traced_vars_[index] = DebugVar::FindVar(static_cast<uint16_t>(id));
+    traced_vars_[index] = DebugVarRegistry::singleton().FindVar(static_cast<uint16_t>(id));
     // The layout of the trace buffer is just a bunch of uint32_t's one per
     // each variable of each sample cycle. In order to be able to interpret
     // the buffer unambiguously, the set of traced variables must be the same

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -37,7 +37,7 @@ static constexpr uint32_t MaxTraceVars{4};
  * could be done using simple printouts over a serial port.
  */
 class Trace {
- public:
+public:
   // Gets/sets the trace flags. At the moment, flags can only be 0 (disabled) or
   // 1 (enabled).
   bool GetStatus() const { return running_; }
@@ -56,17 +56,20 @@ class Trace {
     trace_buffer_.Flush();
   }
 
-  size_t GetNumSamples() { return trace_buffer_.FullCount() / GetNumActiveVars(); }
-
-  uint32_t GetNumActiveVars() {
-    return static_cast<uint32_t>(std::count_if(traced_vars_.begin(), traced_vars_.end(),
-                                               [](const DebugVarBase *var) { return (var); }));
+  size_t GetNumSamples() {
+    return trace_buffer_.FullCount() / GetNumActiveVars();
   }
 
-  template <int index>
-  void SetTracedVarId(int32_t id) {
+  uint32_t GetNumActiveVars() {
+    return static_cast<uint32_t>(
+        std::count_if(traced_vars_.begin(), traced_vars_.end(),
+                      [](const Variable::Base *var) { return (var); }));
+  }
+
+  template <int index> void SetTracedVarId(int32_t id) {
     static_assert(index >= 0 && index < MaxTraceVars);
-    traced_vars_[index] = DebugVarRegistry::singleton().FindVar(static_cast<uint16_t>(id));
+    traced_vars_[index] =
+        Variable::Registry::singleton().FindVar(static_cast<uint16_t>(id));
     // The layout of the trace buffer is just a bunch of uint32_t's one per
     // each variable of each sample cycle. In order to be able to interpret
     // the buffer unambiguously, the set of traced variables must be the same
@@ -74,8 +77,7 @@ class Trace {
     trace_buffer_.Flush();
   }
 
-  template <int index>
-  int32_t GetTracedVarId() {
+  template <int index> int32_t GetTracedVarId() {
     static_assert(index >= 0 && index < MaxTraceVars);
     return traced_vars_[index] ? traced_vars_[index]->GetId() : -1;
   }
@@ -88,9 +90,10 @@ class Trace {
   // variables - this should never happen.
   // Sets *count to the number of elements actually set in *record.
   // This will equal GetNumActiveVars() but is easier to use for testing.
-  [[nodiscard]] bool GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record, size_t *count);
+  [[nodiscard]] bool
+  GetNextTraceRecord(std::array<uint32_t, MaxTraceVars> *record, size_t *count);
 
- private:
+private:
   // This function is called at the end of the high priority loop function.
   // It captures any enabled data variables to the trace buffer.
   bool SampleAllVars();
@@ -104,7 +107,7 @@ class Trace {
   // Number of loop cycles elapsed since last sample was captured.
   uint32_t cycles_count_{0};
 
-  std::array<DebugVarBase *, MaxTraceVars> traced_vars_ = {nullptr};
+  std::array<Variable::Base *, MaxTraceVars> traced_vars_ = {nullptr};
 
   // This circular buffer is as big as we consider reasonable, to give a good
   // tracing capability: 40% of the RAM available on our STM32

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -59,7 +59,7 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  const auto *var = DebugVar::FindVar(var_id);
+  const auto *var = DebugVarRegistry::singleton().FindVar(var_id);
   if (!var) return ErrorCode::UnknownVariable;
 
   // The info I return consists of the following:
@@ -116,7 +116,7 @@ ErrorCode VarHandler::GetVar(Context *context) {
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  auto *var = DebugVar::FindVar(var_id);
+  auto *var = DebugVarRegistry::singleton().FindVar(var_id);
   if (!var) return ErrorCode::UnknownVariable;
 
   if (context->max_response_length < 4) return ErrorCode::NoMemory;
@@ -133,7 +133,7 @@ ErrorCode VarHandler::SetVar(Context *context) {
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  auto *var = DebugVar::FindVar(var_id);
+  auto *var = DebugVarRegistry::singleton().FindVar(var_id);
   if (!var) return ErrorCode::UnknownVariable;
 
   uint32_t count = context->request_length - 3;
@@ -151,7 +151,7 @@ ErrorCode VarHandler::SetVar(Context *context) {
 ErrorCode VarHandler::GetVarCount(Context *context) {
   if (context->max_response_length < 4) return ErrorCode::NoMemory;
 
-  u32_to_u8(DebugVarBase::GetVarCount(), context->response);
+  u32_to_u8(DebugVarRegistry::singleton().GetVarCount(), context->response);
   context->response_length = 4;
   *(context->processed) = true;
   return ErrorCode::None;

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -59,7 +59,7 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  const auto *var = Variable::Registry::singleton().FindVar(var_id);
+  const auto *var = Variable::Registry::singleton().find(var_id);
   if (!var) return ErrorCode::UnknownVariable;
 
   // The info I return consists of the following:
@@ -75,34 +75,34 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
   // <help> - variable length help string
   // <unit> - variable length unit string
   // The strings are not null terminated.
-  size_t name_length = strlen(var->GetName());
-  size_t format_length = strlen(var->GetFormat());
-  size_t help_length = strlen(var->GetHelp());
-  size_t unit_length = strlen(var->GetUnits());
+  size_t name_length = strlen(var->name());
+  size_t format_length = strlen(var->format());
+  size_t help_length = strlen(var->help());
+  size_t unit_length = strlen(var->units());
 
   // Fail if the strings are too large to fit.
   if (context->max_response_length < 8 + name_length + format_length + help_length + unit_length)
     return ErrorCode::NoMemory;
 
   uint32_t count = 0;
-  context->response[count++] = static_cast<uint8_t>(var->GetType());
-  context->response[count++] = static_cast<uint8_t>(var->GetAccess());
+  context->response[count++] = static_cast<uint8_t>(var->type());
+  context->response[count++] = static_cast<uint8_t>(var->access());
   context->response[count++] = 0;
   context->response[count++] = 0;
   context->response[count++] = static_cast<uint8_t>(name_length);
   context->response[count++] = static_cast<uint8_t>(format_length);
   context->response[count++] = static_cast<uint8_t>(help_length);
   context->response[count++] = static_cast<uint8_t>(unit_length);
-  memcpy(&context->response[count], var->GetName(), name_length);
+  memcpy(&context->response[count], var->name(), name_length);
   count += static_cast<uint32_t>(name_length);
 
-  memcpy(&context->response[count], var->GetFormat(), format_length);
+  memcpy(&context->response[count], var->format(), format_length);
   count += static_cast<uint32_t>(format_length);
 
-  memcpy(&context->response[count], var->GetHelp(), help_length);
+  memcpy(&context->response[count], var->help(), help_length);
   count += static_cast<uint32_t>(help_length);
 
-  memcpy(&context->response[count], var->GetUnits(), unit_length);
+  memcpy(&context->response[count], var->units(), unit_length);
   count += static_cast<uint32_t>(unit_length);
 
   context->response_length = count;
@@ -116,12 +116,12 @@ ErrorCode VarHandler::GetVar(Context *context) {
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  auto *var = Variable::Registry::singleton().FindVar(var_id);
+  auto *var = Variable::Registry::singleton().find(var_id);
   if (!var) return ErrorCode::UnknownVariable;
 
   if (context->max_response_length < 4) return ErrorCode::NoMemory;
 
-  u32_to_u8(var->GetValue(), context->response);
+  u32_to_u8(var->get_value(), context->response);
   context->response_length = 4;
   *(context->processed) = true;
   return ErrorCode::None;
@@ -133,16 +133,16 @@ ErrorCode VarHandler::SetVar(Context *context) {
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  auto *var = Variable::Registry::singleton().FindVar(var_id);
+  auto *var = Variable::Registry::singleton().find(var_id);
   if (!var) return ErrorCode::UnknownVariable;
 
   uint32_t count = context->request_length - 3;
 
   if (count < 4) return ErrorCode::MissingData;
 
-  if (!var->WriteAllowed()) return ErrorCode::InternalError;
+  if (!var->write_allowed()) return ErrorCode::InternalError;
 
-  var->SetValue(u8_to_u32(context->request + 3));
+  var->set_value(u8_to_u32(context->request + 3));
   context->response_length = 0;
   *(context->processed) = true;
   return ErrorCode::None;
@@ -151,7 +151,7 @@ ErrorCode VarHandler::SetVar(Context *context) {
 ErrorCode VarHandler::GetVarCount(Context *context) {
   if (context->max_response_length < 4) return ErrorCode::NoMemory;
 
-  u32_to_u8(Variable::Registry::singleton().GetVarCount(), context->response);
+  u32_to_u8(Variable::Registry::singleton().count(), context->response);
   context->response_length = 4;
   *(context->processed) = true;
   return ErrorCode::None;

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -24,27 +24,26 @@ namespace Debug::Command {
 ErrorCode VarHandler::Process(Context *context) {
   // The first byte of data is always required, this
   // gives the sub-command.
-  if (context->request_length < 1)
-    return ErrorCode::MissingData;
+  if (context->request_length < 1) return ErrorCode::MissingData;
 
   Subcommand subcommand{context->request[0]};
 
   switch (subcommand) {
-  // Return info about one of the variables.
-  case Subcommand::GetInfo:
-    return GetVarInfo(context);
+    // Return info about one of the variables.
+    case Subcommand::GetInfo:
+      return GetVarInfo(context);
 
-  case Subcommand::Get:
-    return GetVar(context);
+    case Subcommand::Get:
+      return GetVar(context);
 
-  case Subcommand::Set:
-    return SetVar(context);
+    case Subcommand::Set:
+      return SetVar(context);
 
-  case Subcommand::GetCount:
-    return GetVarCount(context);
+    case Subcommand::GetCount:
+      return GetVarCount(context);
 
-  default:
-    return ErrorCode::InvalidData;
+    default:
+      return ErrorCode::InvalidData;
   }
 }
 
@@ -56,14 +55,12 @@ ErrorCode VarHandler::Process(Context *context) {
 // passed ID is invalid.
 ErrorCode VarHandler::GetVarInfo(Context *context) {
   // We expect a 16-bit ID to be passed
-  if (context->request_length < 3)
-    return ErrorCode::MissingData;
+  if (context->request_length < 3) return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
   const auto *var = Variable::Registry::singleton().FindVar(var_id);
-  if (!var)
-    return ErrorCode::UnknownVariable;
+  if (!var) return ErrorCode::UnknownVariable;
 
   // The info I return consists of the following:
   // <type> - 1 byte variable type code
@@ -84,8 +81,7 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
   size_t unit_length = strlen(var->GetUnits());
 
   // Fail if the strings are too large to fit.
-  if (context->max_response_length <
-      8 + name_length + format_length + help_length + unit_length)
+  if (context->max_response_length < 8 + name_length + format_length + help_length + unit_length)
     return ErrorCode::NoMemory;
 
   uint32_t count = 0;
@@ -116,17 +112,14 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
 
 ErrorCode VarHandler::GetVar(Context *context) {
   // We expect a 16-bit ID to be passed
-  if (context->request_length < 3)
-    return ErrorCode::MissingData;
+  if (context->request_length < 3) return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
   auto *var = Variable::Registry::singleton().FindVar(var_id);
-  if (!var)
-    return ErrorCode::UnknownVariable;
+  if (!var) return ErrorCode::UnknownVariable;
 
-  if (context->max_response_length < 4)
-    return ErrorCode::NoMemory;
+  if (context->max_response_length < 4) return ErrorCode::NoMemory;
 
   u32_to_u8(var->GetValue(), context->response);
   context->response_length = 4;
@@ -136,22 +129,18 @@ ErrorCode VarHandler::GetVar(Context *context) {
 
 ErrorCode VarHandler::SetVar(Context *context) {
   // We expect a 16-bit ID to be passed
-  if (context->request_length < 3)
-    return ErrorCode::MissingData;
+  if (context->request_length < 3) return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
   auto *var = Variable::Registry::singleton().FindVar(var_id);
-  if (!var)
-    return ErrorCode::UnknownVariable;
+  if (!var) return ErrorCode::UnknownVariable;
 
   uint32_t count = context->request_length - 3;
 
-  if (count < 4)
-    return ErrorCode::MissingData;
+  if (count < 4) return ErrorCode::MissingData;
 
-  if (!var->WriteAllowed())
-    return ErrorCode::InternalError;
+  if (!var->WriteAllowed()) return ErrorCode::InternalError;
 
   var->SetValue(u8_to_u32(context->request + 3));
   context->response_length = 0;
@@ -160,8 +149,7 @@ ErrorCode VarHandler::SetVar(Context *context) {
 }
 
 ErrorCode VarHandler::GetVarCount(Context *context) {
-  if (context->max_response_length < 4)
-    return ErrorCode::NoMemory;
+  if (context->max_response_length < 4) return ErrorCode::NoMemory;
 
   u32_to_u8(Variable::Registry::singleton().GetVarCount(), context->response);
   context->response_length = 4;
@@ -169,4 +157,4 @@ ErrorCode VarHandler::GetVarCount(Context *context) {
   return ErrorCode::None;
 }
 
-} // namespace Debug::Command
+}  // namespace Debug::Command

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -24,26 +24,27 @@ namespace Debug::Command {
 ErrorCode VarHandler::Process(Context *context) {
   // The first byte of data is always required, this
   // gives the sub-command.
-  if (context->request_length < 1) return ErrorCode::MissingData;
+  if (context->request_length < 1)
+    return ErrorCode::MissingData;
 
   Subcommand subcommand{context->request[0]};
 
   switch (subcommand) {
-    // Return info about one of the variables.
-    case Subcommand::GetInfo:
-      return GetVarInfo(context);
+  // Return info about one of the variables.
+  case Subcommand::GetInfo:
+    return GetVarInfo(context);
 
-    case Subcommand::Get:
-      return GetVar(context);
+  case Subcommand::Get:
+    return GetVar(context);
 
-    case Subcommand::Set:
-      return SetVar(context);
+  case Subcommand::Set:
+    return SetVar(context);
 
-    case Subcommand::GetCount:
-      return GetVarCount(context);
+  case Subcommand::GetCount:
+    return GetVarCount(context);
 
-    default:
-      return ErrorCode::InvalidData;
+  default:
+    return ErrorCode::InvalidData;
   }
 }
 
@@ -55,12 +56,14 @@ ErrorCode VarHandler::Process(Context *context) {
 // passed ID is invalid.
 ErrorCode VarHandler::GetVarInfo(Context *context) {
   // We expect a 16-bit ID to be passed
-  if (context->request_length < 3) return ErrorCode::MissingData;
+  if (context->request_length < 3)
+    return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  const auto *var = DebugVarRegistry::singleton().FindVar(var_id);
-  if (!var) return ErrorCode::UnknownVariable;
+  const auto *var = Variable::Registry::singleton().FindVar(var_id);
+  if (!var)
+    return ErrorCode::UnknownVariable;
 
   // The info I return consists of the following:
   // <type> - 1 byte variable type code
@@ -81,7 +84,8 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
   size_t unit_length = strlen(var->GetUnits());
 
   // Fail if the strings are too large to fit.
-  if (context->max_response_length < 8 + name_length + format_length + help_length + unit_length)
+  if (context->max_response_length <
+      8 + name_length + format_length + help_length + unit_length)
     return ErrorCode::NoMemory;
 
   uint32_t count = 0;
@@ -112,14 +116,17 @@ ErrorCode VarHandler::GetVarInfo(Context *context) {
 
 ErrorCode VarHandler::GetVar(Context *context) {
   // We expect a 16-bit ID to be passed
-  if (context->request_length < 3) return ErrorCode::MissingData;
+  if (context->request_length < 3)
+    return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  auto *var = DebugVarRegistry::singleton().FindVar(var_id);
-  if (!var) return ErrorCode::UnknownVariable;
+  auto *var = Variable::Registry::singleton().FindVar(var_id);
+  if (!var)
+    return ErrorCode::UnknownVariable;
 
-  if (context->max_response_length < 4) return ErrorCode::NoMemory;
+  if (context->max_response_length < 4)
+    return ErrorCode::NoMemory;
 
   u32_to_u8(var->GetValue(), context->response);
   context->response_length = 4;
@@ -129,18 +136,22 @@ ErrorCode VarHandler::GetVar(Context *context) {
 
 ErrorCode VarHandler::SetVar(Context *context) {
   // We expect a 16-bit ID to be passed
-  if (context->request_length < 3) return ErrorCode::MissingData;
+  if (context->request_length < 3)
+    return ErrorCode::MissingData;
 
   uint16_t var_id = u8_to_u16(&context->request[1]);
 
-  auto *var = DebugVarRegistry::singleton().FindVar(var_id);
-  if (!var) return ErrorCode::UnknownVariable;
+  auto *var = Variable::Registry::singleton().FindVar(var_id);
+  if (!var)
+    return ErrorCode::UnknownVariable;
 
   uint32_t count = context->request_length - 3;
 
-  if (count < 4) return ErrorCode::MissingData;
+  if (count < 4)
+    return ErrorCode::MissingData;
 
-  if (!var->WriteAllowed()) return ErrorCode::InternalError;
+  if (!var->WriteAllowed())
+    return ErrorCode::InternalError;
 
   var->SetValue(u8_to_u32(context->request + 3));
   context->response_length = 0;
@@ -149,12 +160,13 @@ ErrorCode VarHandler::SetVar(Context *context) {
 }
 
 ErrorCode VarHandler::GetVarCount(Context *context) {
-  if (context->max_response_length < 4) return ErrorCode::NoMemory;
+  if (context->max_response_length < 4)
+    return ErrorCode::NoMemory;
 
-  u32_to_u8(DebugVarRegistry::singleton().GetVarCount(), context->response);
+  u32_to_u8(Variable::Registry::singleton().GetVarCount(), context->response);
   context->response_length = 4;
   *(context->processed) = true;
   return ErrorCode::None;
 }
 
-}  // namespace Debug::Command
+} // namespace Debug::Command

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -19,40 +19,42 @@ limitations under the License.
 
 #include "vars_base.h"
 
-template <typename GetFn, typename SetFn>
-class FnDebugVar : public DebugVarBase {
- public:
-  FnDebugVar(VarType type, const char *name, VarAccess access, const char *units, GetFn get_fn,
-             SetFn set_fn, const char *help, const char *fmt = "")
-      : DebugVarBase(type, name, access, units, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {
-    DebugVarRegistry::singleton().RegisterVar(this);
+namespace Debug::Variable {
+
+template <typename GetFn, typename SetFn> class FnVar : public Base {
+public:
+  FnVar(Type type, const char *name, Access access, const char *units,
+        GetFn get_fn, SetFn set_fn, const char *help, const char *fmt = "")
+      : Base(type, name, access, units, help, fmt), get_fn_(get_fn),
+        set_fn_(set_fn) {
+    Registry::singleton().RegisterVar(this);
   }
 
   uint32_t GetValue() override { return get_fn_(); }
   void SetValue(uint32_t value) override { set_fn_(value); }
 
- private:
+private:
   GetFn get_fn_;
   SetFn set_fn_;
 };
 
-class DebugVar : public DebugVarBase {
- public:
+class Primitive32 : public Base {
+public:
   // 32-bit integer variable.
   // @param data Pointer to an actual variable in C++ code that this will access
-  DebugVar(const char *name, VarAccess access, int32_t *data, const char *units,
-           const char *help = "", const char *fmt = "%d")
-      : DebugVar(VarType::Int32, name, access, data, units, help, fmt) {}
+  Primitive32(const char *name, Access access, int32_t *data, const char *units,
+              const char *help = "", const char *fmt = "%d")
+      : Primitive32(Type::Int32, name, access, data, units, help, fmt) {}
 
   // Like above, but unsigned
-  DebugVar(const char *name, VarAccess access, uint32_t *data, const char *units,
-           const char *help = "", const char *fmt = "%u")
-      : DebugVar(VarType::UInt32, name, access, data, units, help, fmt) {}
+  Primitive32(const char *name, Access access, uint32_t *data,
+              const char *units, const char *help = "", const char *fmt = "%u")
+      : Primitive32(Type::UInt32, name, access, data, units, help, fmt) {}
 
   // Like above, but float
-  DebugVar(const char *name, VarAccess access, float *data, const char *units,
-           const char *help = "", const char *fmt = "%.3f")
-      : DebugVar(VarType::Float, name, access, data, units, help, fmt) {}
+  Primitive32(const char *name, Access access, float *data, const char *units,
+              const char *help = "", const char *fmt = "%.3f")
+      : Primitive32(Type::Float, name, access, data, units, help, fmt) {}
 
   // Gets the current value of the variable as an uint32_t.
   uint32_t GetValue() override {
@@ -64,51 +66,55 @@ class DebugVar : public DebugVarBase {
   // Sets the current value of the variable as an uint32_t.
   void SetValue(uint32_t value) override { std::memcpy(address_, &value, 4); }
 
- private:
+private:
   void *address_;
 
-  DebugVar(VarType type, const char *name, VarAccess access, void *data, const char *units,
-           const char *help, const char *fmt = "")
-      : DebugVarBase(type, name, access, units, help, fmt), address_(data) {
-    DebugVarRegistry::singleton().RegisterVar(this);
+  Primitive32(Type type, const char *name, Access access, void *data,
+              const char *units, const char *help, const char *fmt = "")
+      : Base(type, name, access, units, help, fmt), address_(data) {
+    Registry::singleton().RegisterVar(this);
   }
 };
 
-class DebugInt32 : public DebugVar {
- public:
-  explicit DebugInt32(const char *name, VarAccess access, int32_t init, const char *units,
-                      const char *help = "", const char *fmt = "%d")
-      : DebugVar(name, access, &value_, units, help, fmt), value_(init) {}
+class Int32 : public Primitive32 {
+public:
+  explicit Int32(const char *name, Access access, int32_t init,
+                 const char *units, const char *help = "",
+                 const char *fmt = "%d")
+      : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
   void Set(int32_t v) { value_ = v; }
   int32_t Get() const { return value_; }
 
- private:
+private:
   int32_t value_;
 };
 
-class DebugUInt32 : public DebugVar {
- public:
-  explicit DebugUInt32(const char *name, VarAccess access, uint32_t init, const char *units,
-                       const char *help = "", const char *fmt = "%u")
-      : DebugVar(name, access, &value_, units, help, fmt), value_(init) {}
+class UInt32 : public Primitive32 {
+public:
+  explicit UInt32(const char *name, Access access, uint32_t init,
+                  const char *units, const char *help = "",
+                  const char *fmt = "%u")
+      : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
   void Set(uint32_t v) { value_ = v; }
   uint32_t Get() const { return value_; }
 
- private:
+private:
   uint32_t value_;
 };
 
-class DebugFloat : public DebugVar {
- public:
-  explicit DebugFloat(const char *name, VarAccess access, float init, const char *units,
-                      const char *help = "", const char *fmt = "%.3f")
-      : DebugVar(name, access, &value_, units, help, fmt), value_(init) {}
+class Float : public Primitive32 {
+public:
+  explicit Float(const char *name, Access access, float init, const char *units,
+                 const char *help = "", const char *fmt = "%.3f")
+      : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
   void Set(float v) { value_ = v; }
   float Get() const { return value_; }
 
- private:
+private:
   float value_;
 };
+
+} // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -21,25 +21,25 @@ limitations under the License.
 
 namespace Debug::Variable {
 
-template <typename GetFn, typename SetFn> class FnVar : public Base {
-public:
-  FnVar(Type type, const char *name, Access access, const char *units,
-        GetFn get_fn, SetFn set_fn, const char *help, const char *fmt = "")
-      : Base(type, name, access, units, help, fmt), get_fn_(get_fn),
-        set_fn_(set_fn) {
+template <typename GetFn, typename SetFn>
+class FnVar : public Base {
+ public:
+  FnVar(Type type, const char *name, Access access, const char *units, GetFn get_fn, SetFn set_fn,
+        const char *help, const char *fmt = "")
+      : Base(type, name, access, units, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {
     Registry::singleton().RegisterVar(this);
   }
 
   uint32_t GetValue() override { return get_fn_(); }
   void SetValue(uint32_t value) override { set_fn_(value); }
 
-private:
+ private:
   GetFn get_fn_;
   SetFn set_fn_;
 };
 
 class Primitive32 : public Base {
-public:
+ public:
   // 32-bit integer variable.
   // @param data Pointer to an actual variable in C++ code that this will access
   Primitive32(const char *name, Access access, int32_t *data, const char *units,
@@ -47,8 +47,8 @@ public:
       : Primitive32(Type::Int32, name, access, data, units, help, fmt) {}
 
   // Like above, but unsigned
-  Primitive32(const char *name, Access access, uint32_t *data,
-              const char *units, const char *help = "", const char *fmt = "%u")
+  Primitive32(const char *name, Access access, uint32_t *data, const char *units,
+              const char *help = "", const char *fmt = "%u")
       : Primitive32(Type::UInt32, name, access, data, units, help, fmt) {}
 
   // Like above, but float
@@ -66,46 +66,44 @@ public:
   // Sets the current value of the variable as an uint32_t.
   void SetValue(uint32_t value) override { std::memcpy(address_, &value, 4); }
 
-private:
+ private:
   void *address_;
 
-  Primitive32(Type type, const char *name, Access access, void *data,
-              const char *units, const char *help, const char *fmt = "")
+  Primitive32(Type type, const char *name, Access access, void *data, const char *units,
+              const char *help, const char *fmt = "")
       : Base(type, name, access, units, help, fmt), address_(data) {
     Registry::singleton().RegisterVar(this);
   }
 };
 
 class Int32 : public Primitive32 {
-public:
-  explicit Int32(const char *name, Access access, int32_t init,
-                 const char *units, const char *help = "",
-                 const char *fmt = "%d")
+ public:
+  explicit Int32(const char *name, Access access, int32_t init, const char *units,
+                 const char *help = "", const char *fmt = "%d")
       : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
   void Set(int32_t v) { value_ = v; }
   int32_t Get() const { return value_; }
 
-private:
+ private:
   int32_t value_;
 };
 
 class UInt32 : public Primitive32 {
-public:
-  explicit UInt32(const char *name, Access access, uint32_t init,
-                  const char *units, const char *help = "",
-                  const char *fmt = "%u")
+ public:
+  explicit UInt32(const char *name, Access access, uint32_t init, const char *units,
+                  const char *help = "", const char *fmt = "%u")
       : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
   void Set(uint32_t v) { value_ = v; }
   uint32_t Get() const { return value_; }
 
-private:
+ private:
   uint32_t value_;
 };
 
 class Float : public Primitive32 {
-public:
+ public:
   explicit Float(const char *name, Access access, float init, const char *units,
                  const char *help = "", const char *fmt = "%.3f")
       : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
@@ -113,8 +111,8 @@ public:
   void Set(float v) { value_ = v; }
   float Get() const { return value_; }
 
-private:
+ private:
   float value_;
 };
 
-} // namespace Debug::Variable
+}  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -26,12 +26,10 @@ class FnVar : public Base {
  public:
   FnVar(Type type, const char *name, Access access, const char *units, GetFn get_fn, SetFn set_fn,
         const char *help, const char *fmt = "")
-      : Base(type, name, access, units, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {
-    Registry::singleton().RegisterVar(this);
-  }
+      : Base(type, name, access, units, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {}
 
-  uint32_t GetValue() override { return get_fn_(); }
-  void SetValue(uint32_t value) override { set_fn_(value); }
+  uint32_t get_value() override { return get_fn_(); }
+  void set_value(uint32_t value) override { set_fn_(value); }
 
  private:
   GetFn get_fn_;
@@ -57,23 +55,21 @@ class Primitive32 : public Base {
       : Primitive32(Type::Float, name, access, data, units, help, fmt) {}
 
   // Gets the current value of the variable as an uint32_t.
-  uint32_t GetValue() override {
+  uint32_t get_value() override {
     uint32_t res;
     std::memcpy(&res, address_, 4);
     return res;
   }
 
   // Sets the current value of the variable as an uint32_t.
-  void SetValue(uint32_t value) override { std::memcpy(address_, &value, 4); }
+  void set_value(uint32_t value) override { std::memcpy(address_, &value, 4); }
 
  private:
   void *address_;
 
   Primitive32(Type type, const char *name, Access access, void *data, const char *units,
               const char *help, const char *fmt = "")
-      : Base(type, name, access, units, help, fmt), address_(data) {
-    Registry::singleton().RegisterVar(this);
-  }
+      : Base(type, name, access, units, help, fmt), address_(data) {}
 };
 
 class Int32 : public Primitive32 {
@@ -82,8 +78,8 @@ class Int32 : public Primitive32 {
                  const char *help = "", const char *fmt = "%d")
       : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
-  void Set(int32_t v) { value_ = v; }
-  int32_t Get() const { return value_; }
+  void set(int32_t v) { value_ = v; }
+  int32_t get() const { return value_; }
 
  private:
   int32_t value_;
@@ -95,8 +91,8 @@ class UInt32 : public Primitive32 {
                   const char *help = "", const char *fmt = "%u")
       : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
-  void Set(uint32_t v) { value_ = v; }
-  uint32_t Get() const { return value_; }
+  void set(uint32_t v) { value_ = v; }
+  uint32_t get() const { return value_; }
 
  private:
   uint32_t value_;
@@ -108,8 +104,8 @@ class Float : public Primitive32 {
                  const char *help = "", const char *fmt = "%.3f")
       : Primitive32(name, access, &value_, units, help, fmt), value_(init) {}
 
-  void Set(float v) { value_ = v; }
-  float Get() const { return value_; }
+  void set(float v) { value_ = v; }
+  float get() const { return value_; }
 
  private:
   float value_;

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -15,6 +15,8 @@ limitations under the License.
 
 #pragma once
 
+#include <cstring>
+
 #include "vars_base.h"
 
 template <typename GetFn, typename SetFn>

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -19,8 +19,8 @@ limitations under the License.
 
 namespace Debug::Variable {
 
-Base::Base(Type type, const char *name, Access access, const char *units,
-           const char *help, const char *fmt)
+Base::Base(Type type, const char *name, Access access, const char *units, const char *help,
+           const char *fmt)
     : type_(type), access_(access) {
   // \todo use stricpy instead?
   strcpy(name_, name);
@@ -57,4 +57,4 @@ Access Base::GetAccess() const { return access_; }
 
 bool Base::WriteAllowed() const { return (access_ == Access::ReadWrite); }
 
-} // namespace Debug::Variable
+}  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -17,22 +17,29 @@ limitations under the License.
 
 #include <cstring>
 
-// Prepends t into s. Assumes s has enough space allocated for the combined string.
-void prepend(char* s, const char* t) {
-  size_t len = strlen(t);
-  memmove(s + len, s, strlen(s) + 1);
-  memcpy(s, t, len);
-}
-
 DebugVarBase::DebugVarBase(VarType type, const char* name, VarAccess access, const char* units,
                            const char* help, const char* fmt)
-    : type_(type), access_(access), units_(units), help_(help), fmt_(fmt) {
+    : type_(type), access_(access) {
+  // \todo use stricpy instead?
   strcpy(name_, name);
+  strcpy(help_, help);
+  strcpy(units_, units);
+  strcpy(fmt_, fmt);
 }
 
 const char* DebugVarBase::GetName() const { return name_; }
 
-void DebugVarBase::prepend_name(const char* prefix) { prepend(name_, prefix); }
+void DebugVarBase::prepend_name(const char* prefix) {
+  // Assumes name_ has enough space allocated for the combined string.
+  size_t len = strlen(prefix);
+  memmove(name_ + len, name_, strlen(name_) + 1);
+  memcpy(name_, prefix, len);
+}
+
+void DebugVarBase::append_help(const char* text) {
+  // \todo use stricat instead?
+  strcat(help_, text);
+}
 
 const char* DebugVarBase::GetFormat() const { return fmt_; }
 

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -17,8 +17,10 @@ limitations under the License.
 
 #include <cstring>
 
-DebugVarBase::DebugVarBase(VarType type, const char* name, VarAccess access, const char* units,
-                           const char* help, const char* fmt)
+namespace Debug::Variable {
+
+Base::Base(Type type, const char *name, Access access, const char *units,
+           const char *help, const char *fmt)
     : type_(type), access_(access) {
   // \todo use stricpy instead?
   strcpy(name_, name);
@@ -27,30 +29,32 @@ DebugVarBase::DebugVarBase(VarType type, const char* name, VarAccess access, con
   strcpy(fmt_, fmt);
 }
 
-const char* DebugVarBase::GetName() const { return name_; }
+const char *Base::GetName() const { return name_; }
 
-void DebugVarBase::prepend_name(const char* prefix) {
+void Base::prepend_name(const char *prefix) {
   // Assumes name_ has enough space allocated for the combined string.
   size_t len = strlen(prefix);
   memmove(name_ + len, name_, strlen(name_) + 1);
   memcpy(name_, prefix, len);
 }
 
-void DebugVarBase::append_help(const char* text) {
+void Base::append_help(const char *text) {
   // \todo use stricat instead?
   strcat(help_, text);
 }
 
-const char* DebugVarBase::GetFormat() const { return fmt_; }
+const char *Base::GetFormat() const { return fmt_; }
 
-const char* DebugVarBase::GetHelp() const { return help_; }
+const char *Base::GetHelp() const { return help_; }
 
-const char* DebugVarBase::GetUnits() const { return units_; }
+const char *Base::GetUnits() const { return units_; }
 
-VarType DebugVarBase::GetType() const { return type_; }
+Type Base::GetType() const { return type_; }
 
-uint16_t DebugVarBase::GetId() const { return id_; }
+uint16_t Base::GetId() const { return id_; }
 
-VarAccess DebugVarBase::GetAccess() const { return access_; }
+Access Base::GetAccess() const { return access_; }
 
-bool DebugVarBase::WriteAllowed() const { return (access_ == VarAccess::ReadWrite); }
+bool Base::WriteAllowed() const { return (access_ == Access::ReadWrite); }
+
+} // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -27,9 +27,10 @@ Base::Base(Type type, const char *name, Access access, const char *units, const 
   strcpy(help_, help);
   strcpy(units_, units);
   strcpy(fmt_, fmt);
+  Registry::singleton().register_variable(this);
 }
 
-const char *Base::GetName() const { return name_; }
+const char *Base::name() const { return name_; }
 
 void Base::prepend_name(const char *prefix) {
   // Assumes name_ has enough space allocated for the combined string.
@@ -43,18 +44,18 @@ void Base::append_help(const char *text) {
   strcat(help_, text);
 }
 
-const char *Base::GetFormat() const { return fmt_; }
+const char *Base::format() const { return fmt_; }
 
-const char *Base::GetHelp() const { return help_; }
+const char *Base::help() const { return help_; }
 
-const char *Base::GetUnits() const { return units_; }
+const char *Base::units() const { return units_; }
 
-Type Base::GetType() const { return type_; }
+Type Base::type() const { return type_; }
 
-uint16_t Base::GetId() const { return id_; }
+uint16_t Base::id() const { return id_; }
 
-Access Base::GetAccess() const { return access_; }
+Access Base::access() const { return access_; }
 
-bool Base::WriteAllowed() const { return (access_ == Access::ReadWrite); }
+bool Base::write_allowed() const { return (access_ == Access::ReadWrite); }
 
 }  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -1,0 +1,49 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "vars_base.h"
+
+#include <cstring>
+
+// Prepends t into s. Assumes s has enough space allocated for the combined string.
+void prepend(char* s, const char* t) {
+  size_t len = strlen(t);
+  memmove(s + len, s, strlen(s) + 1);
+  memcpy(s, t, len);
+}
+
+DebugVarBase::DebugVarBase(VarType type, const char* name, VarAccess access, const char* units,
+                           const char* help, const char* fmt)
+    : type_(type), access_(access), units_(units), help_(help), fmt_(fmt) {
+  strcpy(name_, name);
+}
+
+const char* DebugVarBase::GetName() const { return name_; }
+
+void DebugVarBase::prepend_name(const char* prefix) { prepend(name_, prefix); }
+
+const char* DebugVarBase::GetFormat() const { return fmt_; }
+
+const char* DebugVarBase::GetHelp() const { return help_; }
+
+const char* DebugVarBase::GetUnits() const { return units_; }
+
+VarType DebugVarBase::GetType() const { return type_; }
+
+uint16_t DebugVarBase::GetId() const { return id_; }
+
+VarAccess DebugVarBase::GetAccess() const { return access_; }
+
+bool DebugVarBase::WriteAllowed() const { return (access_ == VarAccess::ReadWrite); }

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -45,14 +45,14 @@ static constexpr uint16_t InvalidID{std::numeric_limits<uint16_t>::max()};
 // The fmt string gives the debug interface a suggestion on the best way
 // to display the variable's data.
 class Base {
-public:
+ public:
   // @param type Type of the variable
   // @param name Name of the variable
   // @param help String that the Python code displays describing the variable.
   // @param fmt printf style format string.  This is a hint to the Python code
   // as to how the variable data should be displayed.
-  Base(Type type, const char *name, Access access, const char *units,
-       const char *help, const char *fmt = "");
+  Base(Type type, const char *name, Access access, const char *units, const char *help,
+       const char *fmt = "");
 
   virtual uint32_t GetValue() = 0;
   virtual void SetValue(uint32_t value) = 0;
@@ -69,7 +69,7 @@ public:
   Access GetAccess() const;
   bool WriteAllowed() const;
 
-private:
+ private:
   uint16_t id_{InvalidID};
   const Type type_;
   const Access access_;
@@ -82,7 +82,7 @@ private:
 };
 
 class Registry {
-public:
+ public:
   // this is the only way to access it
   static Registry &singleton() {
     // will privately initialize on first call
@@ -95,16 +95,16 @@ public:
   Base *FindVar(uint16_t vid);
   uint32_t GetVarCount() const;
 
-private:
+ private:
   // List of all the variables in the system.
   // Increase size as necessary
   Base *var_list_[100]{};
   uint16_t var_count_{0};
 
   // singleton assurance, because these are private
-  Registry() = default;             // cannot default initialize
-  Registry(Registry const &);       // cannot copy initialize
-  void operator=(Registry const &); // cannot copy assign
+  Registry() = default;              // cannot default initialize
+  Registry(Registry const &);        // cannot copy initialize
+  void operator=(Registry const &);  // cannot copy assign
 };
 
-} // namespace Debug::Variable
+}  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -59,6 +59,7 @@ class DebugVarBase {
 
   const char *GetName() const;
   void prepend_name(const char *prefix);
+  void append_help(const char *text);
 
   const char *GetFormat() const;
   const char *GetHelp() const;
@@ -70,12 +71,12 @@ class DebugVarBase {
 
  private:
   uint16_t id_{InvalidID};
-  char name_[50];  // should be long enough for most variable names
   const VarType type_;
   const VarAccess access_;
-  const char *const units_;
-  const char *const help_;
-  const char *const fmt_;
+  char name_[50]{0};
+  char units_[20]{0};
+  char help_[300]{0};
+  char fmt_[10]{0};
 
   friend class DebugVarRegistry;
 };

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -16,10 +16,10 @@ limitations under the License.
 #pragma once
 
 #include <cstdint>
-#include <limits>
 
 namespace Debug::Variable {
 
+// \todo should we have an `Invalid` type?
 // Defines the type of variable
 enum class Type {
   Int32 = 1,
@@ -33,41 +33,50 @@ enum class Access {
   ReadWrite = 1,
 };
 
-static constexpr uint16_t InvalidID{std::numeric_limits<uint16_t>::max()};
+static constexpr uint16_t MaxVariableCount{100};
 
-// This class represents a variable that you can read/write using the
-// debug serial port.
-//
-// We give each such variable a name which the debugger command line will
-// use to access it.  We can also link it with a C++ variable whose value
-// it will read or write.
-//
-// The fmt string gives the debug interface a suggestion on the best way
-// to display the variable's data.
+static constexpr uint16_t InvalidID{MaxVariableCount + 1};
+
+/*! \class Base vars_base.h "vars_base.h"
+ *  \brief Abstract base class for debug variables
+ *
+ * This class represents a variable that you can read/write using the debug serial port. These are
+ * also variables that can be recorded in traces.
+ *
+ * We give each such variable a name which the debugger command line will use to access it. We can
+ * also link it with a C++ variable whose value it will read or write.
+ *
+ * Each variable will register itself with the debug variable Registry, which will issue it a unique
+ * ID. However, name uniqueness is not automatically guaranteed, and you are responsible for
+ * ensuring it, lest the client side of the debugger fail to function properly.
+ */
 class Base {
  public:
-  // @param type Type of the variable
-  // @param name Name of the variable
-  // @param help String that the Python code displays describing the variable.
-  // @param fmt printf style format string.  This is a hint to the Python code
-  // as to how the variable data should be displayed.
+  /*! \param type Type of the variable, so debug client knows how to interpret it.
+   *  \param name Name of the variable, should be unique.
+   *  \param access Access mode to this variable for the debug interface.
+   *  \param units physical units associated with value represented by variable.
+   *  \param help String that the interface displays describing the variable.
+   *  \param fmt printf style format string, hint for debug client on how to display variable data.
+   *  \post Variable will add itself to the Registry and receive a unique ID.
+   */
   Base(Type type, const char *name, Access access, const char *units, const char *help,
        const char *fmt = "");
 
-  virtual uint32_t GetValue() = 0;
-  virtual void SetValue(uint32_t value) = 0;
+  virtual uint32_t get_value() = 0;
+  virtual void set_value(uint32_t value) = 0;
 
-  const char *GetName() const;
+  const char *name() const;
   void prepend_name(const char *prefix);
   void append_help(const char *text);
 
-  const char *GetFormat() const;
-  const char *GetHelp() const;
-  const char *GetUnits() const;
-  Type GetType() const;
-  uint16_t GetId() const;
-  Access GetAccess() const;
-  bool WriteAllowed() const;
+  const char *format() const;
+  const char *help() const;
+  const char *units() const;
+  Type type() const;
+  uint16_t id() const;
+  Access access() const;
+  bool write_allowed() const;
 
  private:
   uint16_t id_{InvalidID};
@@ -81,6 +90,11 @@ class Base {
   friend class Registry;
 };
 
+/*! \class Registry vars_base.h "vars_base.h"
+ *  \brief Registry for keeping track of extant debug variables
+ *
+ * This is a singleton for keeping track of all debug variables.
+ */
 class Registry {
  public:
   // this is the only way to access it
@@ -91,14 +105,20 @@ class Registry {
     return SingletonInstance;
   }
 
-  void RegisterVar(Base *var);
-  Base *FindVar(uint16_t vid);
-  uint32_t GetVarCount() const;
+  /// \brief adds variable to registry and issues it a unique ID
+  void register_variable(Base *var);
+
+  /*! \param vid ID of variable to be found
+   *  \returns pointer to variable if found, else nullptr
+   */
+  Base *find(uint16_t vid);
+
+  /*! \returns number of debug variables registered
+   */
+  uint32_t count() const;
 
  private:
-  // List of all the variables in the system.
-  // Increase size as necessary
-  Base *var_list_[100]{};
+  Base *var_list_[MaxVariableCount]{};
   uint16_t var_count_{0};
 
   // singleton assurance, because these are private

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -15,10 +15,10 @@ limitations under the License.
 
 #pragma once
 
-#include <array>
 #include <cstdint>
-#include <cstring>
 #include <limits>
+
+// \todo use namespace instead of lengthy type/class names
 
 // Defines the type of variable
 enum class VarType {
@@ -52,25 +52,26 @@ class DebugVarBase {
   // @param fmt printf style format string.  This is a hint to the Python code
   // as to how the variable data should be displayed.
   DebugVarBase(VarType type, const char *name, VarAccess access, const char *units,
-               const char *help, const char *fmt = "")
-      : type_(type), name_(name), access_(access), units_(units), help_(help), fmt_(fmt) {}
+               const char *help, const char *fmt = "");
 
   virtual uint32_t GetValue() = 0;
   virtual void SetValue(uint32_t value) = 0;
 
-  const char *GetName() const { return name_; }
-  const char *GetFormat() const { return fmt_; }
-  const char *GetHelp() const { return help_; }
-  const char *GetUnits() const { return units_; }
-  VarType GetType() const { return type_; }
-  uint16_t GetId() const { return id_; }
-  VarAccess GetAccess() const { return access_; }
-  bool WriteAllowed() const { return (access_ == VarAccess::ReadWrite); }
+  const char *GetName() const;
+  void prepend_name(const char *prefix);
+
+  const char *GetFormat() const;
+  const char *GetHelp() const;
+  const char *GetUnits() const;
+  VarType GetType() const;
+  uint16_t GetId() const;
+  VarAccess GetAccess() const;
+  bool WriteAllowed() const;
 
  private:
   uint16_t id_{InvalidID};
+  char name_[50];  // should be long enough for most variable names
   const VarType type_;
-  const char *const name_;
   const VarAccess access_;
   const char *const units_;
   const char *const help_;
@@ -84,9 +85,9 @@ class DebugVarRegistry {
   // this is the only way to access it
   static DebugVarRegistry &singleton() {
     // will privately initialize on first call
-    static DebugVarRegistry singleton_instance;
+    static DebugVarRegistry SingletonInstance;
     // will always return
-    return singleton_instance;
+    return SingletonInstance;
   }
 
   void RegisterVar(DebugVarBase *var);
@@ -100,7 +101,7 @@ class DebugVarRegistry {
   uint16_t var_count_{0};
 
   // singleton assurance, because these are private
-  DebugVarRegistry() {}                        // cannot default initialize
+  DebugVarRegistry() = default;                // cannot default initialize
   DebugVarRegistry(DebugVarRegistry const &);  // cannot copy initialize
   void operator=(DebugVarRegistry const &);    // cannot copy assign
 };

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -1,0 +1,106 @@
+/* Copyright 2020-2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+// Defines the type of variable
+enum class VarType {
+  Int32 = 1,
+  UInt32 = 2,
+  Float = 3,
+};
+
+// Defines the possible access to variable
+enum class VarAccess {
+  ReadOnly = 0,
+  ReadWrite = 1,
+};
+
+// This class represents a variable that you can read/write using the
+// debug serial port.
+//
+// We give each such variable a name which the debugger command line will
+// use to access it.  We can also link it with a C++ variable whose value
+// it will read or write.
+//
+// The fmt string gives the debug interface a suggestion on the best way
+// to display the variable's data.
+class DebugVarBase {
+ public:
+  static constexpr uint16_t InvalidID{std::numeric_limits<uint16_t>::max()};
+
+  // @param type Type of the variable
+  // @param name Name of the variable
+  // @param help String that the Python code displays describing the variable.
+  // @param fmt printf style format string.  This is a hint to the Python code
+  // as to how the variable data should be displayed.
+  DebugVarBase(VarType type, const char *name, VarAccess access, const char *units,
+               const char *help, const char *fmt = "")
+      : type_(type), name_(name), access_(access), units_(units), help_(help), fmt_(fmt) {}
+
+  virtual uint32_t GetValue() = 0;
+  virtual void SetValue(uint32_t value) = 0;
+
+  const char *GetName() const { return name_; }
+  const char *GetFormat() const { return fmt_; }
+  const char *GetHelp() const { return help_; }
+  const char *GetUnits() const { return units_; }
+  VarType GetType() const { return type_; }
+  uint16_t GetId() const { return id_; }
+  VarAccess GetAccess() const { return access_; }
+  bool WriteAllowed() const { return (access_ == VarAccess::ReadWrite); }
+
+ private:
+  uint16_t id_{InvalidID};
+  const VarType type_;
+  const char *const name_;
+  const VarAccess access_;
+  const char *const units_;
+  const char *const help_;
+  const char *const fmt_;
+
+  friend class DebugVarRegistry;
+};
+
+class DebugVarRegistry {
+ public:
+  // this is the only way to access it
+  static DebugVarRegistry &singleton() {
+    // will privately initialize on first call
+    static DebugVarRegistry singleton_instance;
+    // will always return
+    return singleton_instance;
+  }
+
+  void RegisterVar(DebugVarBase *var);
+  DebugVarBase *FindVar(uint16_t vid);
+  uint32_t GetVarCount();
+
+ private:
+  // List of all the variables in the system.
+  // Increase size as necessary
+  DebugVarBase *var_list_[100]{};
+  uint16_t var_count_{0};
+
+  // singleton assurance, because these are private
+  DebugVarRegistry() {}                        // cannot default initialize
+  DebugVarRegistry(DebugVarRegistry const &);  // cannot copy initialize
+  void operator=(DebugVarRegistry const &);    // cannot copy assign
+};

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -95,6 +95,7 @@ class Base {
  *
  * This is a singleton for keeping track of all debug variables.
  */
+// \todo deregister variables upon destruction
 class Registry {
  public:
   // this is the only way to access it
@@ -115,7 +116,7 @@ class Registry {
 
   /*! \returns number of debug variables registered
    */
-  uint32_t count() const;
+  uint16_t count() const;
 
  private:
   Base *var_list_[MaxVariableCount]{};

--- a/software/controller/lib/debugvars/vars_registry.cpp
+++ b/software/controller/lib/debugvars/vars_registry.cpp
@@ -19,18 +19,18 @@ limitations under the License.
 
 namespace Debug::Variable {
 
-void Registry::RegisterVar(Base *var) {
+void Registry::register_variable(Base *var) {
   if (var_count_ >= static_cast<uint16_t>(std::size(var_list_))) return;
   var_list_[var_count_] = var;
   var->id_ = var_count_;
   var_count_++;
 }
 
-Base *Registry::FindVar(uint16_t vid) {
+Base *Registry::find(uint16_t vid) {
   if (vid >= std::size(var_list_)) return nullptr;
   return var_list_[vid];
 }
 
-uint32_t Registry::GetVarCount() const { return var_count_; }
+uint32_t Registry::count() const { return var_count_; }
 
 }  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_registry.cpp
+++ b/software/controller/lib/debugvars/vars_registry.cpp
@@ -20,19 +20,17 @@ limitations under the License.
 namespace Debug::Variable {
 
 void Registry::RegisterVar(Base *var) {
-  if (var_count_ >= static_cast<uint16_t>(std::size(var_list_)))
-    return;
+  if (var_count_ >= static_cast<uint16_t>(std::size(var_list_))) return;
   var_list_[var_count_] = var;
   var->id_ = var_count_;
   var_count_++;
 }
 
 Base *Registry::FindVar(uint16_t vid) {
-  if (vid >= std::size(var_list_))
-    return nullptr;
+  if (vid >= std::size(var_list_)) return nullptr;
   return var_list_[vid];
 }
 
 uint32_t Registry::GetVarCount() const { return var_count_; }
 
-} // namespace Debug::Variable
+}  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_registry.cpp
+++ b/software/controller/lib/debugvars/vars_registry.cpp
@@ -31,6 +31,6 @@ Base *Registry::find(uint16_t vid) {
   return var_list_[vid];
 }
 
-uint32_t Registry::count() const { return var_count_; }
+uint16_t Registry::count() const { return var_count_; }
 
 }  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars_registry.cpp
+++ b/software/controller/lib/debugvars/vars_registry.cpp
@@ -13,8 +13,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "vars.h"
+#include "vars_base.h"
 
-// static member variables
-DebugVarBase *DebugVarBase::var_list_[100];
-uint16_t DebugVarBase::var_count_ = 0;
+void DebugVarRegistry::RegisterVar(DebugVarBase* var) {
+  if (var_count_ >= static_cast<uint16_t>(std::size(var_list_))) return;
+  var_list_[var_count_] = var;
+  var->id_ = var_count_;
+  var_count_++;
+}
+
+DebugVarBase* DebugVarRegistry::FindVar(uint16_t vid) {
+  if (vid >= std::size(var_list_)) return nullptr;
+  return var_list_[vid];
+}
+
+uint32_t DebugVarRegistry::GetVarCount() { return var_count_; }

--- a/software/controller/lib/debugvars/vars_registry.cpp
+++ b/software/controller/lib/debugvars/vars_registry.cpp
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <array>
+
 #include "vars_base.h"
 
 void DebugVarRegistry::RegisterVar(DebugVarBase* var) {

--- a/software/controller/lib/debugvars/vars_registry.cpp
+++ b/software/controller/lib/debugvars/vars_registry.cpp
@@ -17,16 +17,22 @@ limitations under the License.
 
 #include "vars_base.h"
 
-void DebugVarRegistry::RegisterVar(DebugVarBase* var) {
-  if (var_count_ >= static_cast<uint16_t>(std::size(var_list_))) return;
+namespace Debug::Variable {
+
+void Registry::RegisterVar(Base *var) {
+  if (var_count_ >= static_cast<uint16_t>(std::size(var_list_)))
+    return;
   var_list_[var_count_] = var;
   var->id_ = var_count_;
   var_count_++;
 }
 
-DebugVarBase* DebugVarRegistry::FindVar(uint16_t vid) {
-  if (vid >= std::size(var_list_)) return nullptr;
+Base *Registry::FindVar(uint16_t vid) {
+  if (vid >= std::size(var_list_))
+    return nullptr;
   return var_list_[vid];
 }
 
-uint32_t DebugVarRegistry::GetVarCount() { return var_count_; }
+uint32_t Registry::GetVarCount() const { return var_count_; }
+
+} // namespace Debug::Variable

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -372,12 +372,16 @@ void HalApi::StartLoopTimer(const Duration &period, void (*callback)(void *), vo
 }
 
 static float latency, max_latency, loop_time;
-static DebugVar dbg_loop_latency("loop_latency", VarAccess::ReadOnly, &latency, "\xB5s",
-                                 "Latency of loop function", "%.2f");
-static DebugVar dbg_max_latency("max_latency", VarAccess::ReadOnly, &max_latency, "\xB5s",
-                                "Maximum latency of loop function", "%.2f");
-static DebugVar dbg_loop_time("loop_time", VarAccess::ReadOnly, &loop_time, "\xB5s",
-                              "Duration of loop function", "%.2f");
+static Debug::Variable::Primitive32
+    dbg_loop_latency("loop_latency", Debug::Variable::Access::ReadOnly,
+                     &latency, "\xB5s", "Latency of loop function", "%.2f");
+static Debug::Variable::Primitive32
+    dbg_max_latency("max_latency", Debug::Variable::Access::ReadOnly,
+                    &max_latency, "\xB5s", "Maximum latency of loop function",
+                    "%.2f");
+static Debug::Variable::Primitive32
+    dbg_loop_time("loop_time", Debug::Variable::Access::ReadOnly, &loop_time,
+                  "\xB5s", "Duration of loop function", "%.2f");
 
 static void Timer15ISR() {
   uint32_t start = Timer15Base->counter;

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -372,16 +372,16 @@ void HalApi::StartLoopTimer(const Duration &period, void (*callback)(void *), vo
 }
 
 static float latency, max_latency, loop_time;
-static Debug::Variable::Primitive32
-    dbg_loop_latency("loop_latency", Debug::Variable::Access::ReadOnly,
-                     &latency, "\xB5s", "Latency of loop function", "%.2f");
-static Debug::Variable::Primitive32
-    dbg_max_latency("max_latency", Debug::Variable::Access::ReadOnly,
-                    &max_latency, "\xB5s", "Maximum latency of loop function",
-                    "%.2f");
-static Debug::Variable::Primitive32
-    dbg_loop_time("loop_time", Debug::Variable::Access::ReadOnly, &loop_time,
-                  "\xB5s", "Duration of loop function", "%.2f");
+static Debug::Variable::Primitive32 dbg_loop_latency("loop_latency",
+                                                     Debug::Variable::Access::ReadOnly, &latency,
+                                                     "\xB5s", "Latency of loop function", "%.2f");
+static Debug::Variable::Primitive32 dbg_max_latency("max_latency",
+                                                    Debug::Variable::Access::ReadOnly, &max_latency,
+                                                    "\xB5s", "Maximum latency of loop function",
+                                                    "%.2f");
+static Debug::Variable::Primitive32 dbg_loop_time("loop_time", Debug::Variable::Access::ReadOnly,
+                                                  &loop_time, "\xB5s", "Duration of loop function",
+                                                  "%.2f");
 
 static void Timer15ISR() {
   uint32_t start = Timer15Base->counter;

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -42,14 +42,14 @@ limitations under the License.
 // zero a bit above that) and fully open at 0.90.
 
 // UFlow IBV19M value
-static Debug::Variable::Float
-    dbg_psol_pwm_closed("psol_pwm_closed", Debug::Variable::Access::ReadWrite,
-                        0.35f, "ratio", "PWM power that closes the psol [0,1]");
+static Debug::Variable::Float dbg_psol_pwm_closed("psol_pwm_closed",
+                                                  Debug::Variable::Access::ReadWrite, 0.35f,
+                                                  "ratio", "PWM power that closes the psol [0,1]");
 
 // UFlow IBV19M value
-static Debug::Variable::Float
-    dbg_psol_pwm_open("psol_pwm_open", Debug::Variable::Access::ReadWrite,
-                      0.75f, "ratio", "PWM power that opens the psol [0,1]");
+static Debug::Variable::Float dbg_psol_pwm_open("psol_pwm_open", Debug::Variable::Access::ReadWrite,
+                                                0.75f, "ratio",
+                                                "PWM power that opens the psol [0,1]");
 
 void HalApi::InitPSOL() {
   // I'm using a 20kHz PWM frequency to drive the solenoid

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -42,12 +42,14 @@ limitations under the License.
 // zero a bit above that) and fully open at 0.90.
 
 // UFlow IBV19M value
-static DebugFloat dbg_psol_pwm_closed("psol_pwm_closed", VarAccess::ReadWrite, 0.35f, "ratio",
-                                      "PWM power that closes the psol [0,1]");
+static Debug::Variable::Float
+    dbg_psol_pwm_closed("psol_pwm_closed", Debug::Variable::Access::ReadWrite,
+                        0.35f, "ratio", "PWM power that closes the psol [0,1]");
 
 // UFlow IBV19M value
-static DebugFloat dbg_psol_pwm_open("psol_pwm_open", VarAccess::ReadWrite, 0.75f, "ratio",
-                                    "PWM power that opens the psol [0,1]");
+static Debug::Variable::Float
+    dbg_psol_pwm_open("psol_pwm_open", Debug::Variable::Access::ReadWrite,
+                      0.75f, "ratio", "PWM power that opens the psol [0,1]");
 
 void HalApi::InitPSOL() {
   // I'm using a 20kHz PWM frequency to drive the solenoid

--- a/software/controller/lib/hal/psol.cpp
+++ b/software/controller/lib/hal/psol.cpp
@@ -109,8 +109,8 @@ void HalApi::PSolValue(float val) {
   if (val == 0) {
     scaled = 0;
   } else {
-    float open_pwm = dbg_psol_pwm_open.Get();
-    float closed_pwm = dbg_psol_pwm_closed.Get();
+    float open_pwm = dbg_psol_pwm_open.get();
+    float closed_pwm = dbg_psol_pwm_closed.get();
     scaled = closed_pwm + val * (open_pwm - closed_pwm);
   }
   float duty = scaled * static_cast<float>(tmr->auto_reload);

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -41,17 +41,17 @@ PID::PID(const char *name, const char *help_supplement, float initial_kp, float 
   kd_.append_help(help_supplement);
 }
 
-void PID::kp(float new_kp) { kp_.Set(new_kp); }
+void PID::kp(float new_kp) { kp_.set(new_kp); }
 
-void PID::ki(float new_ki) { ki_.Set(new_ki); }
+void PID::ki(float new_ki) { ki_.set(new_ki); }
 
-void PID::kd(float new_kd) { kd_.Set(new_kd); }
+void PID::kd(float new_kd) { kd_.set(new_kd); }
 
-float PID::kp() const { return kp_.Get(); }
+float PID::kp() const { return kp_.get(); }
 
-float PID::ki() const { return ki_.Get(); }
+float PID::ki() const { return ki_.get(); }
 
-float PID::kd() const { return kd_.Get(); }
+float PID::kd() const { return kd_.get(); }
 
 void PID::reset() { initialized_ = false; }
 
@@ -71,25 +71,25 @@ float PID::compute(Time now, float input, float set_point) {
   float error = set_point - input;
   float delta_input = input - last_input_;
 
-  output_sum_ += (ki_.Get() * error * delta_t);
+  output_sum_ += (ki_.get() * error * delta_t);
 
   if (proportional_term_ == TermApplication::OnMeasurement) {
-    output_sum_ -= kp_.Get() * delta_input;
+    output_sum_ -= kp_.get() * delta_input;
   }
 
   output_sum_ = std::clamp(output_sum_, out_min_, out_max_);
 
   float res = output_sum_;
   if (proportional_term_ == TermApplication::OnError) {
-    res += kp_.Get() * error;
+    res += kp_.get() * error;
   }
   // delta_t may be 0 (e.g. on the first call to compute()), in which case we
   // simply skip using the derivative term.
   if (delta_t > 0) {
     if (differential_term_ == TermApplication::OnMeasurement) {
-      res -= kd_.Get() * delta_input / delta_t;
+      res -= kd_.get() * delta_input / delta_t;
     } else {
-      res += kd_.Get() * (error - last_error_) / delta_t;
+      res += kd_.get() * (error - last_error_) / delta_t;
     }
   }
 

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -20,6 +20,32 @@ limitations under the License.
 
 #include <algorithm>
 
+PID::PID(const char* name, const char* help_supplement, float kp, float ki, float kd,
+         ProportionalTerm p_term, DifferentialTerm d_term, float output_min, float output_max)
+    : kp_(kp),
+      ki_(ki),
+      kd_(kd),
+      dbg_kp_("kp", VarAccess::ReadWrite, kp, "", "Proportional gain"),
+      dbg_ki_("ki", VarAccess::ReadWrite, ki, "", "Integral gain"),
+      dbg_kd_("kd", VarAccess::ReadWrite, kd, "", "Derivative gain"),
+      p_term_(p_term),
+      d_term_(d_term),
+      out_min_(output_min),
+      out_max_(output_max) {
+  dbg_kp_.prepend_name(name);
+  dbg_kp_.append_help(help_supplement);
+  dbg_ki_.prepend_name(name);
+  dbg_ki_.append_help(help_supplement);
+  dbg_kd_.prepend_name(name);
+  dbg_kd_.append_help(help_supplement);
+}
+
+void PID::update_vars() {
+  SetKP(dbg_kp_.Get());
+  SetKI(dbg_ki_.Get());
+  SetKD(dbg_kd_.Get());
+}
+
 float PID::Compute(Time now, float input, float setpoint) {
   if (!initialized_) {
     last_input_ = input;

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -64,10 +64,10 @@ float PID::compute(Time now, float input, float set_point) {
     initialized_ = true;
   }
 
-  // compute time between now and last sample.
+  // Compute time between now and last sample.
   float delta_t = (now - last_update_time_).seconds();
 
-  // compute all the working error variables
+  // Compute all the working error variables
   float error = set_point - input;
   float delta_input = input - last_input_;
 

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -20,18 +20,20 @@ limitations under the License.
 
 #include <algorithm>
 
-PID::PID(const char *name, const char *help_supplement, float initial_kp,
-         float initial_ki, float initial_kd, TermApplication p_term,
-         TermApplication d_term, float output_min, float output_max)
-    : kp_(initial_kp), ki_(initial_ki), kd_(initial_kd),
+PID::PID(const char *name, const char *help_supplement, float initial_kp, float initial_ki,
+         float initial_kd, TermApplication p_term, TermApplication d_term, float output_min,
+         float output_max)
+    : kp_(initial_kp),
+      ki_(initial_ki),
+      kd_(initial_kd),
       dbg_kp_("initial_kp", Debug::Variable::Access::ReadWrite, initial_kp, "",
               "Proportional gain"),
-      dbg_ki_("initial_ki", Debug::Variable::Access::ReadWrite, initial_ki, "",
-              "Integral gain"),
-      dbg_kd_("initial_kd", Debug::Variable::Access::ReadWrite, initial_kd, "",
-              "Derivative gain"),
-      proportional_term_(p_term), differential_term_(d_term),
-      out_min_(output_min), out_max_(output_max) {
+      dbg_ki_("initial_ki", Debug::Variable::Access::ReadWrite, initial_ki, "", "Integral gain"),
+      dbg_kd_("initial_kd", Debug::Variable::Access::ReadWrite, initial_kd, "", "Derivative gain"),
+      proportional_term_(p_term),
+      differential_term_(d_term),
+      out_min_(output_min),
+      out_max_(output_max) {
   dbg_kp_.prepend_name(name);
   dbg_kp_.append_help(help_supplement);
   dbg_ki_.prepend_name(name);

--- a/software/controller/lib/pid/pid.cpp
+++ b/software/controller/lib/pid/pid.cpp
@@ -20,19 +20,18 @@ limitations under the License.
 
 #include <algorithm>
 
-PID::PID(const char* name, const char* help_supplement, float initial_kp, float initial_ki,
-         float initial_kd, TermApplication p_term, TermApplication d_term, float output_min,
-         float output_max)
-    : kp_(initial_kp),
-      ki_(initial_ki),
-      kd_(initial_kd),
-      dbg_kp_("initial_kp", VarAccess::ReadWrite, initial_kp, "", "Proportional gain"),
-      dbg_ki_("initial_ki", VarAccess::ReadWrite, initial_ki, "", "Integral gain"),
-      dbg_kd_("initial_kd", VarAccess::ReadWrite, initial_kd, "", "Derivative gain"),
-      proportional_term_(p_term),
-      differential_term_(d_term),
-      out_min_(output_min),
-      out_max_(output_max) {
+PID::PID(const char *name, const char *help_supplement, float initial_kp,
+         float initial_ki, float initial_kd, TermApplication p_term,
+         TermApplication d_term, float output_min, float output_max)
+    : kp_(initial_kp), ki_(initial_ki), kd_(initial_kd),
+      dbg_kp_("initial_kp", Debug::Variable::Access::ReadWrite, initial_kp, "",
+              "Proportional gain"),
+      dbg_ki_("initial_ki", Debug::Variable::Access::ReadWrite, initial_ki, "",
+              "Integral gain"),
+      dbg_kd_("initial_kd", Debug::Variable::Access::ReadWrite, initial_kd, "",
+              "Derivative gain"),
+      proportional_term_(p_term), differential_term_(d_term),
+      out_min_(output_min), out_max_(output_max) {
   dbg_kp_.prepend_name(name);
   dbg_kp_.append_help(help_supplement);
   dbg_ki_.prepend_name(name);
@@ -61,10 +60,10 @@ void PID::update_vars() {
   kd(dbg_kd_.Get());
 }
 
-float PID::compute(Time now, float input, float setpoint) {
+float PID::compute(Time now, float input, float set_point) {
   if (!initialized_) {
     last_input_ = input;
-    last_error_ = setpoint - input;
+    last_error_ = set_point - input;
     last_update_time_ = now;
     output_sum_ = 0;
     initialized_ = true;
@@ -74,7 +73,7 @@ float PID::compute(Time now, float input, float setpoint) {
   float delta_t = (now - last_update_time_).seconds();
 
   // compute all the working error variables
-  float error = setpoint - input;
+  float error = set_point - input;
   float delta_input = input - last_input_;
 
   output_sum_ += (ki_ * error * delta_t);
@@ -106,10 +105,10 @@ float PID::compute(Time now, float input, float setpoint) {
   return std::clamp(res, out_min_, out_max_);
 }
 
-void PID::observe(Time now, float input, float setpoint, float actual_output) {
+void PID::observe(Time now, float input, float set_point, float actual_output) {
   // All the observable variables are updated the same way as in compute();
   last_input_ = input;
-  last_error_ = setpoint - input;
+  last_error_ = set_point - input;
   last_update_time_ = now;
   // Reset output_sum_ to actual_output so that the next compute()
   // will adjust it only slightly (as if it had been computed by a current

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -21,24 +21,20 @@ limitations under the License.
 #include "units.h"
 #include "vars.h"
 
-enum class ProportionalTerm {
-  OnError,
-  OnMeasurement,
-};
-
-enum class DifferentialTerm {
-  OnError,
-  OnMeasurement,
-};
-
 class PID {
  public:
+  enum class TermApplication {
+    OnError,
+    OnMeasurement,
+  };
+
   // Constructs the PID using the given parameters.
-  PID(const char* name, const char* help_supplement, float kp, float ki, float kd,
-      ProportionalTerm p_term, DifferentialTerm d_term, float output_min, float output_max);
+  PID(const char* name, const char* help_supplement, float initial_kp, float initial_ki,
+      float initial_kd, TermApplication p_term, TermApplication d_term, float output_min,
+      float output_max);
 
   // Performs one step of the PID calculation.
-  float Compute(Time now, float input, float setpoint);
+  float compute(Time now, float input, float setpoint);
 
   // Call this instead of Compute in case on this step of the control loop
   // you intend apply different control logic instead of the PID.
@@ -47,13 +43,19 @@ class PID {
   // This is a variation on the "manual" mode:
   // http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-onoff/
   // http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-initialization/
-  void Observe(Time now, float input, float setpoint, float actual_output);
+  void observe(Time now, float input, float setpoint, float actual_output);
 
-  void SetKP(float kp) { kp_ = kp; }
-  void SetKI(float ki) { ki_ = ki; }
-  void SetKD(float kd) { kd_ = kd; }
+  // Setters
+  void kp(float);
+  void ki(float);
+  void kd(float);
 
-  void Reset() { initialized_ = false; }
+  // Getters
+  float kp() const;
+  float ki() const;
+  float kd() const;
+
+  void reset();
 
   void update_vars();
 
@@ -63,19 +65,19 @@ class PID {
   float kd_;  // * (D)erivative Tuning Parameter
 
   // \TODO: maybe just use these, replacing above simple floats? may not need the update function
-  DebugFloat dbg_kp_;
-  DebugFloat dbg_ki_;
-  DebugFloat dbg_kd_;
+  DebugFloat dbg_kp_;  // * (P)roportional Tuning Parameter
+  DebugFloat dbg_ki_;  // * (I)ntegral Tuning Parameter
+  DebugFloat dbg_kd_;  // * (D)erivative Tuning Parameter
 
-  const ProportionalTerm p_term_;
-  const DifferentialTerm d_term_;
+  const TermApplication proportional_term_;
+  const TermApplication differential_term_;
 
   const float out_min_;
   const float out_max_;
 
-  bool initialized_ = false;
-  Time last_update_time_ = microsSinceStartup(0);
-  float output_sum_ = 0;
-  float last_input_ = 0;
-  float last_error_ = 0;
+  bool initialized_{false};
+  Time last_update_time_{microsSinceStartup(0)};
+  float output_sum_{0};
+  float last_input_{0};
+  float last_error_{0};
 };

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -1,8 +1,11 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2021, RespiraWorks
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,18 +60,10 @@ class PID {
 
   void reset();
 
-  void update_vars();
-
  private:
-  float kp_;  // * (P)roportional Tuning Parameter
-  float ki_;  // * (I)ntegral Tuning Parameter
-  float kd_;  // * (D)erivative Tuning Parameter
-
-  // \TODO: maybe just use these, replacing above simple floats? may not need
-  // the update function
-  Debug::Variable::Float dbg_kp_;  // * (P)roportional Tuning Parameter
-  Debug::Variable::Float dbg_ki_;  // * (I)ntegral Tuning Parameter
-  Debug::Variable::Float dbg_kd_;  // * (D)erivative Tuning Parameter
+  Debug::Variable::Float kp_;  // * (P)roportional Tuning Parameter
+  Debug::Variable::Float ki_;  // * (I)ntegral Tuning Parameter
+  Debug::Variable::Float kd_;  // * (D)erivative Tuning Parameter
 
   const TermApplication proportional_term_;
   const TermApplication differential_term_;

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -22,16 +22,16 @@ limitations under the License.
 #include "vars.h"
 
 class PID {
-public:
+ public:
   enum class TermApplication {
     OnError,
     OnMeasurement,
   };
 
   // Constructs the PID using the given parameters.
-  PID(const char *name, const char *help_supplement, float initial_kp,
-      float initial_ki, float initial_kd, TermApplication p_term,
-      TermApplication d_term, float output_min, float output_max);
+  PID(const char *name, const char *help_supplement, float initial_kp, float initial_ki,
+      float initial_kd, TermApplication p_term, TermApplication d_term, float output_min,
+      float output_max);
 
   // Performs one step of the PID calculation.
   float compute(Time now, float input, float set_point);
@@ -59,16 +59,16 @@ public:
 
   void update_vars();
 
-private:
-  float kp_; // * (P)roportional Tuning Parameter
-  float ki_; // * (I)ntegral Tuning Parameter
-  float kd_; // * (D)erivative Tuning Parameter
+ private:
+  float kp_;  // * (P)roportional Tuning Parameter
+  float ki_;  // * (I)ntegral Tuning Parameter
+  float kd_;  // * (D)erivative Tuning Parameter
 
   // \TODO: maybe just use these, replacing above simple floats? may not need
   // the update function
-  Debug::Variable::Float dbg_kp_; // * (P)roportional Tuning Parameter
-  Debug::Variable::Float dbg_ki_; // * (I)ntegral Tuning Parameter
-  Debug::Variable::Float dbg_kd_; // * (D)erivative Tuning Parameter
+  Debug::Variable::Float dbg_kp_;  // * (P)roportional Tuning Parameter
+  Debug::Variable::Float dbg_ki_;  // * (I)ntegral Tuning Parameter
+  Debug::Variable::Float dbg_kd_;  // * (D)erivative Tuning Parameter
 
   const TermApplication proportional_term_;
   const TermApplication differential_term_;

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -22,19 +22,19 @@ limitations under the License.
 #include "vars.h"
 
 class PID {
- public:
+public:
   enum class TermApplication {
     OnError,
     OnMeasurement,
   };
 
   // Constructs the PID using the given parameters.
-  PID(const char* name, const char* help_supplement, float initial_kp, float initial_ki,
-      float initial_kd, TermApplication p_term, TermApplication d_term, float output_min,
-      float output_max);
+  PID(const char *name, const char *help_supplement, float initial_kp,
+      float initial_ki, float initial_kd, TermApplication p_term,
+      TermApplication d_term, float output_min, float output_max);
 
   // Performs one step of the PID calculation.
-  float compute(Time now, float input, float setpoint);
+  float compute(Time now, float input, float set_point);
 
   // Call this instead of Compute in case on this step of the control loop
   // you intend apply different control logic instead of the PID.
@@ -43,7 +43,7 @@ class PID {
   // This is a variation on the "manual" mode:
   // http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-onoff/
   // http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-initialization/
-  void observe(Time now, float input, float setpoint, float actual_output);
+  void observe(Time now, float input, float set_point, float actual_output);
 
   // Setters
   void kp(float);
@@ -59,15 +59,16 @@ class PID {
 
   void update_vars();
 
- private:
-  float kp_;  // * (P)roportional Tuning Parameter
-  float ki_;  // * (I)ntegral Tuning Parameter
-  float kd_;  // * (D)erivative Tuning Parameter
+private:
+  float kp_; // * (P)roportional Tuning Parameter
+  float ki_; // * (I)ntegral Tuning Parameter
+  float kd_; // * (D)erivative Tuning Parameter
 
-  // \TODO: maybe just use these, replacing above simple floats? may not need the update function
-  DebugFloat dbg_kp_;  // * (P)roportional Tuning Parameter
-  DebugFloat dbg_ki_;  // * (I)ntegral Tuning Parameter
-  DebugFloat dbg_kd_;  // * (D)erivative Tuning Parameter
+  // \TODO: maybe just use these, replacing above simple floats? may not need
+  // the update function
+  Debug::Variable::Float dbg_kp_; // * (P)roportional Tuning Parameter
+  Debug::Variable::Float dbg_ki_; // * (I)ntegral Tuning Parameter
+  Debug::Variable::Float dbg_kd_; // * (D)erivative Tuning Parameter
 
   const TermApplication proportional_term_;
   const TermApplication differential_term_;

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -19,6 +19,7 @@ limitations under the License.
 #pragma once
 
 #include "units.h"
+#include "vars.h"
 
 enum class ProportionalTerm {
   OnError,
@@ -33,15 +34,8 @@ enum class DifferentialTerm {
 class PID {
  public:
   // Constructs the PID using the given parameters.
-  PID(float kp, float ki, float kd, ProportionalTerm p_term, DifferentialTerm d_term,
-      float output_min, float output_max)
-      : kp_(kp),
-        ki_(ki),
-        kd_(kd),
-        p_term_(p_term),
-        d_term_(d_term),
-        out_min_(output_min),
-        out_max_(output_max) {}
+  PID(const char* name, const char* help_supplement, float kp, float ki, float kd,
+      ProportionalTerm p_term, DifferentialTerm d_term, float output_min, float output_max);
 
   // Performs one step of the PID calculation.
   float Compute(Time now, float input, float setpoint);
@@ -61,10 +55,17 @@ class PID {
 
   void Reset() { initialized_ = false; }
 
+  void update_vars();
+
  private:
   float kp_;  // * (P)roportional Tuning Parameter
   float ki_;  // * (I)ntegral Tuning Parameter
   float kd_;  // * (D)erivative Tuning Parameter
+
+  // \TODO: maybe just use these, replacing above simple floats? may not need the update function
+  DebugFloat dbg_kp_;
+  DebugFloat dbg_ki_;
+  DebugFloat dbg_kd_;
 
   const ProportionalTerm p_term_;
   const DifferentialTerm d_term_;

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -41,19 +41,19 @@ static Debug::Variable::UInt32 forced_mode(
 static Debug::Variable::UInt32 forced_breath_rate(
     "forced_breath_rate", Debug::Variable::Access::ReadWrite, 15, "breaths/min",
     "Target breath rate; overrides GUI setting when forced_mode is valid");
-static Debug::Variable::UInt32
-    forced_peep("forced_peep", Debug::Variable::Access::ReadWrite, 5, "cmH2O",
-                "Target PEEP; overrides GUI setting when forced_mode is valid");
-static Debug::Variable::UInt32
-    forced_pip("forced_pip", Debug::Variable::Access::ReadWrite, 15, "cmH2O",
-               "Target PIP; overrides GUI setting when forced_mode is valid");
+static Debug::Variable::UInt32 forced_peep(
+    "forced_peep", Debug::Variable::Access::ReadWrite, 5, "cmH2O",
+    "Target PEEP; overrides GUI setting when forced_mode is valid");
+static Debug::Variable::UInt32 forced_pip(
+    "forced_pip", Debug::Variable::Access::ReadWrite, 15, "cmH2O",
+    "Target PIP; overrides GUI setting when forced_mode is valid");
 static Debug::Variable::Float forced_ie_ratio(
     "forced_ie_ratio", Debug::Variable::Access::ReadWrite, 0.66f, "ratio",
     "Target I:E ratio; overrides GUI setting when forced_mode is valid");
-static Debug::Variable::Float
-    forced_fio2("forced_fio2", Debug::Variable::Access::ReadWrite, 21, "%",
-                "Target percent oxygen [21, 100]; overrides GUI "
-                "setting when forced_mode is valid");
+static Debug::Variable::Float forced_fio2("forced_fio2", Debug::Variable::Access::ReadWrite, 21,
+                                          "%",
+                                          "Target percent oxygen [21, 100]; overrides GUI "
+                                          "setting when forced_mode is valid");
 
 static Controller controller;
 static ControllerStatus controller_status;

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -31,24 +31,29 @@ limitations under the License.
 // By default, the controller receives settings (on/off, pip, rr, etc.) from
 // the GUI.  But you can also command the controller by setting the gui_foo
 // DebugVars below.
-static DebugUInt32 forced_mode("forced_mode", VarAccess::ReadWrite, _VentMode_MAX + 1, "",
-                               "Overrides ventilation mode as commanded by GUI; see VentMode enum "
-                               "in network_protocol.proto. If out of range, this and all of the "
-                               "other gui_foo DebugVars are ignored.",
-                               "%s");
-static DebugUInt32 forced_breath_rate(
-    "forced_breath_rate", VarAccess::ReadWrite, 15, "breaths/min",
+static Debug::Variable::UInt32 forced_mode(
+    "forced_mode", Debug::Variable::Access::ReadWrite, _VentMode_MAX + 1, "",
+    "Overrides ventilation mode as commanded by GUI; see VentMode enum in "
+    "network_protocol.proto. If out of range, this and all of the other "
+    "gui_foo "
+    "DebugVars are ignored.",
+    "%s");
+static Debug::Variable::UInt32 forced_breath_rate(
+    "forced_breath_rate", Debug::Variable::Access::ReadWrite, 15, "breaths/min",
     "Target breath rate; overrides GUI setting when forced_mode is valid");
-static DebugUInt32 forced_peep("forced_peep", VarAccess::ReadWrite, 5, "cmH2O",
-                               "Target PEEP; overrides GUI setting when forced_mode is valid");
-static DebugUInt32 forced_pip("forced_pip", VarAccess::ReadWrite, 15, "cmH2O",
-                              "Target PIP; overrides GUI setting when forced_mode is valid");
-static DebugFloat forced_ie_ratio(
-    "forced_ie_ratio", VarAccess::ReadWrite, 0.66f, "ratio",
+static Debug::Variable::UInt32
+    forced_peep("forced_peep", Debug::Variable::Access::ReadWrite, 5, "cmH2O",
+                "Target PEEP; overrides GUI setting when forced_mode is valid");
+static Debug::Variable::UInt32
+    forced_pip("forced_pip", Debug::Variable::Access::ReadWrite, 15, "cmH2O",
+               "Target PIP; overrides GUI setting when forced_mode is valid");
+static Debug::Variable::Float forced_ie_ratio(
+    "forced_ie_ratio", Debug::Variable::Access::ReadWrite, 0.66f, "ratio",
     "Target I:E ratio; overrides GUI setting when forced_mode is valid");
-static DebugFloat forced_fio2("forced_fio2", VarAccess::ReadWrite, 21, "%",
-                              "Target percent oxygen [21, 100]; overrides GUI "
-                              "setting when forced_mode is valid");
+static Debug::Variable::Float
+    forced_fio2("forced_fio2", Debug::Variable::Access::ReadWrite, 21, "%",
+                "Target percent oxygen [21, 100]; overrides GUI "
+                "setting when forced_mode is valid");
 
 static Controller controller;
 static ControllerStatus controller_status;

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -178,14 +178,14 @@ static void BackgroundLoop() {
 
     // Override received gui_status from the RPi with values from DebugVars iff
     // the forced_mode DebugVar has a legal value.
-    if (uint32_t m = forced_mode.Get(); m >= _VentMode_MIN && m <= _VentMode_MAX) {
+    if (uint32_t m = forced_mode.get(); m >= _VentMode_MIN && m <= _VentMode_MAX) {
       auto &p = gui_status.desired_params;
       p.mode = static_cast<VentMode>(m);
-      p.breaths_per_min = forced_breath_rate.Get();
-      p.peep_cm_h2o = forced_peep.Get();
-      p.pip_cm_h2o = forced_pip.Get();
-      p.inspiratory_expiratory_ratio = forced_ie_ratio.Get();
-      p.fio2 = forced_fio2.Get() / 100.f;
+      p.breaths_per_min = forced_breath_rate.get();
+      p.peep_cm_h2o = forced_peep.get();
+      p.pip_cm_h2o = forced_pip.get();
+      p.inspiratory_expiratory_ratio = forced_ie_ratio.get();
+      p.fio2 = forced_fio2.get() / 100.f;
     }
 
     // Copy the gui_status data into our controller status

--- a/software/controller/test/debug/interface_test.cpp
+++ b/software/controller/test/debug/interface_test.cpp
@@ -141,11 +141,9 @@ uint32_t GetVarViaCmd(Interface *serial, uint16_t id) {
 
 TEST(Interface, GetVar) {
   uint32_t foo = 0xDEADBEEF;
-  Debug::Variable::Primitive32 var_foo("foo", Debug::Variable::Access::ReadOnly,
-                                       &foo, "unit");
+  Debug::Variable::Primitive32 var_foo("foo", Debug::Variable::Access::ReadOnly, &foo, "unit");
   uint32_t bar = 0xC0DEBABE;
-  Debug::Variable::Primitive32 var_bar("bar", Debug::Variable::Access::ReadOnly,
-                                       &bar, "unit");
+  Debug::Variable::Primitive32 var_bar("bar", Debug::Variable::Access::ReadOnly, &bar, "unit");
 
   Trace trace;
   Command::VarHandler var_command;

--- a/software/controller/test/debug/interface_test.cpp
+++ b/software/controller/test/debug/interface_test.cpp
@@ -151,8 +151,8 @@ TEST(Interface, GetVar) {
   // Run a bunch of times with different expected results
   // to exercise buffer management.
   for (int i = 0; i < 100; ++i, ++foo, ++bar) {
-    EXPECT_EQ(foo, GetVarViaCmd(&serial, var_foo.GetId()));
-    EXPECT_EQ(bar, GetVarViaCmd(&serial, var_bar.GetId()));
+    EXPECT_EQ(foo, GetVarViaCmd(&serial, var_foo.id()));
+    EXPECT_EQ(bar, GetVarViaCmd(&serial, var_bar.id()));
   }
 }
 

--- a/software/controller/test/debug/interface_test.cpp
+++ b/software/controller/test/debug/interface_test.cpp
@@ -141,9 +141,11 @@ uint32_t GetVarViaCmd(Interface *serial, uint16_t id) {
 
 TEST(Interface, GetVar) {
   uint32_t foo = 0xDEADBEEF;
-  DebugVar var_foo("foo", VarAccess::ReadOnly, &foo, "unit");
+  Debug::Variable::Primitive32 var_foo("foo", Debug::Variable::Access::ReadOnly,
+                                       &foo, "unit");
   uint32_t bar = 0xC0DEBABE;
-  DebugVar var_bar("bar", VarAccess::ReadOnly, &bar, "unit");
+  Debug::Variable::Primitive32 var_bar("bar", Debug::Variable::Access::ReadOnly,
+                                       &bar, "unit");
 
   Trace trace;
   Command::VarHandler var_command;

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -51,8 +51,8 @@ TEST(TraceHandler, Flush) {
   TraceHandler trace_handler = TraceHandler(&trace);
 
   // activate trace
-  trace.SetTracedVarId<1>(var_x.GetId());
-  trace.SetTracedVarId<3>(var_y.GetId());
+  trace.SetTracedVarId<1>(var_x.id());
+  trace.SetTracedVarId<3>(var_y.id());
   trace.Start();  // Enable tracing
 
   trace.MaybeSample();
@@ -104,8 +104,8 @@ TEST(TraceHandler, Read) {
   EXPECT_TRUE(processed);
   EXPECT_EQ(read_context.response_length, 0);
 
-  trace.SetTracedVarId<1>(var_x.GetId());
-  trace.SetTracedVarId<3>(var_y.GetId());
+  trace.SetTracedVarId<1>(var_x.id());
+  trace.SetTracedVarId<3>(var_y.id());
 
   // start the trace (using debug command)
   std::array start_command = {static_cast<uint8_t>(TraceHandler::Subcommand::Start)};
@@ -181,7 +181,7 @@ TEST(TraceHandler, SettersAndGetters) {
   // Set trace var ID for var 1
   std::array<uint8_t, 4> set_var1_command = {
       static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), 1, 0, 0};
-  u16_to_u8(var_y.GetId(), &set_var1_command[2]);
+  u16_to_u8(var_y.id(), &set_var1_command[2]);
   std::array<uint8_t, kResponseSize> response;
   bool processed{false};
   Context set_var1_context = {.request = set_var1_command.data(),
@@ -285,8 +285,8 @@ TEST(TraceHandler, Errors) {
   Trace trace;
   TraceHandler trace_handler = TraceHandler(&trace);
 
-  trace.SetTracedVarId<1>(var_x.GetId());
-  trace.SetTracedVarId<3>(var_y.GetId());
+  trace.SetTracedVarId<1>(var_x.id());
+  trace.SetTracedVarId<3>(var_y.id());
   trace.Start();
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -39,12 +39,12 @@ void CheckBufferOutput(std::array<uint8_t, kResponseSize> response, uint32_t res
 TEST(TraceHandler, Flush) {
   // define some debug variables
   uint32_t i = 0;
-  FnDebugVar var_x(
-      VarType::UInt32, "x", VarAccess::ReadOnly, "unit", [&] { return i; },
-      [&](uint32_t value) { (void)value; }, "");
-  FnDebugVar var_y(
-      VarType::UInt32, "x", VarAccess::ReadOnly, "unit", [&] { return i * 10; },
-      [&](uint32_t value) { (void)value; }, "");
+  Debug::Variable::FnVar var_x(
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
+      "unit", [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
+  Debug::Variable::FnVar var_y(
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
+      "unit", [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
 
   // define trace and trace handler
   Trace trace;
@@ -79,12 +79,12 @@ TEST(TraceHandler, Read) {
 
   // define some debug variables
   uint32_t i = 0;
-  FnDebugVar var_x(
-      VarType::UInt32, "x", VarAccess::ReadOnly, "unit", [&] { return i; },
-      [&](uint32_t value) { (void)value; }, "");
-  FnDebugVar var_y(
-      VarType::UInt32, "y", VarAccess::ReadOnly, "unit", [&] { return i * 10; },
-      [&](uint32_t value) { (void)value; }, "");
+  Debug::Variable::FnVar var_x(
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
+      "unit", [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
+  Debug::Variable::FnVar var_y(
+      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly,
+      "unit", [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
 
   // define trace and trace handler
   Trace trace;
@@ -171,8 +171,10 @@ TEST(TraceHandler, Read) {
 
 TEST(TraceHandler, SettersAndGetters) {
   // define debug variables
-  DebugUInt32 var_x("x", VarAccess::ReadOnly, 0, "unit");
-  DebugUInt32 var_y("y", VarAccess::ReadOnly, 0, "unit");
+  Debug::Variable::UInt32 var_x("x", Debug::Variable::Access::ReadOnly, 0,
+                                "unit");
+  Debug::Variable::UInt32 var_y("y", Debug::Variable::Access::ReadOnly, 0,
+                                "unit");
 
   // define trace and trace handler
   Trace trace;
@@ -278,8 +280,10 @@ TEST(TraceHandler, SettersAndGetters) {
 
 TEST(TraceHandler, Errors) {
   // define some debug variables
-  DebugUInt32 var_x("x", VarAccess::ReadOnly, 0, "unit");
-  DebugUInt32 var_y("y", VarAccess::ReadOnly, 0, "unit");
+  Debug::Variable::UInt32 var_x("x", Debug::Variable::Access::ReadOnly, 0,
+                                "unit");
+  Debug::Variable::UInt32 var_y("y", Debug::Variable::Access::ReadOnly, 0,
+                                "unit");
 
   // define trace and trace handler
   Trace trace;

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -40,11 +40,11 @@ TEST(TraceHandler, Flush) {
   // define some debug variables
   uint32_t i = 0;
   Debug::Variable::FnVar var_x(
-      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
-      "unit", [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
+      [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
   Debug::Variable::FnVar var_y(
-      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
-      "unit", [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
+      [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
 
   // define trace and trace handler
   Trace trace;
@@ -80,11 +80,11 @@ TEST(TraceHandler, Read) {
   // define some debug variables
   uint32_t i = 0;
   Debug::Variable::FnVar var_x(
-      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
-      "unit", [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
+      [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
   Debug::Variable::FnVar var_y(
-      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly,
-      "unit", [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
+      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly, "unit",
+      [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
 
   // define trace and trace handler
   Trace trace;
@@ -171,10 +171,8 @@ TEST(TraceHandler, Read) {
 
 TEST(TraceHandler, SettersAndGetters) {
   // define debug variables
-  Debug::Variable::UInt32 var_x("x", Debug::Variable::Access::ReadOnly, 0,
-                                "unit");
-  Debug::Variable::UInt32 var_y("y", Debug::Variable::Access::ReadOnly, 0,
-                                "unit");
+  Debug::Variable::UInt32 var_x("x", Debug::Variable::Access::ReadOnly, 0, "unit");
+  Debug::Variable::UInt32 var_y("y", Debug::Variable::Access::ReadOnly, 0, "unit");
 
   // define trace and trace handler
   Trace trace;
@@ -280,10 +278,8 @@ TEST(TraceHandler, SettersAndGetters) {
 
 TEST(TraceHandler, Errors) {
   // define some debug variables
-  Debug::Variable::UInt32 var_x("x", Debug::Variable::Access::ReadOnly, 0,
-                                "unit");
-  Debug::Variable::UInt32 var_y("y", Debug::Variable::Access::ReadOnly, 0,
-                                "unit");
+  Debug::Variable::UInt32 var_x("x", Debug::Variable::Access::ReadOnly, 0, "unit");
+  Debug::Variable::UInt32 var_y("y", Debug::Variable::Access::ReadOnly, 0, "unit");
 
   // define trace and trace handler
   Trace trace;

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -28,12 +28,11 @@ using namespace Debug;
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
   Debug::Variable::FnVar var_x(
-      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
-      "units", [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "units",
+      [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
   Debug::Variable::FnVar var_y(
-      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly,
-      "units", [&] { return 10 * i; }, [&](uint32_t value) { (void)value; },
-      "");
+      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly, "units",
+      [&] { return 10 * i; }, [&](uint32_t value) { (void)value; }, "");
 
   Trace trace;
   trace.SetPeriod(3);  // Trace every 3 cycles.
@@ -88,8 +87,7 @@ TEST(Trace, MaybeSampleTwoVars) {
 TEST(Trace, TracesEveryCycleByDefault) {
   Trace trace;
   uint32_t x = 42;
-  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x,
-                                     "units");
+  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
   trace.SetTracedVarId<0>(var_x.GetId());
   trace.Start();
   // Do not set period
@@ -102,8 +100,7 @@ TEST(Trace, TracesEveryCycleByDefault) {
 
 TEST(Trace, BufferFull) {
   uint32_t x = 42;
-  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x,
-                                     "units");
+  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
   Trace trace;
   trace.SetTracedVarId<0>(var_x.GetId());
   trace.Start();
@@ -137,10 +134,8 @@ TEST(Trace, BufferFull) {
 
 TEST(Trace, FlushOnSetVar) {
   uint32_t x = 42, y = 37;
-  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x,
-                                     "units");
-  Debug::Variable::Primitive32 var_y("y", Debug::Variable::Access::ReadOnly, &y,
-                                     "units");
+  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
+  Debug::Variable::Primitive32 var_y("y", Debug::Variable::Access::ReadOnly, &y, "units");
   Trace trace;
   trace.SetTracedVarId<0>(var_x.GetId());
   trace.Start();

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -37,14 +37,14 @@ TEST(Trace, MaybeSampleTwoVars) {
   Trace trace;
   trace.SetPeriod(3);  // Trace every 3 cycles.
   trace.Start();       // Enable tracing
-  trace.SetTracedVarId<1>(var_x.GetId());
-  trace.SetTracedVarId<3>(var_y.GetId());
+  trace.SetTracedVarId<1>(var_x.id());
+  trace.SetTracedVarId<3>(var_y.id());
 
   EXPECT_EQ(2, trace.GetNumActiveVars());
   EXPECT_EQ(-1, trace.GetTracedVarId<0>());
-  EXPECT_EQ(var_x.GetId(), trace.GetTracedVarId<1>());
+  EXPECT_EQ(var_x.id(), trace.GetTracedVarId<1>());
   EXPECT_EQ(-1, trace.GetTracedVarId<2>());
-  EXPECT_EQ(var_y.GetId(), trace.GetTracedVarId<3>());
+  EXPECT_EQ(var_y.id(), trace.GetTracedVarId<3>());
 
   int expected_num_samples = 0;
   for (; i < 9; ++i) {
@@ -88,7 +88,7 @@ TEST(Trace, TracesEveryCycleByDefault) {
   Trace trace;
   uint32_t x = 42;
   Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
-  trace.SetTracedVarId<0>(var_x.GetId());
+  trace.SetTracedVarId<0>(var_x.id());
   trace.Start();
   // Do not set period
 
@@ -102,7 +102,7 @@ TEST(Trace, BufferFull) {
   uint32_t x = 42;
   Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
   Trace trace;
-  trace.SetTracedVarId<0>(var_x.GetId());
+  trace.SetTracedVarId<0>(var_x.id());
   trace.Start();
 
   // Buffer capacity from trace.h header file. Update if necessary.
@@ -137,7 +137,7 @@ TEST(Trace, FlushOnSetVar) {
   Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
   Debug::Variable::Primitive32 var_y("y", Debug::Variable::Access::ReadOnly, &y, "units");
   Trace trace;
-  trace.SetTracedVarId<0>(var_x.GetId());
+  trace.SetTracedVarId<0>(var_x.id());
   trace.Start();
 
   trace.MaybeSample();
@@ -147,7 +147,7 @@ TEST(Trace, FlushOnSetVar) {
 
   // Adding a new variable should reset the trace because otherwise
   // the interpretation of the circular buffer becomes ambiguous.
-  trace.SetTracedVarId<2>(var_y.GetId());
+  trace.SetTracedVarId<2>(var_y.id());
   EXPECT_EQ(0, trace.GetNumSamples());
 
   trace.MaybeSample();

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -27,12 +27,13 @@ using namespace Debug;
 
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
-  FnDebugVar var_x(
-      VarType::UInt32, "x", VarAccess::ReadOnly, "units", [&] { return i; },
-      [&](uint32_t value) { (void)value; }, "");
-  FnDebugVar var_y(
-      VarType::UInt32, "y", VarAccess::ReadOnly, "units", [&] { return 10 * i; },
-      [&](uint32_t value) { (void)value; }, "");
+  Debug::Variable::FnVar var_x(
+      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly,
+      "units", [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
+  Debug::Variable::FnVar var_y(
+      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly,
+      "units", [&] { return 10 * i; }, [&](uint32_t value) { (void)value; },
+      "");
 
   Trace trace;
   trace.SetPeriod(3);  // Trace every 3 cycles.
@@ -87,7 +88,8 @@ TEST(Trace, MaybeSampleTwoVars) {
 TEST(Trace, TracesEveryCycleByDefault) {
   Trace trace;
   uint32_t x = 42;
-  DebugVar var_x("x", VarAccess::ReadOnly, &x, "units");
+  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x,
+                                     "units");
   trace.SetTracedVarId<0>(var_x.GetId());
   trace.Start();
   // Do not set period
@@ -100,7 +102,8 @@ TEST(Trace, TracesEveryCycleByDefault) {
 
 TEST(Trace, BufferFull) {
   uint32_t x = 42;
-  DebugVar var_x("x", VarAccess::ReadOnly, &x, "units");
+  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x,
+                                     "units");
   Trace trace;
   trace.SetTracedVarId<0>(var_x.GetId());
   trace.Start();
@@ -134,8 +137,10 @@ TEST(Trace, BufferFull) {
 
 TEST(Trace, FlushOnSetVar) {
   uint32_t x = 42, y = 37;
-  DebugVar var_x("x", VarAccess::ReadOnly, &x, "units");
-  DebugVar var_y("y", VarAccess::ReadOnly, &y, "units");
+  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x,
+                                     "units");
+  Debug::Variable::Primitive32 var_y("y", Debug::Variable::Access::ReadOnly, &y,
+                                     "units");
   Trace trace;
   trace.SetTracedVarId<0>(var_x.GetId());
   trace.Start();

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -18,8 +18,8 @@ limitations under the License.
 #include <array>
 
 #include "commands.h"
-#include "vars.h"
 #include "gtest/gtest.h"
+#include "vars.h"
 
 namespace Debug::Command {
 
@@ -29,33 +29,28 @@ TEST(VarHandler, GetVarInfo) {
   const char *help = "help string";
   const char *format = "format";
   const char *unit = "unit";
-  Debug::Variable::Primitive32 var(name, Debug::Variable::Access::ReadOnly,
-                                   &value, unit, help, format);
+  Debug::Variable::Primitive32 var(name, Debug::Variable::Access::ReadOnly, &value, unit, help,
+                                   format);
 
   // expected result is hand-built from format given in var_cmd.cpp
-  std::vector<uint8_t> expected = {
-      static_cast<uint8_t>(Debug::Variable::Type::UInt32),
-      static_cast<uint8_t>(Debug::Variable::Access::ReadOnly),
-      0,
-      0,
-      static_cast<uint8_t>(strlen(name)),
-      static_cast<uint8_t>(strlen(format)),
-      static_cast<uint8_t>(strlen(help)),
-      static_cast<uint8_t>(strlen(unit))};
-  for (size_t i = 0; i < strlen(name); ++i)
-    expected.push_back(name[i]);
-  for (size_t i = 0; i < strlen(format); ++i)
-    expected.push_back(format[i]);
-  for (size_t i = 0; i < strlen(help); ++i)
-    expected.push_back(help[i]);
-  for (size_t i = 0; i < strlen(unit); ++i)
-    expected.push_back(unit[i]);
+  std::vector<uint8_t> expected = {static_cast<uint8_t>(Debug::Variable::Type::UInt32),
+                                   static_cast<uint8_t>(Debug::Variable::Access::ReadOnly),
+                                   0,
+                                   0,
+                                   static_cast<uint8_t>(strlen(name)),
+                                   static_cast<uint8_t>(strlen(format)),
+                                   static_cast<uint8_t>(strlen(help)),
+                                   static_cast<uint8_t>(strlen(unit))};
+  for (size_t i = 0; i < strlen(name); ++i) expected.push_back(name[i]);
+  for (size_t i = 0; i < strlen(format); ++i) expected.push_back(format[i]);
+  for (size_t i = 0; i < strlen(help); ++i) expected.push_back(help[i]);
+  for (size_t i = 0; i < strlen(unit); ++i) expected.push_back(unit[i]);
 
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
       static_cast<uint8_t>(VarHandler::Subcommand::GetInfo), id[0],
-      id[1], // Var id
+      id[1],  // Var id
   };
   std::array<uint8_t, 50> response;
   bool processed{false};
@@ -75,15 +70,15 @@ TEST(VarHandler, GetVarInfo) {
 
 TEST(VarHandler, GetVar) {
   uint32_t value = 0xDEADBEEF;
-  Debug::Variable::Primitive32 var("name", Debug::Variable::Access::ReadWrite,
-                                   &value, "units", "help");
+  Debug::Variable::Primitive32 var("name", Debug::Variable::Access::ReadWrite, &value, "units",
+                                   "help");
 
   // Test that a GET command obtains the variable's value.
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
   std::array req = {
       static_cast<uint8_t>(VarHandler::Subcommand::Get), id[0],
-      id[1], // Var id
+      id[1],  // Var id
   };
   std::array<uint8_t, 4> response;
   bool processed{false};
@@ -105,8 +100,8 @@ TEST(VarHandler, GetVar) {
 
 TEST(VarHandler, SetVar) {
   uint32_t value = 0xDEADBEEF;
-  Debug::Variable::Primitive32 var("name", Debug::Variable::Access::ReadWrite,
-                                   &value, "units", "help");
+  Debug::Variable::Primitive32 var("name", Debug::Variable::Access::ReadWrite, &value, "units",
+                                   "help");
 
   uint32_t new_value = 0xCAFEBABE;
   std::array<uint8_t, 4> new_bytes;
@@ -118,11 +113,11 @@ TEST(VarHandler, SetVar) {
   std::array req = {
       static_cast<uint8_t>(VarHandler::Subcommand::Set),
       id[0],
-      id[1], // Var id
+      id[1],  // Var id
       new_bytes[0],
       new_bytes[1],
       new_bytes[2],
-      new_bytes[3] // Value
+      new_bytes[3]  // Value
   };
 
   std::array<uint8_t, 0> response;
@@ -143,8 +138,7 @@ TEST(VarHandler, SetVar) {
 
 TEST(VarHandler, GetVarCount) {
   uint32_t value = 0xDEADBEEF;
-  Debug::Variable::Primitive32 dummy("name", Debug::Variable::Access::ReadWrite,
-                                     &value, "units");
+  Debug::Variable::Primitive32 dummy("name", Debug::Variable::Access::ReadWrite, &value, "units");
 
   // Test that GetVarCount command obtains the number of defined variables
   std::array req = {static_cast<uint8_t>(VarHandler::Subcommand::GetCount)};
@@ -162,25 +156,23 @@ TEST(VarHandler, GetVarCount) {
   EXPECT_EQ(4, context.response_length);
 
   std::array<uint8_t, 4> expected_result;
-  u32_to_u8(Debug::Variable::Registry::singleton().GetVarCount(),
-            expected_result.data());
+  u32_to_u8(Debug::Variable::Registry::singleton().GetVarCount(), expected_result.data());
   EXPECT_EQ(response, expected_result);
 }
 
 TEST(VarHandler, Errors) {
   uint32_t value = 0xDEADBEEF;
-  Debug::Variable::UInt32 var("name", Debug::Variable::Access::ReadWrite, value,
-                              "units", "help");
+  Debug::Variable::UInt32 var("name", Debug::Variable::Access::ReadWrite, value, "units", "help");
   uint8_t id[2];
   u16_to_u8(var.GetId(), id);
-  Debug::Variable::UInt32 var_readonly(
-      "name", Debug::Variable::Access::ReadOnly, value, "units", "help");
+  Debug::Variable::UInt32 var_readonly("name", Debug::Variable::Access::ReadOnly, value, "units",
+                                       "help");
   uint8_t id_readonly[2];
   u16_to_u8(var_readonly.GetId(), id_readonly);
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::MissingData},  // Missing subcommand
-      {{4}, ErrorCode::InvalidData}, // Invalid subcommand
+      {{}, ErrorCode::MissingData},   // Missing subcommand
+      {{4}, ErrorCode::InvalidData},  // Invalid subcommand
       {{0, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
       {{1, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
       {{2, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
@@ -191,8 +183,7 @@ TEST(VarHandler, Errors) {
       {{1, id[0], id[1]}, ErrorCode::NoMemory},
       {{3}, ErrorCode::NoMemory},
       {{2, id[0], id[1], 0xCA, 0xFE, 0x00}, ErrorCode::MissingData},
-      {{2, id_readonly[0], id_readonly[1], 0xCA, 0xFE, 0x00, 0x00},
-       ErrorCode::InternalError},
+      {{2, id_readonly[0], id_readonly[1], 0xCA, 0xFE, 0x00, 0x00}, ErrorCode::InternalError},
   };
 
   for (auto &[request, error] : requests) {
@@ -211,4 +202,4 @@ TEST(VarHandler, Errors) {
   }
 }
 
-} // namespace Debug::Command
+}  // namespace Debug::Command

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -153,7 +153,7 @@ TEST(VarHandler, GetVarCount) {
   EXPECT_EQ(4, context.response_length);
 
   std::array<uint8_t, 4> expected_result;
-  u32_to_u8(DebugVarBase::GetVarCount(), expected_result.data());
+  u32_to_u8(DebugVarRegistry::singleton().GetVarCount(), expected_result.data());
   EXPECT_EQ(response, expected_result);
 }
 

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -47,7 +47,7 @@ TEST(VarHandler, GetVarInfo) {
   for (size_t i = 0; i < strlen(unit); ++i) expected.push_back(unit[i]);
 
   uint8_t id[2];
-  u16_to_u8(var.GetId(), id);
+  u16_to_u8(var.id(), id);
   std::array req = {
       static_cast<uint8_t>(VarHandler::Subcommand::GetInfo), id[0],
       id[1],  // Var id
@@ -75,7 +75,7 @@ TEST(VarHandler, GetVar) {
 
   // Test that a GET command obtains the variable's value.
   uint8_t id[2];
-  u16_to_u8(var.GetId(), id);
+  u16_to_u8(var.id(), id);
   std::array req = {
       static_cast<uint8_t>(VarHandler::Subcommand::Get), id[0],
       id[1],  // Var id
@@ -109,7 +109,7 @@ TEST(VarHandler, SetVar) {
 
   // Test that a SET command changes the variable's value.
   uint8_t id[2];
-  u16_to_u8(var.GetId(), id);
+  u16_to_u8(var.id(), id);
   std::array req = {
       static_cast<uint8_t>(VarHandler::Subcommand::Set),
       id[0],
@@ -156,7 +156,7 @@ TEST(VarHandler, GetVarCount) {
   EXPECT_EQ(4, context.response_length);
 
   std::array<uint8_t, 4> expected_result;
-  u32_to_u8(Debug::Variable::Registry::singleton().GetVarCount(), expected_result.data());
+  u32_to_u8(Debug::Variable::Registry::singleton().count(), expected_result.data());
   EXPECT_EQ(response, expected_result);
 }
 
@@ -164,11 +164,11 @@ TEST(VarHandler, Errors) {
   uint32_t value = 0xDEADBEEF;
   Debug::Variable::UInt32 var("name", Debug::Variable::Access::ReadWrite, value, "units", "help");
   uint8_t id[2];
-  u16_to_u8(var.GetId(), id);
+  u16_to_u8(var.id(), id);
   Debug::Variable::UInt32 var_readonly("name", Debug::Variable::Access::ReadOnly, value, "units",
                                        "help");
   uint8_t id_readonly[2];
-  u16_to_u8(var_readonly.GetId(), id_readonly);
+  u16_to_u8(var_readonly.id(), id_readonly);
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
       {{}, ErrorCode::MissingData},   // Missing subcommand

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -30,7 +30,7 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ("fmt", var.GetFormat());
   EXPECT_EQ("unit", var.GetUnits());
   EXPECT_EQ(VarAccess::ReadOnly, var.GetAccess());
-  EXPECT_EQ(&var, DebugVar::FindVar(var.GetId()));
+  EXPECT_EQ(&var, DebugVarRegistry::singleton().FindVar(var.GetId()));
 
   EXPECT_EQ(uint32_t{5}, var.GetValue());
   var.SetValue(7);
@@ -76,18 +76,18 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 }
 
 TEST(DebugVar, Registration) {
-  uint32_t num_vars = DebugVarBase::GetVarCount();
+  uint32_t num_vars = DebugVarRegistry::singleton().GetVarCount();
   int32_t int_value = 5;
   DebugVar var1("var1", VarAccess::ReadWrite, &int_value, "unit");
 
-  EXPECT_EQ(DebugVarBase::GetVarCount(), num_vars + 1);
+  EXPECT_EQ(DebugVarRegistry::singleton().GetVarCount(), num_vars + 1);
 
   float float_value = 7;
   DebugVar var2("var2", VarAccess::ReadWrite, &float_value, "unit");
 
-  EXPECT_EQ(DebugVarBase::GetVarCount(), num_vars + 2);
+  EXPECT_EQ(DebugVarRegistry::singleton().GetVarCount(), num_vars + 2);
 
-  EXPECT_EQ(&var1, DebugVar::FindVar(var1.GetId()));
-  EXPECT_EQ(&var2, DebugVar::FindVar(var2.GetId()));
-  EXPECT_EQ(nullptr, DebugVar::FindVar(12345));
+  EXPECT_EQ(&var1, DebugVarRegistry::singleton().FindVar(var1.GetId()));
+  EXPECT_EQ(&var2, DebugVarRegistry::singleton().FindVar(var2.GetId()));
+  EXPECT_EQ(nullptr, DebugVarRegistry::singleton().FindVar(12345));
 }

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -19,8 +19,8 @@ limitations under the License.
 
 TEST(DebugVar, DebugVarInt32) {
   int32_t value = 5;
-  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadOnly,
-                                   &value, "unit", "help", "fmt");
+  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadOnly, &value, "unit", "help",
+                                   "fmt");
   EXPECT_STREQ("var", var.GetName());
   var.prepend_name("pre_");
   EXPECT_STREQ("pre_var", var.GetName());
@@ -45,8 +45,8 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ(static_cast<int32_t>(max), value);
 
   // All default arguments
-  Debug::Variable::Primitive32 var_default(
-      "var", Debug::Variable::Access::ReadWrite, &value, "unit");
+  Debug::Variable::Primitive32 var_default("var", Debug::Variable::Access::ReadWrite, &value,
+                                           "unit");
   EXPECT_STREQ("", var_default.GetHelp());
   EXPECT_STREQ("%d", var_default.GetFormat());
 }
@@ -54,8 +54,7 @@ TEST(DebugVar, DebugVarInt32) {
 TEST(DebugVar, DebugVarUint32Defaults) {
   uint32_t value = 5;
   // All default arguments
-  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite,
-                                   &value, "unit");
+  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
   EXPECT_EQ(uint32_t{5}, var.GetValue());
   EXPECT_STREQ("", var.GetHelp());
   EXPECT_STREQ("%u", var.GetFormat());
@@ -65,8 +64,7 @@ TEST(DebugVar, DebugVarUint32Defaults) {
 TEST(DebugVar, DebugVarFloatDefaults) {
   float value = 5.0f;
   // All default arguments
-  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite,
-                                   &value, "unit");
+  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
 
   EXPECT_STREQ("", var.GetHelp());
   EXPECT_STREQ("%.3f", var.GetFormat());
@@ -82,20 +80,17 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 TEST(DebugVar, Registration) {
   uint32_t num_vars = Debug::Variable::Registry::singleton().GetVarCount();
   int32_t int_value = 5;
-  Debug::Variable::Primitive32 var1("var1", Debug::Variable::Access::ReadWrite,
-                                    &int_value, "unit");
+  Debug::Variable::Primitive32 var1("var1", Debug::Variable::Access::ReadWrite, &int_value, "unit");
 
   EXPECT_EQ(Debug::Variable::Registry::singleton().GetVarCount(), num_vars + 1);
 
   float float_value = 7;
-  Debug::Variable::Primitive32 var2("var2", Debug::Variable::Access::ReadWrite,
-                                    &float_value, "unit");
+  Debug::Variable::Primitive32 var2("var2", Debug::Variable::Access::ReadWrite, &float_value,
+                                    "unit");
 
   EXPECT_EQ(Debug::Variable::Registry::singleton().GetVarCount(), num_vars + 2);
 
-  EXPECT_EQ(&var1,
-            Debug::Variable::Registry::singleton().FindVar(var1.GetId()));
-  EXPECT_EQ(&var2,
-            Debug::Variable::Registry::singleton().FindVar(var2.GetId()));
+  EXPECT_EQ(&var1, Debug::Variable::Registry::singleton().FindVar(var1.GetId()));
+  EXPECT_EQ(&var2, Debug::Variable::Registry::singleton().FindVar(var2.GetId()));
   EXPECT_EQ(nullptr, Debug::Variable::Registry::singleton().FindVar(12345));
 }

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -15,16 +15,14 @@ limitations under the License.
 
 #include "vars.h"
 
-#include <stdint.h>
-
-#include <limits>
-
 #include "gtest/gtest.h"
 
 TEST(DebugVar, DebugVarInt32) {
   int32_t value = 5;
   DebugVar var("var", VarAccess::ReadOnly, &value, "unit", "help", "fmt");
-  EXPECT_EQ("var", var.GetName());
+  EXPECT_STREQ("var", var.GetName());
+  var.prepend_name("pre_");
+  EXPECT_STREQ("pre_var", var.GetName());
   EXPECT_EQ("help", var.GetHelp());
   EXPECT_EQ(VarType::Int32, var.GetType());
   EXPECT_EQ("fmt", var.GetFormat());

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -19,18 +19,19 @@ limitations under the License.
 
 TEST(DebugVar, DebugVarInt32) {
   int32_t value = 5;
-  DebugVar var("var", VarAccess::ReadOnly, &value, "unit", "help", "fmt");
+  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadOnly,
+                                   &value, "unit", "help", "fmt");
   EXPECT_STREQ("var", var.GetName());
   var.prepend_name("pre_");
   EXPECT_STREQ("pre_var", var.GetName());
   EXPECT_STREQ("help", var.GetHelp());
   var.append_help(" so much help");
   EXPECT_STREQ("help so much help", var.GetHelp());
-  EXPECT_EQ(VarType::Int32, var.GetType());
+  EXPECT_EQ(Debug::Variable::Type::Int32, var.GetType());
   EXPECT_STREQ("fmt", var.GetFormat());
   EXPECT_STREQ("unit", var.GetUnits());
-  EXPECT_EQ(VarAccess::ReadOnly, var.GetAccess());
-  EXPECT_EQ(&var, DebugVarRegistry::singleton().FindVar(var.GetId()));
+  EXPECT_EQ(Debug::Variable::Access::ReadOnly, var.GetAccess());
+  EXPECT_EQ(&var, Debug::Variable::Registry::singleton().FindVar(var.GetId()));
 
   EXPECT_EQ(uint32_t{5}, var.GetValue());
   var.SetValue(7);
@@ -44,7 +45,8 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ(static_cast<int32_t>(max), value);
 
   // All default arguments
-  DebugVar var_default("var", VarAccess::ReadWrite, &value, "unit");
+  Debug::Variable::Primitive32 var_default(
+      "var", Debug::Variable::Access::ReadWrite, &value, "unit");
   EXPECT_STREQ("", var_default.GetHelp());
   EXPECT_STREQ("%d", var_default.GetFormat());
 }
@@ -52,21 +54,23 @@ TEST(DebugVar, DebugVarInt32) {
 TEST(DebugVar, DebugVarUint32Defaults) {
   uint32_t value = 5;
   // All default arguments
-  DebugVar var("var", VarAccess::ReadWrite, &value, "unit");
+  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite,
+                                   &value, "unit");
   EXPECT_EQ(uint32_t{5}, var.GetValue());
   EXPECT_STREQ("", var.GetHelp());
   EXPECT_STREQ("%u", var.GetFormat());
-  EXPECT_EQ(VarType::UInt32, var.GetType());
+  EXPECT_EQ(Debug::Variable::Type::UInt32, var.GetType());
 }
 
 TEST(DebugVar, DebugVarFloatDefaults) {
   float value = 5.0f;
   // All default arguments
-  DebugVar var("var", VarAccess::ReadWrite, &value, "unit");
+  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite,
+                                   &value, "unit");
 
   EXPECT_STREQ("", var.GetHelp());
   EXPECT_STREQ("%.3f", var.GetFormat());
-  EXPECT_EQ(VarType::Float, var.GetType());
+  EXPECT_EQ(Debug::Variable::Type::Float, var.GetType());
 
   // Rountrip through uint32 should not change value.
   uint32_t uint_value = var.GetValue();
@@ -76,18 +80,22 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 }
 
 TEST(DebugVar, Registration) {
-  uint32_t num_vars = DebugVarRegistry::singleton().GetVarCount();
+  uint32_t num_vars = Debug::Variable::Registry::singleton().GetVarCount();
   int32_t int_value = 5;
-  DebugVar var1("var1", VarAccess::ReadWrite, &int_value, "unit");
+  Debug::Variable::Primitive32 var1("var1", Debug::Variable::Access::ReadWrite,
+                                    &int_value, "unit");
 
-  EXPECT_EQ(DebugVarRegistry::singleton().GetVarCount(), num_vars + 1);
+  EXPECT_EQ(Debug::Variable::Registry::singleton().GetVarCount(), num_vars + 1);
 
   float float_value = 7;
-  DebugVar var2("var2", VarAccess::ReadWrite, &float_value, "unit");
+  Debug::Variable::Primitive32 var2("var2", Debug::Variable::Access::ReadWrite,
+                                    &float_value, "unit");
 
-  EXPECT_EQ(DebugVarRegistry::singleton().GetVarCount(), num_vars + 2);
+  EXPECT_EQ(Debug::Variable::Registry::singleton().GetVarCount(), num_vars + 2);
 
-  EXPECT_EQ(&var1, DebugVarRegistry::singleton().FindVar(var1.GetId()));
-  EXPECT_EQ(&var2, DebugVarRegistry::singleton().FindVar(var2.GetId()));
-  EXPECT_EQ(nullptr, DebugVarRegistry::singleton().FindVar(12345));
+  EXPECT_EQ(&var1,
+            Debug::Variable::Registry::singleton().FindVar(var1.GetId()));
+  EXPECT_EQ(&var2,
+            Debug::Variable::Registry::singleton().FindVar(var2.GetId()));
+  EXPECT_EQ(nullptr, Debug::Variable::Registry::singleton().FindVar(12345));
 }

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -23,10 +23,12 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_STREQ("var", var.GetName());
   var.prepend_name("pre_");
   EXPECT_STREQ("pre_var", var.GetName());
-  EXPECT_EQ("help", var.GetHelp());
+  EXPECT_STREQ("help", var.GetHelp());
+  var.append_help(" so much help");
+  EXPECT_STREQ("help so much help", var.GetHelp());
   EXPECT_EQ(VarType::Int32, var.GetType());
-  EXPECT_EQ("fmt", var.GetFormat());
-  EXPECT_EQ("unit", var.GetUnits());
+  EXPECT_STREQ("fmt", var.GetFormat());
+  EXPECT_STREQ("unit", var.GetUnits());
   EXPECT_EQ(VarAccess::ReadOnly, var.GetAccess());
   EXPECT_EQ(&var, DebugVarRegistry::singleton().FindVar(var.GetId()));
 
@@ -43,8 +45,8 @@ TEST(DebugVar, DebugVarInt32) {
 
   // All default arguments
   DebugVar var_default("var", VarAccess::ReadWrite, &value, "unit");
-  EXPECT_EQ("", var_default.GetHelp());
-  EXPECT_EQ("%d", var_default.GetFormat());
+  EXPECT_STREQ("", var_default.GetHelp());
+  EXPECT_STREQ("%d", var_default.GetFormat());
 }
 
 TEST(DebugVar, DebugVarUint32Defaults) {
@@ -52,8 +54,8 @@ TEST(DebugVar, DebugVarUint32Defaults) {
   // All default arguments
   DebugVar var("var", VarAccess::ReadWrite, &value, "unit");
   EXPECT_EQ(uint32_t{5}, var.GetValue());
-  EXPECT_EQ("", var.GetHelp());
-  EXPECT_EQ("%u", var.GetFormat());
+  EXPECT_STREQ("", var.GetHelp());
+  EXPECT_STREQ("%u", var.GetFormat());
   EXPECT_EQ(VarType::UInt32, var.GetType());
 }
 
@@ -62,8 +64,8 @@ TEST(DebugVar, DebugVarFloatDefaults) {
   // All default arguments
   DebugVar var("var", VarAccess::ReadWrite, &value, "unit");
 
-  EXPECT_EQ("", var.GetHelp());
-  EXPECT_EQ("%.3f", var.GetFormat());
+  EXPECT_STREQ("", var.GetHelp());
+  EXPECT_STREQ("%.3f", var.GetFormat());
   EXPECT_EQ(VarType::Float, var.GetType());
 
   // Rountrip through uint32 should not change value.

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -21,44 +21,44 @@ TEST(DebugVar, DebugVarInt32) {
   int32_t value = 5;
   Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadOnly, &value, "unit", "help",
                                    "fmt");
-  EXPECT_STREQ("var", var.GetName());
+  EXPECT_STREQ("var", var.name());
   var.prepend_name("pre_");
-  EXPECT_STREQ("pre_var", var.GetName());
-  EXPECT_STREQ("help", var.GetHelp());
+  EXPECT_STREQ("pre_var", var.name());
+  EXPECT_STREQ("help", var.help());
   var.append_help(" so much help");
-  EXPECT_STREQ("help so much help", var.GetHelp());
-  EXPECT_EQ(Debug::Variable::Type::Int32, var.GetType());
-  EXPECT_STREQ("fmt", var.GetFormat());
-  EXPECT_STREQ("unit", var.GetUnits());
-  EXPECT_EQ(Debug::Variable::Access::ReadOnly, var.GetAccess());
-  EXPECT_EQ(&var, Debug::Variable::Registry::singleton().FindVar(var.GetId()));
+  EXPECT_STREQ("help so much help", var.help());
+  EXPECT_EQ(Debug::Variable::Type::Int32, var.type());
+  EXPECT_STREQ("fmt", var.format());
+  EXPECT_STREQ("unit", var.units());
+  EXPECT_EQ(Debug::Variable::Access::ReadOnly, var.access());
+  EXPECT_EQ(&var, Debug::Variable::Registry::singleton().find(var.id()));
 
-  EXPECT_EQ(uint32_t{5}, var.GetValue());
-  var.SetValue(7);
-  EXPECT_EQ(uint32_t{7}, var.GetValue());
+  EXPECT_EQ(uint32_t{5}, var.get_value());
+  var.set_value(7);
+  EXPECT_EQ(uint32_t{7}, var.get_value());
   EXPECT_EQ(7, value);
 
   // Test a value outside the range of int32_t.
   uint32_t max = std::numeric_limits<uint32_t>::max();
-  var.SetValue(max);
-  EXPECT_EQ(max, var.GetValue());
+  var.set_value(max);
+  EXPECT_EQ(max, var.get_value());
   EXPECT_EQ(static_cast<int32_t>(max), value);
 
   // All default arguments
   Debug::Variable::Primitive32 var_default("var", Debug::Variable::Access::ReadWrite, &value,
                                            "unit");
-  EXPECT_STREQ("", var_default.GetHelp());
-  EXPECT_STREQ("%d", var_default.GetFormat());
+  EXPECT_STREQ("", var_default.help());
+  EXPECT_STREQ("%d", var_default.format());
 }
 
 TEST(DebugVar, DebugVarUint32Defaults) {
   uint32_t value = 5;
   // All default arguments
   Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
-  EXPECT_EQ(uint32_t{5}, var.GetValue());
-  EXPECT_STREQ("", var.GetHelp());
-  EXPECT_STREQ("%u", var.GetFormat());
-  EXPECT_EQ(Debug::Variable::Type::UInt32, var.GetType());
+  EXPECT_EQ(uint32_t{5}, var.get_value());
+  EXPECT_STREQ("", var.help());
+  EXPECT_STREQ("%u", var.format());
+  EXPECT_EQ(Debug::Variable::Type::UInt32, var.type());
 }
 
 TEST(DebugVar, DebugVarFloatDefaults) {
@@ -66,31 +66,31 @@ TEST(DebugVar, DebugVarFloatDefaults) {
   // All default arguments
   Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
 
-  EXPECT_STREQ("", var.GetHelp());
-  EXPECT_STREQ("%.3f", var.GetFormat());
-  EXPECT_EQ(Debug::Variable::Type::Float, var.GetType());
+  EXPECT_STREQ("", var.help());
+  EXPECT_STREQ("%.3f", var.format());
+  EXPECT_EQ(Debug::Variable::Type::Float, var.type());
 
   // Rountrip through uint32 should not change value.
-  uint32_t uint_value = var.GetValue();
-  var.SetValue(uint_value);
-  EXPECT_EQ(uint_value, var.GetValue());
+  uint32_t uint_value = var.get_value();
+  var.set_value(uint_value);
+  EXPECT_EQ(uint_value, var.get_value());
   EXPECT_EQ(5.0f, value);
 }
 
 TEST(DebugVar, Registration) {
-  uint32_t num_vars = Debug::Variable::Registry::singleton().GetVarCount();
+  uint32_t num_vars = Debug::Variable::Registry::singleton().count();
   int32_t int_value = 5;
   Debug::Variable::Primitive32 var1("var1", Debug::Variable::Access::ReadWrite, &int_value, "unit");
 
-  EXPECT_EQ(Debug::Variable::Registry::singleton().GetVarCount(), num_vars + 1);
+  EXPECT_EQ(Debug::Variable::Registry::singleton().count(), num_vars + 1);
 
   float float_value = 7;
   Debug::Variable::Primitive32 var2("var2", Debug::Variable::Access::ReadWrite, &float_value,
                                     "unit");
 
-  EXPECT_EQ(Debug::Variable::Registry::singleton().GetVarCount(), num_vars + 2);
+  EXPECT_EQ(Debug::Variable::Registry::singleton().count(), num_vars + 2);
 
-  EXPECT_EQ(&var1, Debug::Variable::Registry::singleton().FindVar(var1.GetId()));
-  EXPECT_EQ(&var2, Debug::Variable::Registry::singleton().FindVar(var2.GetId()));
-  EXPECT_EQ(nullptr, Debug::Variable::Registry::singleton().FindVar(12345));
+  EXPECT_EQ(&var1, Debug::Variable::Registry::singleton().find(var1.id()));
+  EXPECT_EQ(&var2, Debug::Variable::Registry::singleton().find(var2.id()));
+  EXPECT_EQ(nullptr, Debug::Variable::Registry::singleton().find(12345));
 }

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -75,9 +75,9 @@ TEST(PidTest, AccessSetViaDebug) {
           /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
 
   EXPECT_EQ(registry.count(), 3 + count_offset);
-  auto kp = reinterpret_cast<Debug::Variable::Float*>(registry.find(0 + count_offset));
-  auto ki = reinterpret_cast<Debug::Variable::Float*>(registry.find(1 + count_offset));
-  auto kd = reinterpret_cast<Debug::Variable::Float*>(registry.find(2 + count_offset));
+  auto kp = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(0) + count_offset));
+  auto ki = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(1) + count_offset));
+  auto kd = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(2) + count_offset));
 
   kp->set(11.f);
   EXPECT_EQ(pid.kp(), 11.f);

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -47,13 +47,14 @@ TEST(PidTest, Proportional) {
   const float input = setpoint - 10;
 
   // Create PID and run once
-  PID pid(Kp, /*ki=*/0, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", Kp, /*ki=*/0, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Ki and Kd = 0 therefore output = Kp*error, nothing more
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint), (setpoint - input) * Kp);
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint), (setpoint - input) * Kp);
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, setpoint), (setpoint - input) * Kp);
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, setpoint), (setpoint - input) * Kp);
 }
 
 TEST(PidTest, IntegralBasic) {
@@ -61,19 +62,20 @@ TEST(PidTest, IntegralBasic) {
   const float setpoint = 25;
   const float input = setpoint - 10;
 
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, Ki, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // on first call, integral = error * 0, output = 0.
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint), 0);
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, setpoint), 0);
 
   // on second call, integral = error * sample_time, output = Ki*integral
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint),
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, setpoint),
                 (setpoint - input) * sample_period.seconds() * Ki);
 
   // on third call, integral = error * 2 * sample_time, output = Ki*integral
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint),
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, setpoint),
                 (setpoint - input) * 2 * sample_period.seconds() * Ki);
 }
 
@@ -82,24 +84,25 @@ TEST(PidTest, IntegralSaturationMax) {
   const float setpoint = 25;
   const float input = setpoint - 10;
 
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, Ki, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   float output = 0;
   for (int i = 0; i < 1000; ++i) {
-    output = pid.Compute(ticks(t++), input, setpoint);
+    output = pid.compute(ticks(t++), input, setpoint);
     if (output >= MAX_OUTPUT) break;
   }
   EXPECT_EQ(output, MAX_OUTPUT);
 
   for (int i = 0; i < 10; i++) {
-    pid.Compute(ticks(t++), input, setpoint);
+    pid.compute(ticks(t++), input, setpoint);
   }
 
   // make setpoint lower than input to de-saturate output
   const float low_setpoint = input - 10;
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, low_setpoint),
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, low_setpoint),
                 MAX_OUTPUT + (low_setpoint - input) * sample_period.seconds() * Ki);
 }
 
@@ -109,26 +112,27 @@ TEST(PidTest, IntegralSaturationMin) {
   const float input = setpoint + 10;
 
   // Create PID and run once
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, Ki, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   float output = 0;
   for (int i = 0; i < 1000; ++i) {
-    output = pid.Compute(ticks(t++), input, setpoint);
+    output = pid.compute(ticks(t++), input, setpoint);
     if (output <= MIN_OUTPUT) break;
   }
   EXPECT_EQ(output, MIN_OUTPUT);
 
   // run a few times to make sure actual integral is lower
   for (int i = 0; i < 10; i++) {
-    pid.Compute(ticks(t++), input, setpoint);
+    pid.compute(ticks(t++), input, setpoint);
   }
 
   // make setpoint bigger than input again to de-saturate output
   float new_setpoint = input + 10;
 
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, new_setpoint),
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, new_setpoint),
                 MIN_OUTPUT + (new_setpoint - input) * sample_period.seconds() * Ki);
 }
 
@@ -141,16 +145,17 @@ TEST(PidTest, DerivativeOnMeasure) {
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
   const float input2 = setpoint2 - 13;
-  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::OnMeasurement, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, /*ki=*/0, Kd,
+          /*p_term=*/PID::TermApplication::OnMeasurement,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Expect no derivative on first call
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input1, setpoint1), 0);
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input1, setpoint1), 0);
 
   // Note that DifferentialTerm::OnMeasurement actually works with
   // -1*Kd to allow using the same parameters as DifferentialTerm::OnError
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input2, setpoint2),
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input2, setpoint2),
                 -1 * Kd * (input2 - input1) / sample_period.seconds());
 }
 
@@ -160,13 +165,14 @@ TEST(PidTest, DerivativeOnError) {
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
   const float input2 = setpoint2 - 13;
-  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::OnMeasurement, DifferentialTerm::OnError,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, /*ki=*/0, Kd,
+          /*p_term=*/PID::TermApplication::OnMeasurement,
+          /*d_term=*/PID::TermApplication::OnError, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Expect no derivative on first call
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input1, setpoint1), 0);
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input2, setpoint2),
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input1, setpoint1), 0);
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input2, setpoint2),
                 Kd * ((setpoint2 - input2) - (setpoint1 - input1)) / sample_period.seconds());
 }
 
@@ -177,26 +183,27 @@ TEST(PidTest, TaskJitter) {
   const float Ki = 0.5f;
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, Ki, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   Time now = base;
 
   float integral = (setpoint - input) * sample_period.seconds();
-  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+  EXPECT_OUTPUT(pid.compute(now, input, setpoint), integral * Ki);
 
   // Advance time with jitter
   Duration dt_high = sample_period + max_task_jitter;
   now += dt_high;
   // Expect output to take jitter into account in integral
   integral += (setpoint - input) * dt_high.seconds();
-  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+  EXPECT_OUTPUT(pid.compute(now, input, setpoint), integral * Ki);
 
   // Advance time and compensate previous jitter to have total time
   // elapsed = 2*sample time
   Duration dt_low = sample_period - max_task_jitter;
   integral += (setpoint - input) * dt_low.seconds();
   now += dt_low;
-  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+  EXPECT_OUTPUT(pid.compute(now, input, setpoint), integral * Ki);
 }
 
 TEST(PidTest, MissedSample) {
@@ -205,44 +212,46 @@ TEST(PidTest, MissedSample) {
   const float Ki = 0.2f;
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, Ki, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   Time now = base;
 
   float integral = (setpoint - input) * (sample_period.seconds());
-  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+  EXPECT_OUTPUT(pid.compute(now, input, setpoint), integral * Ki);
 
   // Advance time
   now += 2 * sample_period;
-  float output = pid.Compute(now, input, setpoint);
+  float output = pid.compute(now, input, setpoint);
   // Expect output to integrate this
   integral += (setpoint - input) * 2 * sample_period.seconds();
   EXPECT_OUTPUT(output, integral * Ki);
 
   // check that a new call without change in time has no effect, even if we
   // missed a sample
-  EXPECT_EQ(pid.Compute(now, input, setpoint), output);
+  EXPECT_EQ(pid.compute(now, input, setpoint), output);
 
   // Advance time a small amount to allow PID to catch up to missed sample
   Duration dt = max_task_jitter;
   now += dt;
   integral += (setpoint - input) * dt.seconds();
   // Expect output to have a new update
-  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+  EXPECT_OUTPUT(pid.compute(now, input, setpoint), integral * Ki);
 }
 
-TEST(PidTest, Observe) {
+TEST(PidTest, observe) {
   float Ki = 1;
   float setpoint = 25;
   float input = setpoint - 10;
-  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::OnError, DifferentialTerm::OnMeasurement,
-          MIN_OUTPUT, MAX_OUTPUT);
+  PID pid("", "", /*kp=*/0, Ki, /*kd=*/0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
   int t = 0;
 
   // Run PID a few times
   float output;
   for (int i = 0; i < 10; i++) {
-    output = pid.Compute(ticks(t++), input, setpoint);
+    output = pid.compute(ticks(t++), input, setpoint);
   }
   // Make sure we're not saturated in either direction so the following tests
   // are not vacuous.
@@ -253,46 +262,48 @@ TEST(PidTest, Observe) {
   float last_output;
   for (int i = 0; i < 10; i++) {
     last_output = static_cast<float>(128 + i);
-    pid.Observe(ticks(t++), input, setpoint, /*actual_output=*/last_output);
+    pid.observe(ticks(t++), input, setpoint, /*actual_output=*/last_output);
   }
 
   float integral = (setpoint - input) * sample_period.seconds();
-  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint), 128 + 10 + integral * Ki);
+  EXPECT_OUTPUT(pid.compute(ticks(t++), input, setpoint), 128 + 10 + integral * Ki);
 }
 
-TEST(PidTest, Reset) {
-  PID pid(0, 0, 0, ProportionalTerm::OnError, DifferentialTerm::OnError, MIN_OUTPUT, MAX_OUTPUT);
+TEST(PidTest, reset) {
+  PID pid("", "", 0, 0, 0,
+          /*p_term=*/PID::TermApplication::OnError,
+          /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
 
   // Run one cycle to set last error
   int t = 0;
   float kp = 1;
   float setpoint = 25;
   float error = 10;
-  pid.SetKP(kp);
-  float output = pid.Compute(ticks(t++), setpoint - error, setpoint);
+  pid.kp(kp);
+  float output = pid.compute(ticks(t++), setpoint - error, setpoint);
   EXPECT_EQ(output, kp * error);
 
   // Normally the kd term would act on the change in error.
   // If I reset the PID then the change in error will be zero, so
   // if the reset works the output will be zero
-  pid.SetKP(0);
-  pid.SetKD(1);
+  pid.kp(0);
+  pid.kd(1);
   error = 20;
-  pid.Reset();
-  output = pid.Compute(ticks(t++), setpoint - error, setpoint);
+  pid.reset();
+  output = pid.compute(ticks(t++), setpoint - error, setpoint);
   EXPECT_EQ(output, 0.0f);
 
   // Build up an integral sum
-  pid.SetKD(0);
-  pid.SetKI(1);
-  for (int i = 0; i < 10; i++) output = pid.Compute(ticks(t++), setpoint - error, setpoint);
+  pid.kd(0);
+  pid.ki(1);
+  for (int i = 0; i < 10; i++) output = pid.compute(ticks(t++), setpoint - error, setpoint);
 
   // With all gains set to zero, running again will not change the output
   // it will still be the output_sum_ value
-  pid.SetKI(0);
-  EXPECT_EQ(output, pid.Compute(ticks(t++), setpoint - error, setpoint));
+  pid.ki(0);
+  EXPECT_EQ(output, pid.compute(ticks(t++), setpoint - error, setpoint));
 
-  // Resetting the PID will reset output_sum to zero
-  pid.Reset();
-  EXPECT_EQ(0.0f, pid.Compute(ticks(t++), setpoint - error, setpoint));
+  // resetting the PID will reset output_sum to zero
+  pid.reset();
+  EXPECT_EQ(0.0f, pid.compute(ticks(t++), setpoint - error, setpoint));
 }

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -75,9 +75,9 @@ TEST(PidTest, AccessSetViaDebug) {
           /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);
 
   EXPECT_EQ(registry.count(), 3 + count_offset);
-  auto kp = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(0) + count_offset));
-  auto ki = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(1) + count_offset));
-  auto kd = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(2) + count_offset));
+  auto kp = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(0 + count_offset)));
+  auto ki = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(1 + count_offset)));
+  auto kd = reinterpret_cast<Debug::Variable::Float*>(registry.find(uint16_t(2 + count_offset)));
 
   kp->set(11.f);
   EXPECT_EQ(pid.kp(), 11.f);

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -32,7 +32,7 @@ inline constexpr float OUTPUT_TOLERANCE = 1;
 inline constexpr const float MAX_OUTPUT = 255;
 inline constexpr const float MIN_OUTPUT = 0;
 
-// Maximum task jitter (assume 5 ms for now, will need adjuting)
+// Maximum task jitter (assume 5 ms for now, will need adjusting)
 inline constexpr Duration max_task_jitter = milliseconds(5);
 
 inline constexpr Time base = microsSinceStartup(10'000'000);

--- a/software/controller/test/pid_lib/pid_test.cpp
+++ b/software/controller/test/pid_lib/pid_test.cpp
@@ -69,7 +69,7 @@ TEST(PidTest, Initialization) {
 
 TEST(PidTest, AccessSetViaDebug) {
   auto& registry = Debug::Variable::Registry::singleton();
-  auto count_offset = registry.count();
+  uint16_t count_offset = registry.count();
   PID pid("pid_", " for help", 1.f, 2.f, 3.f,
           /*p_term=*/PID::TermApplication::OnError,
           /*d_term=*/PID::TermApplication::OnMeasurement, MIN_OUTPUT, MAX_OUTPUT);


### PR DESCRIPTION
# Description

* the debug variable registry is now a proper singleton implementation, a single point of access and encapsulation. It ensures unique variable IDs, but unique names is still "someone else's job". For now, the python client detects name clashes.
* debug variable name may be prepended, allowing use in classes that may be multiply-instantiated and yet result in unique names; in the same way, help test may be appended to disambiguate purpose of variable
* debug variables are now part of the `Debug::Variable` namespace. Class names and member function names have been changed and updated throughout the code base.
* PID class now uses debug variables for storing its tuning parameters. Initialization requires strings to help disambiguate the parameters. There is no longer an explicit update step. The assumption is that we do not have race conditions, and in case of user update, new values will be used when the PID again computes actuator value.
* Because of how the PIDs are initialized, using a negative value for KI to enable gain scheduling is not really feasible. It was a hacky implementation anyways. We have removed the gain scheduling implementation form `controller.cpp`. The implementation is anyway going away with the impending "nested flow control" that will also soon be in PRs. @inceptionev has confirmed that it is ok to remove gain scheduling. We can still find the old implementation in our git history if we ever need to look it up.
* Append & prepend functions have some unit testing. Although there is potential for more tests, the interface of either variables or registry has not fundamentally changed, so I think we can keep it as is.
* More of the debug variables could be moved into classes to lessen our "globals" footprint, but this PR is already getting big, so I think we can do the rest as we slowly refactor and improve all the various components.

Fixes #1148

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
