### PR TITLE
Modernized include guards

### DIFF
--- a/software/common/libs/binary_utils/binary_utils.h
+++ b/software/common/libs/binary_utils/binary_utils.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef BINUTILS_H
-#define BINUTILS_H
+#pragma once
 
 #include <stdint.h>
 // Some simple data conversion functions.
@@ -44,5 +43,3 @@ inline void u32_to_u8(uint32_t val, uint8_t *buff) {
   buff[2] = static_cast<uint8_t>(val >> 16);
   buff[3] = static_cast<uint8_t>(val >> 24);
 }
-
-#endif  // BINUTILS_H

--- a/software/common/libs/proto_traits/proto_traits.h
+++ b/software/common/libs/proto_traits/proto_traits.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef PROTO_TRAITS_H
-#define PROTO_TRAITS_H
+#pragma once
 
 #include "network_protocol.pb.h"
 
@@ -57,5 +56,3 @@ MAKE_TRAITS(ControllerStatus);
 MAKE_TRAITS(GuiStatus);
 
 #undef MAKE_TRAITS
-
-#endif  // PROTO_TRAITS_H

--- a/software/common/libs/units/units.h
+++ b/software/common/libs/units/units.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef UNITS_H
-#define UNITS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -441,5 +440,3 @@ constexpr inline Volume operator*(Duration b, VolumetricFlow a) {
 constexpr inline VolumetricFlow operator/(Volume a, Duration b) {
   return ml_per_min(a.ml() / b.minutes());
 }
-
-#endif  // UNITS_H

--- a/software/controller/lib/core/actuators.h
+++ b/software/controller/lib/core/actuators.h
@@ -16,8 +16,7 @@ limitations under the License.
 // This module is responsible for passing the actuator commands to hal to
 // generate the actual electrical signals.
 
-#ifndef ACTUATORS_H
-#define ACTUATORS_H
+#pragma once
 
 #include <optional>
 
@@ -47,5 +46,3 @@ void ActuatorsExecute(const ActuatorsState &desired_state);
 // if they aren't (for example pinch valves are homing).
 // The system should be kept in a safe state until this returns true.
 bool AreActuatorsReady();
-
-#endif  // ACTUATORS_H

--- a/software/controller/lib/core/blower_fsm.h
+++ b/software/controller/lib/core/blower_fsm.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef BLOWER_FSM_H
-#define BLOWER_FSM_H
+#pragma once
 
 #include <optional>
 #include <variant>
@@ -187,5 +186,3 @@ class BlowerFsm {
  private:
   std::variant<OffFsm, PressureControlFsm, PressureAssistFsm> fsm_;
 };
-
-#endif  // BLOWER_FSM_H

--- a/software/controller/lib/core/comms.h
+++ b/software/controller/lib/core/comms.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef COMMS_H
-#define COMMS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -30,5 +29,3 @@ void CommsInit();
 // periodically to the GUI.  When we receive a message from the GUI, we update
 // gui_status accordingly.
 void CommsHandler(const ControllerStatus &controller_status, GuiStatus *gui_status);
-
-#endif  // COMMS_H

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#ifndef CONTROLLER_H
-#define CONTROLLER_H
+
+#pragma once
 
 #include <optional>
 #include <utility>
@@ -83,5 +83,3 @@ class Controller {
   // Off state to On state.
   bool ventilator_was_on_{false};
 };
-
-#endif  // CONTROLLER_H

--- a/software/controller/lib/core/errors.h
+++ b/software/controller/lib/core/errors.h
@@ -13,10 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef ERRORS_H
-#define ERRORS_H
+#pragma once
 
 #define VC_STATUS_SUCCESS (0)
 #define VC_STATUS_FAILURE (-1)
-
-#endif  // ERRORS_H

--- a/software/controller/lib/core/flow_integrator.h
+++ b/software/controller/lib/core/flow_integrator.h
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#pragma once
+
 #include <optional>
 
 #include "hal.h"

--- a/software/controller/lib/core/pinch_valve.h
+++ b/software/controller/lib/core/pinch_valve.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef PINCH_VALVE_H
-#define PINCH_VALVE_H
+#pragma once
 
 #include "stepper.h"
 #include "units.h"
@@ -83,5 +82,3 @@ class PinchValve {
 
   PinchValveHomeState home_state_{PinchValveHomeState::Disabled};
 };
-
-#endif

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -19,8 +19,7 @@ pressure sensors in the ventilator design. It is designed to be used with the
 Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 */
 
-#ifndef SENSORS_H
-#define SENSORS_H
+#pragma once
 
 #include "hal.h"
 #include "units.h"
@@ -94,5 +93,3 @@ class Sensors {
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[NumSensors];
 };
-
-#endif  // SENSORS_H

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef COMMAND_H
-#define COMMAND_H
+#pragma once
 
 #include "binary_utils.h"
 #include "eeprom.h"
@@ -196,5 +195,3 @@ class EepromHandler : public Handler {
 };
 
 }  // namespace Debug::Command
-
-#endif  // COMMAND_H

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef DEBUG_TYPES_H
-#define DEBUG_TYPES_H
+#pragma once
 
 #include <stdint.h>
 
@@ -80,5 +79,3 @@ class Handler {
 }  // namespace Command
 
 }  // namespace Debug
-
-#endif  // DEBUG_TYPES_H

--- a/software/controller/lib/debug/interface.h
+++ b/software/controller/lib/debug/interface.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef INTERFACE_H
-#define INTERFACE_H
+#pragma once
 
 #include <cstdarg>
 #include <optional>
@@ -105,5 +104,3 @@ class Interface {
 };
 
 }  // namespace Debug
-
-#endif  // INTERFACE_H

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef TRACE_H
-#define TRACE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -114,5 +113,3 @@ class Trace {
 };
 
 }  // namespace Debug
-
-#endif  // TRACE_H

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef VARS_H
-#define VARS_H
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -184,5 +183,3 @@ class DebugFloat : public DebugVar {
  private:
   float value_;
 };
-
-#endif

--- a/software/controller/lib/hal/circular_buffer.h
+++ b/software/controller/lib/hal/circular_buffer.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef CIRCULAR_BUFFER_H
-#define CIRCULAR_BUFFER_H
+#pragma once
 
 #include <stdint.h>
 
@@ -92,5 +91,3 @@ class CircularBuffer {
     head_ = tail_ = 0;
   }
 };
-
-#endif

--- a/software/controller/lib/hal/eeprom.h
+++ b/software/controller/lib/hal/eeprom.h
@@ -17,8 +17,7 @@ limitations under the License.
 // https://ww1.microchip.com/downloads/en/DeviceDoc/24AA256-24LC256-24FC256-Data-Sheet-20001203W.pdf
 // The EEPROM we have on the board is at address 0x50 (see [PCBsp])
 
-#ifndef EEPROM_H
-#define EEPROM_H
+#pragma once
 
 #include <stdint.h>
 
@@ -65,5 +64,3 @@ class TestEeprom : public I2Ceeprom {
   bool SendBytes(const I2C::Request &request) override;
   bool ReceiveBytes(const I2C::Request &request) override;
 };
-
-#endif  // EEPROM_H

--- a/software/controller/lib/hal/flash.h
+++ b/software/controller/lib/hal/flash.h
@@ -14,8 +14,7 @@ limitations under the License.
 
 */
 
-#ifndef FLASH_H
-#define FLASH_H
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -24,5 +23,3 @@ limitations under the License.
 inline constexpr uint32_t FlashStartAddr{0x08000000};
 inline constexpr size_t FlashSize{32 * 1024};
 inline constexpr size_t FlashPageSize{2 * 1024};
-
-#endif

--- a/software/controller/lib/hal/hal_stm32.h
+++ b/software/controller/lib/hal/hal_stm32.h
@@ -20,8 +20,7 @@ STM32L452 processor used on the controller.
 Reference abbreviations [RM], [DS], etc are defined in hal/README.md.
 */
 
-#ifndef HAL_STM32_H
-#define HAL_STM32_H
+#pragma once
 
 #if !defined(BARE_STM32)
 #error \
@@ -119,5 +118,3 @@ inline void GpioPullDn(GpioReg *gpio, int pin) {
   x |= 2 << (2 * pin);
   gpio->pullup_pulldown = x;
 }
-
-#endif

--- a/software/controller/lib/hal/hal_stm32_regs.h
+++ b/software/controller/lib/hal/hal_stm32_regs.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef HAL_STM32_REGS_H
-#define HAL_STM32_REGS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -855,5 +854,3 @@ inline GpioReg *const GpioCBase = reinterpret_cast<GpioReg *>(0x48000800);
 inline GpioReg *const GpioDBase = reinterpret_cast<GpioReg *>(0x48000C00);
 inline GpioReg *const GpioEBase = reinterpret_cast<GpioReg *>(0x48001000);
 inline GpioReg *const GpioHBase = reinterpret_cast<GpioReg *>(0x48001C00);
-
-#endif

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -17,8 +17,7 @@ limitations under the License.
 // See [RM] chapter 37 for details on their inner workings.
 // Our design uses the STM32 as an I²C master
 
-#ifndef I2C_H
-#define I2C_H
+#pragma once
 
 #include "circular_buffer.h"
 #if defined(BARE_STM32)
@@ -268,5 +267,3 @@ extern I2C::STM32Channel i2c1;
 #else
 extern I2C::Channel i2c1;
 #endif
-
-#endif  // I2C_H

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -44,8 +44,7 @@ limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef STEPPER_H
-#define STEPPER_H
+#pragma once
 
 #include <stdint.h>
 
@@ -344,5 +343,3 @@ class StepMotor {
   // at the end of the high priority loop timer ISR
   static void StartQueuedCommands();
 };
-
-#endif

--- a/software/controller/lib/hal/uart_dma.h
+++ b/software/controller/lib/hal/uart_dma.h
@@ -14,8 +14,7 @@ limitations under the License.
 
 */
 
-#ifndef UART_DMA_H
-#define UART_DMA_H
+#pragma once
 #include "hal_stm32_regs.h"
 
 enum class RxError { RxUnknownError, RxOverflow, RxFramingError, RxTimeout, RxDmaError };
@@ -109,4 +108,3 @@ class UartDma {
   bool tx_in_progress_{false};
   bool rx_in_progress_{false};
 };
-#endif

--- a/software/controller/lib/pid/pid.h
+++ b/software/controller/lib/pid/pid.h
@@ -16,8 +16,7 @@ limitations under the License.
  * Original project hash: 9b4ca0e5b6d7bab9c6ac023e249d6af2446d99bb
  **********************************************************************************************/
 
-#ifndef PID_H
-#define PID_H
+#pragma once
 
 #include "units.h"
 
@@ -79,4 +78,3 @@ class PID {
   float last_input_ = 0;
   float last_error_ = 0;
 };
-#endif  // PID_H

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -60,7 +60,7 @@ check_flags =
   ; This helps with output readability.
   cppcheck: --enable=all --std=c++17 --suppress=missingIncludeSystem --suppress=unmatchedSuppression --suppress=unusedFunction
   ; The actual checks are defined in .clang-tidy.
-  clangtidy: --checks='-*' --extra-arg-before=-xc++ --extra-arg-before=-std=c++17
+  clangtidy: --checks='-*' --extra-arg-before=-xc++ --extra-arg-before=-std=c++17 --extra-arg-before=-Wno-pragma-once-outside-header
 check_patterns =
   ../controller/lib
   ../controller/src

--- a/software/controller/test/blower_fsm/blower_fsm_test_data.h
+++ b/software/controller/test/blower_fsm/blower_fsm_test_data.h
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef BLOWER_FSM_PRESSURE_ASSIST_TEST_DATA_H
-#define BLOWER_FSM_PRESSURE_ASSIST_TEST_DATA_H
+#pragma once
 
 #include "units.h"
 
@@ -1057,5 +1056,3 @@ inline const VolumetricFlow FLOW_TRACE_NO_INSPIRATORY_EFFORT[] = {
     ml_per_sec(20.192f),
     ml_per_sec(-17.382f),
 };
-
-#endif  // BLOWER_FSM_PRESSURE_ASSIST_TEST_DATA_H


### PR DESCRIPTION
# Description

This PR replaces most of the `#ifdef` type include guards with `#pragma once` for all of the headers under `controller` and `common`, with the exception of third party or generated code.

Most compilers (and in particular the ones we use - definitely) support `#pragma once`. It is easier to maintain, less prone to name clashes and other unintended effects of bad ifdeffery. There are very few drawbacks to using it and only in under rather exotic circumstaces, such as having multiple files with identical names, which we should be be avoiding anyways.

However, `clang-tidy` misunderstands its use and, probably due to how `platformio` does things, throws up warnings indicating its use in source (cpp) files. This PR also includes a change to `platformio.ini` that suppresses this warning.

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
