### PR TITLE
Sensor code refactoring

### DIFF
--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -52,7 +52,7 @@ The following options are provided:
   --test        Builds and runs all tests locally
     [--no-checks]     - do not run static checks (yes, it's to annoy you!)
   --run         Builds and deploys firmware to controller
-                There can be only one connected. Otherwise, use the platformi/deploy.sh script manually.
+                There can be only one connected. Otherwise, use the platformio/deploy.sh script manually.
 EOF
 }
 

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -27,11 +27,14 @@ set -o xtrace
 # This script should work no matter where you call it from.
 cd "$(dirname "$0")"
 
+EXIT_FAILURE=1
+EXIT_SUCCESS=0
+
 # Check if Linux
 PLATFORM="$(uname -s)"
 if [ $PLATFORM != "Linux" ]; then
   echo "Error: This script only supports 'Linux'. You have $PLATFORM."
-  exit 1
+  exit $EXIT_FAILURE
 fi
 
 #########
@@ -45,9 +48,11 @@ The following options are provided:
   --help        Display this dialog
   --install     Install platformio and configure udev rules for deployment
   --clean       Clean build directories
+  --check       Runs static checks only
   --test        Builds and runs all tests locally
     [--no-checks]     - do not run static checks (yes, it's to annoy you!)
-  --run         Builds and deploys firmware to controller (there can be only one, use deploy script manually for others)
+  --run         Builds and deploys firmware to controller
+                There can be only one connected. Otherwise, use the platformi/deploy.sh script manually.
 EOF
 }
 
@@ -63,71 +68,7 @@ clean_dir() {
   fi
 }
 
-########
-# HELP #
-########
-
-if [ "$1" == "--help" ]; then
-  print_help
-  exit 0
-fi
-
-###########
-# INSTALL #
-###########
-
-if [ "$1" == "--install" ]; then
-  if [ "$EUID" -eq 0 ] && [ "$2" != "-f" ]; then
-    echo "Please do not run install with root privileges!"
-    exit 1
-  fi
-
-  pushd "$HOME"
-  python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
-  echo 'export PATH=$PATH:~/.platformio/penv/bin' >> ~/.profile
-  popd
-
-  curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
-  sudo service udev restart
-  sudo usermod -a -G dialout "$USER"
-  sudo usermod -a -G plugdev "$USER"
-
-  echo "Updated udev rules. You might have to restart your machine for changes to become effective."
-
-  exit 0
-fi
-
-#########
-# CLEAN #
-#########
-
-if [ "$1" == "--clean" ]; then
-  clean_dir .pio
-  exit 0
-fi
-
-########
-# TEST #
-########
-
-if [ "$1" == "--test" ]; then
-  # Controller unit tests on native.
-  pio test -e native
-
-  # Make sure controller integration tests build for target platform.
-  # TODO(martukas) This will actually have to be build and tested on Jenkins and not here
-  INTEGRATION_TEST_H=idle_test.h pio run -e integration-test
-  INTEGRATION_TEST_H=buzzer_test.h TEST_PARAM_1=0.0f TEST_PARAM_2=1.0f pio run -e integration-test
-  INTEGRATION_TEST_H=blower_test.h TEST_PARAM_1=0.0f TEST_PARAM_2=1.0f pio run -e integration-test
-  INTEGRATION_TEST_H=stepper_test.h TEST_PARAM_1=0 TEST_PARAM_2=90.0f pio run -e integration-test
-  INTEGRATION_TEST_H=pinch_valve_test.h TEST_PARAM_1=0 pio run -e integration-test
-  INTEGRATION_TEST_H=psol_test.h pio run -e integration-test
-  INTEGRATION_TEST_H=eeprom_test.h pio run -e integration-test
-
-  # Make sure controller builds for target platform.
-  pio run
-
-  if [ "$2" != "--no-checks" ]; then
+run_checks() {
     # Code style / bug-prone pattern checks (eg. clang-tidy)
     # WARNING: This might sometimes give different results for different people,
     # and different results on CI:
@@ -145,11 +86,92 @@ if [ "$1" == "--test" ]; then
 
     pio check -e stm32 --fail-on-defect=high --skip-packages
     pio check -e native --fail-on-defect=high
+}
+
+run_integration_tests() {
+  # Make sure controller integration tests build for target platform.
+  # TODO(martukas) This will actually have to build an deploy on Jenkins and not here
+  INTEGRATION_TEST_H=idle_test.h pio run -e integration-test
+  INTEGRATION_TEST_H=buzzer_test.h TEST_PARAM_1=0.0f TEST_PARAM_2=1.0f pio run -e integration-test
+  INTEGRATION_TEST_H=blower_test.h TEST_PARAM_1=0.0f TEST_PARAM_2=1.0f pio run -e integration-test
+  INTEGRATION_TEST_H=stepper_test.h TEST_PARAM_1=0 TEST_PARAM_2=90.0f pio run -e integration-test
+  INTEGRATION_TEST_H=pinch_valve_test.h TEST_PARAM_1=0 pio run -e integration-test
+  INTEGRATION_TEST_H=psol_test.h pio run -e integration-test
+  INTEGRATION_TEST_H=eeprom_test.h pio run -e integration-test
+}
+
+########
+# HELP #
+########
+
+if [ "$1" == "--help" ]; then
+  print_help
+  exit $EXIT_SUCCESS
+fi
+
+###########
+# INSTALL #
+###########
+
+if [ "$1" == "--install" ]; then
+  if [ "$EUID" -eq 0 ] && [ "$2" != "-f" ]; then
+    echo "Please do not run install with root privileges!"
+    exit $EXIT_SUCCESS
+  fi
+
+  pushd "$HOME"
+  python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+  echo 'export PATH=$PATH:~/.platformio/penv/bin' >> ~/.profile
+  popd
+
+  curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
+  sudo service udev restart
+  sudo usermod -a -G dialout "$USER"
+  sudo usermod -a -G plugdev "$USER"
+
+  echo "Updated udev rules. You might have to restart your machine for changes to become effective."
+
+  exit $EXIT_SUCCESS
+fi
+
+#########
+# CLEAN #
+#########
+
+if [ "$1" == "--clean" ]; then
+  clean_dir .pio
+  exit $EXIT_SUCCESS
+fi
+
+#########
+# CHECK #
+#########
+
+if [ "$1" == "--check" ]; then
+  run_checks
+  exit $EXIT_SUCCESS
+fi
+
+########
+# TEST #
+########
+
+if [ "$1" == "--test" ]; then
+  # Controller unit tests on native.
+  pio test -e native
+
+  run_integration_tests
+
+  # Make sure controller builds for target platform.
+  pio run -e stm32
+
+  if [ "$2" != "--no-checks" ]; then
+    run_checks
   else
     echo "Skipping static checks."
   fi
 
-  exit 0
+  exit $EXIT_SUCCESS
 fi
 
 #######
@@ -160,10 +182,12 @@ if [ "$1" == "--run" ]; then
 
   if [ "$EUID" -eq 0 ] && [ "$2" != "-f" ]; then
     echo "Please do not run the app with root privileges!"
-    exit 1
+    exit $EXIT_FAILURE
   fi
 
   platformio/deploy.sh stm32
 
-  exit 0
+  exit $EXIT_SUCCESS
 fi
+
+}

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -66,7 +66,7 @@ static Debug::Variable::UInt32 dbg_breath_id("breath_id", Debug::Variable::Acces
 
 std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentParams &params,
                                                            const SensorReadings &sensor_readings) {
-  VolumetricFlow uncorrected_net_flow = sensor_readings.inflow - sensor_readings.outflow;
+  VolumetricFlow uncorrected_net_flow = sensor_readings.air_inflow - sensor_readings.outflow;
   flow_integrator_->AddFlow(now, uncorrected_net_flow);
   uncorrected_flow_integrator_->AddFlow(now, uncorrected_net_flow);
 
@@ -164,7 +164,7 @@ std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentP
 
   dbg_pc_setpoint.set(desired_state.pressure_setpoint.value_or(kPa(0)).cmH2O());
   dbg_net_flow.set(controller_state.net_flow.ml_per_sec());
-  dbg_net_flow_uncorrected.set((sensor_readings.inflow - sensor_readings.outflow).ml_per_sec());
+  dbg_net_flow_uncorrected.set((sensor_readings.air_inflow - sensor_readings.outflow).ml_per_sec());
   dbg_volume.set(controller_state.patient_volume.ml());
   dbg_volume_uncorrected.set(uncorrected_flow_integrator_->GetVolume().ml());
   dbg_flow_correction.set(flow_integrator_->FlowCorrection().ml_per_sec());

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -66,7 +66,8 @@ static Debug::Variable::UInt32 dbg_breath_id("breath_id", Debug::Variable::Acces
 
 std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentParams &params,
                                                            const SensorReadings &sensor_readings) {
-  VolumetricFlow uncorrected_net_flow = sensor_readings.air_inflow - sensor_readings.outflow;
+  VolumetricFlow uncorrected_net_flow =
+      sensor_readings.air_inflow + sensor_readings.oxygen_inflow - sensor_readings.outflow;
   flow_integrator_->AddFlow(now, uncorrected_net_flow);
   uncorrected_flow_integrator_->AddFlow(now, uncorrected_net_flow);
 
@@ -164,7 +165,7 @@ std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentP
 
   dbg_pc_setpoint.set(desired_state.pressure_setpoint.value_or(kPa(0)).cmH2O());
   dbg_net_flow.set(controller_state.net_flow.ml_per_sec());
-  dbg_net_flow_uncorrected.set((sensor_readings.air_inflow - sensor_readings.outflow).ml_per_sec());
+  dbg_net_flow_uncorrected.set(uncorrected_net_flow.ml_per_sec());
   dbg_volume.set(controller_state.patient_volume.ml());
   dbg_volume_uncorrected.set(uncorrected_flow_integrator_->GetVolume().ml());
   dbg_flow_correction.set(flow_integrator_->FlowCorrection().ml_per_sec());

--- a/software/controller/lib/core/controller.h
+++ b/software/controller/lib/core/controller.h
@@ -130,7 +130,7 @@ class Controller {
                              static_cast<uint32_t>(GetLoopPeriod().microseconds()), "\xB5s",
                              "Loop period"};
 
-  // Outputs - read from external debug program, modified here.
+  // Outputs - read from external debug program, modified by the controller.
   DbgFloat dbg_pc_setpoint_{"pc_setpoint", DbgAccess::ReadOnly, 0.0f, "cmH2O",
                             "Pressure control set-point"};
   DbgFloat dbg_net_flow_{"net_flow", DbgAccess::ReadOnly, 0.0f, "mL/s", "Net flow rate"};

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -11,35 +11,11 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
- module contributors: verityRF, jlebar, lee-matthews, Edwin Chiu
- The purpose of this module is to allow calibrated readings from the different
-pressure sensors in the ventilator design. It is designed to be used with the
-Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 */
 
 #include "sensors.h"
 
 #include <cmath>
-
-#include "vars.h"
-
-static Debug::Variable::Float dbg_dp_inhale("dp_inhale", Debug::Variable::Access::ReadOnly, 0.0f,
-                                            "cmH2O", "Inhale diff pressure");
-static Debug::Variable::Float dbg_dp_exhale("dp_exhale", Debug::Variable::Access::ReadOnly, 0.0f,
-                                            "cmH2O", "Exhale diff pressure");
-static Debug::Variable::Float dbg_pressure("pressure", Debug::Variable::Access::ReadOnly, 0.0f,
-                                           "cmH2O", "Patient pressure");
-static Debug::Variable::Float dbg_flow_inhale("flow_inhale", Debug::Variable::Access::ReadOnly,
-                                              0.0f, "mL/s", "Inhale flow rate");
-static Debug::Variable::Float dbg_flow_exhale("flow_exhale", Debug::Variable::Access::ReadOnly,
-                                              0.0f, "mL/s", "Exhale flow rate");
-static Debug::Variable::Float dbg_fio2("fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
-                                       "Fraction of inspired oxygen");
-// Flow correction happens as part of volume computation, in the Controller.
-static Debug::Variable::Float dbg_flow_uncorrected("flow_uncorrected",
-                                                   Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
-                                                   "Uncorrected net flow rate");
 
 //@TODO: Potential Caution: Density of air slightly varies over temperature and
 // altitude - need mechanism to adjust based on delivery? Constant involving
@@ -180,13 +156,13 @@ SensorReadings Sensors::GetReadings() const {
   VolumetricFlow uncorrected_flow = air_inflow - outflow;
 
   // Set debug variables.
-  dbg_dp_inhale.set(air_inflow_delta.cmH2O());
-  dbg_dp_exhale.set(outflow_delta.cmH2O());
-  dbg_pressure.set(patient_pressure.cmH2O());
-  dbg_fio2.set(fio2);
-  dbg_flow_inhale.set(air_inflow.ml_per_sec());
-  dbg_flow_exhale.set(outflow.ml_per_sec());
-  dbg_flow_uncorrected.set(uncorrected_flow.ml_per_sec());
+  inflow_air_dp_.set(air_inflow_delta.cmH2O());
+  outflow_dp_.set(outflow_delta.cmH2O());
+  patient_pressure_.set(patient_pressure.cmH2O());
+  fio2_.set(fio2);
+  inflow_air_.set(air_inflow.ml_per_sec());
+  outflow_.set(outflow.ml_per_sec());
+  net_flow_uncorrected_.set(uncorrected_flow.ml_per_sec());
 
   return {
       .patient_pressure = patient_pressure,

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -81,9 +81,9 @@ void Sensors::Calibrate() {
   // open any necessary valves, and recalibrate.
   hal.Delay(milliseconds(20));
 
-  for (Sensor s : {Sensor::OxygenInflowPressureDiff, Sensor::PatientPressure,
-                   Sensor::AirInflowPressureDiff, Sensor::OutflowPressureDiff, Sensor::FIO2}) {
-    sensors_zero_vals_[static_cast<int>(s)] = hal.AnalogRead(PinFor(s));
+  for (Sensor s : {Sensor::PatientPressure, Sensor::AirInflowPressureDiff,
+                   Sensor::OxygenInflowPressureDiff, Sensor::OutflowPressureDiff, Sensor::FIO2}) {
+    sensors_zero_vals_[static_cast<uint16_t>(s)] = hal.AnalogRead(PinFor(s));
   }
 }
 
@@ -100,7 +100,7 @@ Pressure Sensors::ReadPressureSensor(Sensor s) const {
   // a pressure in kPa.
   static const float PressureSensorGain{5.f / 3.3f};
   return kPa(PressureSensorGain *
-             (hal.AnalogRead(PinFor(s)) - sensors_zero_vals_[static_cast<int>(s)]).volts());
+             (hal.AnalogRead(PinFor(s)) - sensors_zero_vals_[static_cast<uint16_t>(s)]).volts());
 }
 
 // Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
@@ -174,9 +174,6 @@ SensorReadings Sensors::GetReadings() const {
 
   return {
       .patient_pressure = patient_pressure,
-      .air_inflow_pressure_diff = air_inflow_delta,
-      .oxygen_inflow_pressure_diff = oxygen_inflow_delta,
-      .outflow_pressure_diff = outflow_delta,
       .fio2 = fio2,
       .air_inflow = air_inflow,
       .oxygen_inflow = oxygen_inflow,

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -22,9 +22,9 @@ limitations under the License.
 AnalogPin PinFor(Sensor s) {
   switch (s) {
     case Sensor::OxygenInflowPressureDiff:
-      return AnalogPin::U3PatientPressure;
-    case Sensor::PatientPressure:
       return AnalogPin::InterimBoardAnalogPressure;
+    case Sensor::PatientPressure:
+      return AnalogPin::U3PatientPressure;
     case Sensor::AirInflowPressureDiff:
       return AnalogPin::U4InhaleFlow;
     case Sensor::OutflowPressureDiff:

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 //                   SENSOR LOGICAL MAPPINGS                    //
 //   Change these if you route your sensor tubing differently   //
 //////////////////////////////////////////////////////////////////
-AnalogPin PinFor(Sensor s) {
+AnalogPin sensor_pin(Sensor s) {
   switch (s) {
     case Sensor::OxygenInflowPressureDiff:
       return AnalogPin::InterimBoardAnalogPressure;
@@ -40,7 +40,7 @@ Sensors::Sensors() = default;
 
 // NOTE - I can't do this in the constructor now because it gets called before
 // the HAL is set up, so the busy wait never finishes.
-void Sensors::Calibrate() {
+void Sensors::calibrate() {
   // We wait 20ms from power-on-reset for pressure sensors to warm up.
   //
   // TODO: Is 20ms the right amount of time?  We're basing it on the data sheet
@@ -68,23 +68,23 @@ void Sensors::Calibrate() {
 
 /// \TODO: Add alarms if sensor value is out of expected range?
 
-SensorReadings Sensors::GetReadings() const {
+SensorReadings Sensors::get_readings() const {
   //@TODO: Potential Caution: Density of air slightly varies over temperature and
   // altitude - need mechanism to adjust based on delivery? Constant involving
   // density of air. Density assumed at 15 deg. Celsius and 1 atm of pressure.
   // Sourced from https://en.wikipedia.org/wiki/Density_of_air
-  static constexpr float air_density{1.225f};  // kg/m^3
+  static constexpr float AirDensity{1.225f};  // kg/m^3
 
   // Assuming ambient pressure of 101.3 kPa
   // TODO: measure ambient pressure from an additional sensor
   //  and/or estimate from user input (from altitude?)
-  static constexpr Pressure ambient_pressure = kPa(101.3f);
+  static constexpr Pressure AmbientPressure = kPa(101.3f);
 
   return {
       .patient_pressure = patient_pressure_sensor_.read(hal),
-      .fio2 = fio2_sensor_.read(hal, ambient_pressure),
-      .air_inflow = air_influx_sensor_.read(hal, air_density),
-      .oxygen_inflow = oxygen_influx_sensor_.read(hal, air_density),
-      .outflow = outflow_sensor_.read(hal, air_density),
+      .fio2 = fio2_sensor_.read(hal, AmbientPressure),
+      .air_inflow = air_influx_sensor_.read(hal, AirDensity),
+      .oxygen_inflow = oxygen_influx_sensor_.read(hal, AirDensity),
+      .outflow = outflow_sensor_.read(hal, AirDensity),
   };
 }

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -37,18 +37,22 @@ constexpr static float VenturiCorrection{0.97f};
 static_assert(VenturiPortDiameter > VenturiChokeDiameter);
 static_assert(VenturiChokeDiameter > meters(0));
 
-AnalogPin Sensors::PinFor(Sensor s) {
+//////////////////////////////////////////////////////////////////
+//                   SENSOR LOGICAL MAPPINGS                    //
+//   Change these if you route your sensor tubing differently   //
+//////////////////////////////////////////////////////////////////
+AnalogPin PinFor(Sensor s) {
   switch (s) {
     case Sensor::OxygenInflowPressureDiff:
-      return AnalogPin::OxygenInflowPressureDiff;
+      return AnalogPin::U3PatientPressure;
     case Sensor::PatientPressure:
-      return AnalogPin::PatientPressure;
+      return AnalogPin::InterimBoardAnalogPressure;
     case Sensor::AirInflowPressureDiff:
-      return AnalogPin::AirInflowPressureDiff;
+      return AnalogPin::U4InhaleFlow;
     case Sensor::OutflowPressureDiff:
-      return AnalogPin::OutflowPressureDiff;
+      return AnalogPin::U5ExhaleFlow;
     case Sensor::FIO2:
-      return AnalogPin::FIO2;
+      return AnalogPin::InterimBoardOxygenSensor;
   }
   // Switch above covers all cases.
   __builtin_unreachable();

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "hal.h"
 #include "units.h"
+#include "vars.h"
 
 struct SensorReadings {
   Pressure patient_pressure;
@@ -86,4 +87,21 @@ class Sensors {
 
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[NumSensors];
+
+  mutable Debug::Variable::Float inflow_air_dp_{"inflow_air_dp", Debug::Variable::Access::ReadOnly,
+                                                0.0f, "cmH2O", "Inhale diff pressure"};
+  mutable Debug::Variable::Float outflow_dp_{"outflow_dp", Debug::Variable::Access::ReadOnly, 0.0f,
+                                             "cmH2O", "Exhale diff pressure"};
+  mutable Debug::Variable::Float patient_pressure_{"pressure", Debug::Variable::Access::ReadOnly,
+                                                   0.0f, "cmH2O", "Patient pressure"};
+  mutable Debug::Variable::Float inflow_air_{"inflow_air", Debug::Variable::Access::ReadOnly, 0.0f,
+                                             "mL/s", "Inhale flow rate"};
+  mutable Debug::Variable::Float outflow_{"outflow", Debug::Variable::Access::ReadOnly, 0.0f,
+                                          "mL/s", "Exhale flow rate"};
+  mutable Debug::Variable::Float fio2_{"fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
+                                       "Fraction of inspired oxygen"};
+  // Flow correction happens as part of volume computation, in the Controller.
+  mutable Debug::Variable::Float net_flow_uncorrected_{"net_flow_uncorrected",
+                                                       Debug::Variable::Access::ReadOnly, 0.0f,
+                                                       "mL/s", "Uncorrected net flow rate"};
 };

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include "vars.h"
 
 // Keep this in sync with the Sensor enum below
-constexpr static int16_t NumSensors{5};
+constexpr static uint16_t NumSensors{5};
 
 enum class Sensor {
   PatientPressure,
@@ -35,10 +35,6 @@ AnalogPin PinFor(Sensor s);
 
 struct SensorReadings {
   Pressure patient_pressure;
-  // Pressure differences read at the inflow/outflow venturis.
-  Pressure air_inflow_pressure_diff;
-  Pressure oxygen_inflow_pressure_diff;
-  Pressure outflow_pressure_diff;
 
   // fraction of inspired oxygen (fiO2)
   float fio2;
@@ -94,22 +90,22 @@ class Sensors {
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[NumSensors];
 
-  using dvFloat = Debug::Variable::Float;
+  using DbgFloat = Debug::Variable::Float;
 
-  mutable dvFloat inflow_air_dp_{"inflow_air_dp", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
-                                 "Air influx differential pressure"};
-  mutable dvFloat inflow_oxy_dp_{"inflow_oxygen_dp", Debug::Variable::Access::ReadOnly, 0.0f,
-                                 "cmH2O", "Concentrated oxygen influx differential pressure"};
-  mutable dvFloat outflow_dp_{"outflow_dp", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
-                              "Exhale differential pressure"};
-  mutable dvFloat patient_pressure_{"pressure", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
-                                    "Patient pressure"};
-  mutable dvFloat inflow_air_{"inflow_air", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
-                              "Air influx flow rate"};
-  mutable dvFloat inflow_oxy_{"inflow_oxygen", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
-                              "Concentrated oxygen influx flow rate"};
-  mutable dvFloat outflow_{"outflow", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
-                           "Outflow rate"};
-  mutable dvFloat fio2_{"fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
-                        "Fraction of inspired oxygen"};
+  mutable DbgFloat inflow_air_dp_{"inflow_air_dp", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                                  "Air influx differential pressure"};
+  mutable DbgFloat inflow_oxy_dp_{"inflow_oxygen_dp", Debug::Variable::Access::ReadOnly, 0.0f,
+                                  "cmH2O", "Concentrated oxygen influx differential pressure"};
+  mutable DbgFloat outflow_dp_{"outflow_dp", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                               "Exhale differential pressure"};
+  mutable DbgFloat patient_pressure_{"pressure", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                                     "Patient pressure"};
+  mutable DbgFloat inflow_air_{"inflow_air", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                               "Air influx flow rate"};
+  mutable DbgFloat inflow_oxy_{"inflow_oxygen", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                               "Concentrated oxygen influx flow rate"};
+  mutable DbgFloat outflow_{"outflow", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                            "Outflow rate"};
+  mutable DbgFloat fio2_{"fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
+                         "Fraction of inspired oxygen"};
 };

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -19,6 +19,20 @@ limitations under the License.
 #include "units.h"
 #include "vars.h"
 
+// Keep this in sync with the Sensor enum below
+constexpr static int16_t NumSensors{5};
+
+enum class Sensor {
+  PatientPressure,
+  AirInflowPressureDiff,
+  OxygenInflowPressureDiff,
+  OutflowPressureDiff,
+  FIO2,
+};
+
+// Logical mappings: conceptual sensor -> ADC channel
+AnalogPin PinFor(Sensor s);
+
 struct SensorReadings {
   Pressure patient_pressure;
   // Pressure differences read at the inflow/outflow venturis.
@@ -74,38 +88,28 @@ class Sensors {
   static VolumetricFlow PressureDeltaToFlow(Pressure delta);
 
  private:
-  enum class Sensor {
-    OxygenInflowPressureDiff,
-    PatientPressure,
-    AirInflowPressureDiff,
-    OutflowPressureDiff,
-    FIO2,
-  };
-  // Keep this in sync with the Sensor enum!
-  constexpr static int NumSensors{5};
-
-  static AnalogPin PinFor(Sensor s);
   Pressure ReadPressureSensor(Sensor s) const;
   float ReadOxygenSensor(Pressure p_ambient) const;
 
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[NumSensors];
 
-  mutable Debug::Variable::Float inflow_air_dp_{"inflow_air_dp", Debug::Variable::Access::ReadOnly,
-                                                0.0f, "cmH2O", "Air influx differential pressure"};
-  mutable Debug::Variable::Float inflow_oxy_dp_{"inflow_oxygen_dp",
-                                                Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
-                                                "Concentrated oxygen influx differential pressure"};
-  mutable Debug::Variable::Float outflow_dp_{"outflow_dp", Debug::Variable::Access::ReadOnly, 0.0f,
-                                             "cmH2O", "Exhale differential pressure"};
-  mutable Debug::Variable::Float patient_pressure_{"pressure", Debug::Variable::Access::ReadOnly,
-                                                   0.0f, "cmH2O", "Patient pressure"};
-  mutable Debug::Variable::Float inflow_air_{"inflow_air", Debug::Variable::Access::ReadOnly, 0.0f,
-                                             "mL/s", "Air influx flow rate"};
-  mutable Debug::Variable::Float inflow_oxy_{"inflow_oxygen", Debug::Variable::Access::ReadOnly,
-                                             0.0f, "mL/s", "Concentrated oxygen influx flow rate"};
-  mutable Debug::Variable::Float outflow_{"outflow", Debug::Variable::Access::ReadOnly, 0.0f,
-                                          "mL/s", "Outflow rate"};
-  mutable Debug::Variable::Float fio2_{"fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
-                                       "Fraction of inspired oxygen"};
+  using dvFloat = Debug::Variable::Float;
+
+  mutable dvFloat inflow_air_dp_{"inflow_air_dp", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                                 "Air influx differential pressure"};
+  mutable dvFloat inflow_oxy_dp_{"inflow_oxygen_dp", Debug::Variable::Access::ReadOnly, 0.0f,
+                                 "cmH2O", "Concentrated oxygen influx differential pressure"};
+  mutable dvFloat outflow_dp_{"outflow_dp", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                              "Exhale differential pressure"};
+  mutable dvFloat patient_pressure_{"pressure", Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                                    "Patient pressure"};
+  mutable dvFloat inflow_air_{"inflow_air", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                              "Air influx flow rate"};
+  mutable dvFloat inflow_oxy_{"inflow_oxygen", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                              "Concentrated oxygen influx flow rate"};
+  mutable dvFloat outflow_{"outflow", Debug::Variable::Access::ReadOnly, 0.0f, "mL/s",
+                           "Outflow rate"};
+  mutable dvFloat fio2_{"fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
+                        "Fraction of inspired oxygen"};
 };

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -81,25 +81,25 @@ class Sensors {
   static_assert(venturi_choke_diameter_ > meters(0));
 
   // Fundamental sensors
-  MPXV5004DP patient_pressure_sensor_{"patient_pressure_", " in patient airway",
+  MPXV5004DP patient_pressure_sensor_{"patient_pressure_", "for patient airway pressure",
                                       PinFor(Sensor::PatientPressure), ADC_voltage_range_};
   TeledyneR24 fio2_sensor_{"fio2", PinFor(Sensor::FIO2), " "};
-  MPXV5004DP air_influx_sensor_dp_{"air_influx_", " for ambient air influx",
+  MPXV5004DP air_influx_sensor_dp_{"air_influx_", "for ambient air influx",
                                    PinFor(Sensor::AirInflowPressureDiff), ADC_voltage_range_};
-  MPXV5004DP oxygen_influx_sensor_dp_{"oxygen_influx_", " for concentrated oxygen influx",
+  MPXV5004DP oxygen_influx_sensor_dp_{"oxygen_influx_", "for concentrated oxygen influx",
                                       PinFor(Sensor::OxygenInflowPressureDiff), ADC_voltage_range_};
   MPXV5004DP outflow_sensor_dp_{"outflow_", " for outflow", PinFor(Sensor::OutflowPressureDiff),
                                 ADC_voltage_range_};
 
   // These require existing DP sensors to link to
-  VenturiFlowSensor air_influx_sensor_{"air_influx_",           " for ambient air influx",
+  VenturiFlowSensor air_influx_sensor_{"air_influx_",           "for ambient air influx",
                                        &air_influx_sensor_dp_,  venturi_port_diameter_,
                                        venturi_choke_diameter_, venturi_correction_};
   VenturiFlowSensor oxygen_influx_sensor_{
-      "oxygen_influx_",       " for concentrated oxygen influx", &oxygen_influx_sensor_dp_,
-      venturi_port_diameter_, venturi_choke_diameter_,           venturi_correction_};
+      "oxygen_influx_",       "for concentrated oxygen influx", &oxygen_influx_sensor_dp_,
+      venturi_port_diameter_, venturi_choke_diameter_,          venturi_correction_};
   VenturiFlowSensor outflow_sensor_{"outflow_",
-                                    " for outflow",
+                                    "for outflow",
                                     &outflow_sensor_dp_,
                                     venturi_port_diameter_,
                                     venturi_choke_diameter_,

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -11,12 +11,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-module contributors: verityRF, jlebar, lee-matthews, Edwin Chiu
-
-The purpose of this module is to allow calibrated readings from the different
-pressure sensors in the ventilator design. It is designed to be used with the
-Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 */
 
 #pragma once
@@ -27,7 +21,7 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 struct SensorReadings {
   Pressure patient_pressure;
   // Pressure differences read at the inflow/outflow venturis.
-  Pressure inflow_pressure_diff;
+  Pressure air_inflow_pressure_diff;
   Pressure outflow_pressure_diff;
 
   // fraction of inspired oxygen (fiO2)
@@ -39,7 +33,7 @@ struct SensorReadings {
   // These are "uncorrected" values.  We account for high-frequency noise by
   // e.g. averaging many samples, but we don't account here for low-frequency
   // sensor zero-point drift.
-  VolumetricFlow inflow;
+  VolumetricFlow air_inflow;
   VolumetricFlow outflow;
 };
 
@@ -79,7 +73,7 @@ class Sensors {
  private:
   enum class Sensor {
     PatientPressure,
-    InflowPressureDiff,
+    AirInflowPressureDiff,
     OutflowPressureDiff,
     FIO2,
   };

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -23,6 +23,7 @@ struct SensorReadings {
   Pressure patient_pressure;
   // Pressure differences read at the inflow/outflow venturis.
   Pressure air_inflow_pressure_diff;
+  Pressure oxygen_inflow_pressure_diff;
   Pressure outflow_pressure_diff;
 
   // fraction of inspired oxygen (fiO2)
@@ -35,6 +36,7 @@ struct SensorReadings {
   // e.g. averaging many samples, but we don't account here for low-frequency
   // sensor zero-point drift.
   VolumetricFlow air_inflow;
+  VolumetricFlow oxygen_inflow;
   VolumetricFlow outflow;
 };
 
@@ -73,13 +75,14 @@ class Sensors {
 
  private:
   enum class Sensor {
+    OxygenInflowPressureDiff,
     PatientPressure,
     AirInflowPressureDiff,
     OutflowPressureDiff,
     FIO2,
   };
   // Keep this in sync with the Sensor enum!
-  constexpr static int NumSensors{4};
+  constexpr static int NumSensors{5};
 
   static AnalogPin PinFor(Sensor s);
   Pressure ReadPressureSensor(Sensor s) const;
@@ -89,19 +92,20 @@ class Sensors {
   Voltage sensors_zero_vals_[NumSensors];
 
   mutable Debug::Variable::Float inflow_air_dp_{"inflow_air_dp", Debug::Variable::Access::ReadOnly,
-                                                0.0f, "cmH2O", "Inhale diff pressure"};
+                                                0.0f, "cmH2O", "Air influx differential pressure"};
+  mutable Debug::Variable::Float inflow_oxy_dp_{"inflow_oxygen_dp",
+                                                Debug::Variable::Access::ReadOnly, 0.0f, "cmH2O",
+                                                "Concentrated oxygen influx differential pressure"};
   mutable Debug::Variable::Float outflow_dp_{"outflow_dp", Debug::Variable::Access::ReadOnly, 0.0f,
-                                             "cmH2O", "Exhale diff pressure"};
+                                             "cmH2O", "Exhale differential pressure"};
   mutable Debug::Variable::Float patient_pressure_{"pressure", Debug::Variable::Access::ReadOnly,
                                                    0.0f, "cmH2O", "Patient pressure"};
   mutable Debug::Variable::Float inflow_air_{"inflow_air", Debug::Variable::Access::ReadOnly, 0.0f,
-                                             "mL/s", "Inhale flow rate"};
+                                             "mL/s", "Air influx flow rate"};
+  mutable Debug::Variable::Float inflow_oxy_{"inflow_oxygen", Debug::Variable::Access::ReadOnly,
+                                             0.0f, "mL/s", "Concentrated oxygen influx flow rate"};
   mutable Debug::Variable::Float outflow_{"outflow", Debug::Variable::Access::ReadOnly, 0.0f,
-                                          "mL/s", "Exhale flow rate"};
+                                          "mL/s", "Outflow rate"};
   mutable Debug::Variable::Float fio2_{"fio2", Debug::Variable::Access::ReadOnly, 0.0f, "ratio",
                                        "Fraction of inspired oxygen"};
-  // Flow correction happens as part of volume computation, in the Controller.
-  mutable Debug::Variable::Float net_flow_uncorrected_{"net_flow_uncorrected",
-                                                       Debug::Variable::Access::ReadOnly, 0.0f,
-                                                       "mL/s", "Uncorrected net flow rate"};
 };

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -82,8 +82,8 @@ static constexpr int OversampleLog2 = 4;
 static constexpr int OversampleCount = 1 << OversampleLog2;
 
 // [RM] 16.4.30: Oversampler (pg 425)
-// This calculated constant gives the maximum A/D reading based on the
-// number of samples.
+// This calculated constant gives the maximum A/D reading based on the number of samples.
+// \TODO: what is 4?
 static constexpr int MaxAdcReading = (OversampleLog2 >= 4) ? 65536 : (1 << (12 + OversampleLog2));
 
 // Set sample time ([RM] 16.4.12). I'm using 92.5 A/D clocks to sample.
@@ -168,10 +168,12 @@ void HalApi::InitADC() {
 
   adc->adc[0].configuration2.oversampling_ratio = (OversampleLog2 > 0) ? OversampleLog2 - 1 : 0;
 
+  // \TODO: what is 4?
   adc->adc[0].configuration2.oversampling_shift = (OversampleLog2 < 4) ? 0 : (OversampleLog2 - 4);
 
   // Set sample times ([RM] 16.4.12). I'm using 92.5 A/D clocks to sample.
   static_assert(AdcSampleTime == 92);
+  // \todo all of these are = 5 -- should this be a single variable based on something above?
   adc->adc[0].sample_times.ch5 = 5;
   adc->adc[0].sample_times.ch6 = 5;
   adc->adc[0].sample_times.ch9 = 5;
@@ -179,6 +181,7 @@ void HalApi::InitADC() {
   adc->adc[0].sample_times.ch2 = 5;
 
   // Set conversion sequence length:
+  // \TODO: why - 1 ?
   adc->adc[0].sequence.length = AdcChannels - 1;
 
   adc->adc[0].sequence.sequence1 = 5;   // PA0 (ADC1_IN5)  interim board: analog pressure

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -59,11 +59,11 @@ limitations under the License.
 Please refer to [PCB] as the ultimate source of which pin is used for which function.
 
 The following pins are used as analog inputs on the rev-1 PCB:
-- PA0 (ADC1_IN5)  - oxygen influx flow
-- PA1 (ADC1_IN6)  - pressure
-- PA4 (ADC1_IN9)  - air influx flow
-- PB0 (ADC1_IN15) - exhale flow
-- PC3 (ADC1_IN2) - oxygen sensor
+- PA0 (ADC1_IN5)  interim board: analog pressure
+- PA1 (ADC1_IN6)  U3 patient pressure
+- PA4 (ADC1_IN9)  U4 inhale flow
+- PB0 (ADC1_IN15) U5 exhale flow
+- PC3 (ADC1_IN2)  interim board: oxygen sensor
 
 Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 */
@@ -121,11 +121,11 @@ void HalApi::InitADC() {
   EnableClock(AdcBase);
 
   // Configure the 4 pins used as analog inputs
-  GpioPinMode(GpioABase, 0, GPIOPinMode::Analog);
-  GpioPinMode(GpioABase, 1, GPIOPinMode::Analog);
-  GpioPinMode(GpioABase, 4, GPIOPinMode::Analog);
-  GpioPinMode(GpioBBase, 0, GPIOPinMode::Analog);
-  GpioPinMode(GpioCBase, 1, GPIOPinMode::Analog);
+  GpioPinMode(GpioABase, 0, GPIOPinMode::Analog);  // PA0 (ADC1_IN5)  interim board: analog pressure
+  GpioPinMode(GpioABase, 1, GPIOPinMode::Analog);  // PA1 (ADC1_IN6)  U3 patient pressure
+  GpioPinMode(GpioABase, 4, GPIOPinMode::Analog);  // PA4 (ADC1_IN9)  U4 inhale flow
+  GpioPinMode(GpioBBase, 0, GPIOPinMode::Analog);  // PB0 (ADC1_IN15) U5 exhale flow
+  GpioPinMode(GpioCBase, 1, GPIOPinMode::Analog);  // PC3 (ADC1_IN2)  interim board: oxygen sensor
 
   // Perform a power-up and calibration sequence on
   // the A/D converter
@@ -181,11 +181,11 @@ void HalApi::InitADC() {
   // Set conversion sequence length:
   adc->adc[0].sequence.length = AdcChannels - 1;
 
-  adc->adc[0].sequence.sequence1 = 5;
-  adc->adc[0].sequence.sequence2 = 6;
-  adc->adc[0].sequence.sequence3 = 9;
-  adc->adc[0].sequence.sequence4 = 15;
-  adc->adc[0].sequence.sequence5 = 2;
+  adc->adc[0].sequence.sequence1 = 5;   // PA0 (ADC1_IN5)  interim board: analog pressure
+  adc->adc[0].sequence.sequence2 = 6;   // PA1 (ADC1_IN6)  U3 patient pressure
+  adc->adc[0].sequence.sequence3 = 9;   // PA4 (ADC1_IN9)  U4 inhale flow
+  adc->adc[0].sequence.sequence4 = 15;  // PB0 (ADC1_IN15) U5 exhale flow
+  adc->adc[0].sequence.sequence5 = 2;   // PC3 (ADC1_IN2)  interim board: oxygen sensor
 
   // I use DMA1 channel 1 to copy my A/D readings into my buffer ([RM] 11.4.4)
   EnableClock(Dma1Base);
@@ -218,15 +218,15 @@ void HalApi::InitADC() {
 Voltage HalApi::AnalogRead(AnalogPin pin) {
   int offset = [&] {
     switch (pin) {
-      case AnalogPin::OxygenInflowPressureDiff:
+      case AnalogPin::InterimBoardAnalogPressure:
         return 0;
-      case AnalogPin::PatientPressure:
+      case AnalogPin::U3PatientPressure:
         return 1;
-      case AnalogPin::AirInflowPressureDiff:
+      case AnalogPin::U4InhaleFlow:
         return 2;
-      case AnalogPin::OutflowPressureDiff:
+      case AnalogPin::U5ExhaleFlow:
         return 3;
-      case AnalogPin::FIO2:
+      case AnalogPin::InterimBoardOxygenSensor:
         return 4;
     }
     // All cases covered above (and GCC checks this).

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -219,7 +219,7 @@ Voltage HalApi::AnalogRead(AnalogPin pin) {
     switch (pin) {
       case AnalogPin::PatientPressure:
         return 0;
-      case AnalogPin::InflowPressureDiff:
+      case AnalogPin::AirInflowPressureDiff:
         return 1;
       case AnalogPin::OutflowPressureDiff:
         return 2;

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -120,7 +120,7 @@ void HalApi::InitADC() {
   // Enable the clock to the A/D converter
   EnableClock(AdcBase);
 
-  // Configure the 4 pins used as analog inputs
+  // Configure the 5 pins used as analog inputs
   GpioPinMode(GpioABase, 0, GPIOPinMode::Analog);  // PA0 (ADC1_IN5)  interim board: analog pressure
   GpioPinMode(GpioABase, 1, GPIOPinMode::Analog);  // PA1 (ADC1_IN6)  U3 patient pressure
   GpioPinMode(GpioABase, 4, GPIOPinMode::Analog);  // PA4 (ADC1_IN9)  U4 inhale flow

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -85,6 +85,7 @@ enum class AnalogPin {
   // - PATIENT_PRESSURE reads an absolute pressure value at the patient.
   // - {INFLOW,OUTFLOW}_PRESSURE_DIFF, read a differential across a venturi.
   //   They let us measure volumetric flow into and out of the patient.
+  OxygenInflowPressureDiff,
   PatientPressure,
   AirInflowPressureDiff,
   OutflowPressureDiff,

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -80,17 +80,14 @@ enum class PinMode {
 // Usage: VoltageLevel::High, Low
 enum class VoltageLevel { High, Low };
 
+// Location of analog sensors as labeled on the PCB(s). Note that this does not necessarily define
+// their function and further mapping should be done in the higher layers of the software.
 enum class AnalogPin {
-  // MPXV5004DP pressure sensors:
-  // - PATIENT_PRESSURE reads an absolute pressure value at the patient.
-  // - {INFLOW,OUTFLOW}_PRESSURE_DIFF, read a differential across a venturi.
-  //   They let us measure volumetric flow into and out of the patient.
-  OxygenInflowPressureDiff,
-  PatientPressure,
-  AirInflowPressureDiff,
-  OutflowPressureDiff,
-  // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
-  FIO2,
+  InterimBoardAnalogPressure,
+  U3PatientPressure,
+  U4InhaleFlow,
+  U5ExhaleFlow,
+  InterimBoardOxygenSensor,
 };
 
 // Pulse-width modulated outputs from the controller.  These can be set to

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -31,9 +31,11 @@ limitations under the License.
 // observe whether mocked methods are called.  So far that hasn't been
 // necessary.
 
-#include "units.h"
-#include <algorithm>
 #include <stdint.h>
+
+#include <algorithm>
+
+#include "units.h"
 
 #ifdef TEST_MODE
 
@@ -41,20 +43,22 @@ limitations under the License.
 #error "TEST_MODE intended to be run only on native, but BARE_STM32 is defined"
 #endif
 
-#include "checksum.h"
 #include <assert.h>
+
 #include <cstring>
 #include <deque>
 #include <map>
 #include <vector>
 
-#else // !TEST_MODE
+#include "checksum.h"
+
+#else  // !TEST_MODE
 
 #if !defined(BARE_STM32)
 #error "When running without TEST_MODE, expecting BARE_STM32 to be defined"
 #endif
 
-#endif // TEST_MODE
+#endif  // TEST_MODE
 
 // ---------------------------------------------------------------
 // Strongly typed analogues of some Arduino types.
@@ -82,7 +86,7 @@ enum class AnalogPin {
   // - {INFLOW,OUTFLOW}_PRESSURE_DIFF, read a differential across a venturi.
   //   They let us measure volumetric flow into and out of the patient.
   PatientPressure,
-  InflowPressureDiff,
+  AirInflowPressureDiff,
   OutflowPressureDiff,
   // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
   FIO2,
@@ -121,16 +125,16 @@ enum class BinaryPin {
 // priority of -1, so they can always interrupt any other
 // priority level.
 enum class IntPriority {
-  Critical = 2, // Very important interrupt
-  Standard = 5, // Normal hardware interrupts
-  Low = 8,      // Less important.  Hardware interrupts can interrupt this
+  Critical = 2,  // Very important interrupt
+  Standard = 5,  // Normal hardware interrupts
+  Low = 8,       // Less important.  Hardware interrupts can interrupt this
 };
 
 enum class InterruptVector;
 
 #ifdef TEST_MODE
 class TestSerialPort {
-public:
+ public:
   [[nodiscard]] uint16_t Write(const char *buf, uint16_t len);
   [[nodiscard]] uint16_t Read(char *buf, uint16_t len);
   uint16_t BytesAvailableForWrite();
@@ -138,11 +142,11 @@ public:
   void PutIncomingData(const char *data, uint16_t len);
   uint16_t GetOutgoingData(char *data, uint16_t len);
 
-private:
+ private:
   std::deque<std::vector<char>> incoming_data_;
   std::vector<char> outgoing_data_;
 };
-#endif // TEST_MODE
+#endif  // TEST_MODE
 
 // Singleton class which implements a hardware abstraction layer.
 //
@@ -152,7 +156,7 @@ private:
 // any ifdefs for different platforms, and all of the "global variables" can
 // move into the hal_foo.cpp files.
 class HalApi {
-public:
+ public:
   void Init();
 
   // Amount of time that has passed since the board started running the
@@ -302,8 +306,7 @@ public:
   [[noreturn]] void ResetDevice();
 
   // Start the loop timer
-  void StartLoopTimer(const Duration &period, void (*callback)(void *),
-                      void *arg);
+  void StartLoopTimer(const Duration &period, void (*callback)(void *), void *arg);
 
   // Pets the watchdog, this makes the watchdog not reset the
   // system for configured amount of time
@@ -327,7 +330,7 @@ public:
   // Return true if we are currently executing in an interrupt handler
   bool InInterruptHandler();
 
-private:
+ private:
   // Initializes watchdog, sets appropriate pins to Output, etc.  Called by
   // HalApi::Init
   void WatchdogInit();
@@ -382,7 +385,7 @@ extern HalApi hal;
 // This class is reentrant, i.e. it's safe to BlockInterrupts even when
 // interrupts are already disabled.
 class [[nodiscard]] BlockInterrupts {
-public:
+ public:
   BlockInterrupts() : active_(hal.InterruptsEnabled()) {
     if (active_) {
       hal.DisableInterrupts();
@@ -402,15 +405,13 @@ public:
     }
   }
 
-private:
+ private:
   bool active_;
 };
 
 #if defined(BARE_STM32)
 
-inline void HalApi::DisableInterrupts() {
-  asm volatile("cpsid i" ::: "memory");
-}
+inline void HalApi::DisableInterrupts() { asm volatile("cpsid i" ::: "memory"); }
 inline void HalApi::EnableInterrupts() { asm volatile("cpsie i" ::: "memory"); }
 inline bool HalApi::InterruptsEnabled() const {
   int ret;
@@ -430,15 +431,11 @@ inline void HalApi::WatchdogHandler() {}
 
 inline Time HalApi::Now() { return time_; }
 inline void HalApi::Delay(Duration d) { time_ = time_ + d; }
-inline Voltage HalApi::AnalogRead(AnalogPin pin) {
-  return analog_pin_values_.at(pin);
-}
+inline Voltage HalApi::AnalogRead(AnalogPin pin) { return analog_pin_values_.at(pin); }
 inline void HalApi::TESTSetAnalogPin(AnalogPin pin, Voltage value) {
   analog_pin_values_[pin] = value;
 }
-inline void HalApi::SetDigitalPinMode(PwmPin pin, PinMode mode) {
-  pwm_pin_modes_[pin] = mode;
-}
+inline void HalApi::SetDigitalPinMode(PwmPin pin, PinMode mode) { pwm_pin_modes_[pin] = mode; }
 inline void HalApi::SetDigitalPinMode(BinaryPin pin, PinMode mode) {
   binary_pin_modes_[pin] = mode;
 }
@@ -455,9 +452,7 @@ inline void HalApi::AnalogWrite(PwmPin pin, float duty) {
   pwm_pin_values_[pin] = duty;
 }
 
-inline uint16_t HalApi::SerialRead(char *buf, uint16_t len) {
-  return serial_port_.Read(buf, len);
-}
+inline uint16_t HalApi::SerialRead(char *buf, uint16_t len) { return serial_port_.Read(buf, len); }
 inline uint16_t HalApi::SerialBytesAvailableForRead() {
   return serial_port_.BytesAvailableForRead();
 }
@@ -512,9 +507,7 @@ inline uint16_t TestSerialPort::Read(char *buf, uint16_t len) {
   return n;
 }
 inline uint16_t TestSerialPort::BytesAvailableForRead() {
-  return incoming_data_.empty()
-             ? 0
-             : static_cast<uint16_t>(incoming_data_.front().size());
+  return incoming_data_.empty() ? 0 : static_cast<uint16_t>(incoming_data_.front().size());
 }
 inline uint16_t TestSerialPort::Write(const char *buf, uint16_t len) {
   uint16_t n = std::min(len, BytesAvailableForWrite());
@@ -542,16 +535,13 @@ inline void TestSerialPort::PutIncomingData(const char *data, uint16_t len) {
   incoming_data_.push_back(std::vector<char>(data, data + len));
 }
 
-inline void HalApi::StartLoopTimer(const Duration &period,
-                                   void (*callback)(void *), void *arg) {}
+inline void HalApi::StartLoopTimer(const Duration &period, void (*callback)(void *), void *arg) {}
 
 inline void BuzzerOn(float volume) {}
 inline void BuzzerOff() {}
 inline void InitPSOL() {}
 inline void PSolValue(float val) {}
 inline bool HalApi::FlashErasePage(uint32_t address) { return true; }
-inline bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) {
-  return true;
-}
+inline bool HalApi::FlashWrite(uint32_t addr, void *data, size_t ct) { return true; }
 
 #endif

--- a/software/controller/lib/sensors/oxygen.cpp
+++ b/software/controller/lib/sensors/oxygen.cpp
@@ -1,0 +1,48 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "oxygen.h"
+
+TeledyneR24::TeledyneR24(const char *name, AnalogPin pin, const char *help_supplement)
+    : OxygenSensor(name, help_supplement), AnalogSensor(name, pin, help_supplement) {}
+
+// Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
+//
+// Output scales with partial pressure of O2, so ambient pressure must be
+// compensated to get an accurate FIO2.
+float TeledyneR24::read(HalApi &hal_api, Pressure p_ambient) const {
+  // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
+  // http://www.medicalsolutiontechnology.com/wp-content/uploads/2012/09/GO-04-DATA-SHEET.pdf
+  // Sensitivity of 0.060V/fio2, where fio2 is 0.0 to 1.0, at pressure = 1atm
+  // https://www.apogeeinstruments.com/content/SO-100-200-spec-sheet.pdf:
+  // sensitivity similar to SO-210-SS PCB has an op-amp to gain the output up by
+  // 50V/V This gives about 3.0V full scale.
+
+  // Standard air O2 concentration. This assumes that calibration occured with
+  // pure air, meaning the system has been filled with air only.
+  static const float O2ConcentrationInAir{0.21f};
+
+  static const float AmplifierGain{50.0f};
+  static const float OxygenSensorGain{0.060f};
+
+  // TODO: raise alarm if fio2 is out of expected (0,1) range
+  auto ret = AnalogSensor::read_diff_volts(hal_api) / (AmplifierGain * OxygenSensorGain) /
+                 p_ambient.atm() +
+             O2ConcentrationInAir;
+
+  dbg_fio2_.set(ret);
+
+  return ret;
+}

--- a/software/controller/lib/sensors/oxygen.cpp
+++ b/software/controller/lib/sensors/oxygen.cpp
@@ -15,8 +15,8 @@ limitations under the License.
 
 #include "oxygen.h"
 
-TeledyneR24::TeledyneR24(const char *name, AnalogPin pin, const char *help_supplement)
-    : OxygenSensor(name, help_supplement), AnalogSensor(name, pin, help_supplement) {}
+TeledyneR24::TeledyneR24(const char *name, const char *help_supplement, AnalogPin pin)
+    : OxygenSensor(name, help_supplement), AnalogSensor(name, help_supplement, pin) {}
 
 // Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
 //

--- a/software/controller/lib/sensors/oxygen.h
+++ b/software/controller/lib/sensors/oxygen.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 class TeledyneR24 : public OxygenSensor, public AnalogSensor {
  public:
-  TeledyneR24(const char* name, AnalogPin pin, const char* help_supplement);
+  TeledyneR24(const char* name, const char* help_supplement, AnalogPin pin);
 
   float read(HalApi& hal_api, Pressure p_ambient) const override;
 };

--- a/software/controller/lib/sensors/oxygen.h
+++ b/software/controller/lib/sensors/oxygen.h
@@ -1,0 +1,25 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "sensor_base.h"
+
+class TeledyneR24 : public OxygenSensor, public AnalogSensor {
+ public:
+  TeledyneR24(const char* name, AnalogPin pin, const char* help_supplement);
+
+  float read(HalApi& hal_api, Pressure p_ambient) const override;
+};

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 AnalogPressureSensor::AnalogPressureSensor(const char *name, const char *help_supplement,
                                            AnalogPin pin, float voltage_to_kPa)
     : PressureSensor(name, help_supplement),
-      AnalogSensor(name, pin, help_supplement),
+      AnalogSensor(name, help_supplement, pin),
       voltage_to_kPa_(voltage_to_kPa) {}
 
 Pressure AnalogPressureSensor::read(HalApi &hal_api) const {

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -1,0 +1,38 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "pressure_sensors.h"
+
+AnalogPressureSensor::AnalogPressureSensor(const char *name, const char *help_supplement,
+                                           AnalogPin pin, float voltage_to_kPa)
+    : PressureSensor(name, help_supplement),
+      AnalogSensor(name, pin, help_supplement),
+      voltage_to_kPa_(voltage_to_kPa) {}
+
+Pressure AnalogPressureSensor::read(HalApi &hal_api) const {
+  auto ret = kPa(AnalogSensor::read_diff_volts(hal_api) * voltage_to_kPa_);
+  dbg_pressure_.set(ret.cmH2O());
+  return ret;
+}
+
+// The pressure sensors output 1-5V, and each additional 1V of output
+// corresponds to an additional 1kPa of pressure difference.
+// https://www.nxp.com/docs/en/data-sheet/MPXV5004G.pdf.
+//
+// voltage_range is whatever the voltage is scaled to as captured by your ADC.
+// Therefore, if we multiply the received voltage by 5/voltage_range, we get a pressure in kPa.
+MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, AnalogPin pin,
+                       float voltage_range)
+    : AnalogPressureSensor(name, help_supplement, pin, 5.f / voltage_range) {}

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -1,0 +1,40 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "sensor_base.h"
+
+class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
+ public:
+  AnalogPressureSensor(const char *name, const char *help_supplement, AnalogPin pin,
+                       float voltage_to_kPa);
+
+  Pressure read(HalApi &hal_api) const override;
+
+ private:
+  // Assume linear relationship, pending further research
+  float voltage_to_kPa_;
+};
+
+class MPXV5004DP : public AnalogPressureSensor {
+ public:
+  MPXV5004DP(const char *name, const char *help_supplement, AnalogPin pin, float voltage_range);
+
+  // min/max possible reading from MPXV5004GP pressure sensors
+  // \TODO: are we supposed to use these somehow?
+  constexpr static Pressure MinPressure{kPa(0.0f)};
+  constexpr static Pressure MaxPressure{kPa(3.92f)};
+};

--- a/software/controller/lib/sensors/sensor_base.cpp
+++ b/software/controller/lib/sensors/sensor_base.cpp
@@ -1,0 +1,59 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "sensor_base.h"
+
+#include <cmath>
+
+AnalogSensor::AnalogSensor(const char *name, AnalogPin pin, const char *help_supplement)
+    : pin_(pin),
+      dbg_zero_("zero", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage offset "),
+      dbg_voltage_("voltage", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage reading ") {
+  dbg_zero_.prepend_name(name);
+  dbg_zero_.append_help(help_supplement);
+
+  dbg_voltage_.prepend_name(name);
+  dbg_voltage_.append_help(help_supplement);
+}
+
+void AnalogSensor::set_zero(HalApi &hal_api) {
+  zero_ = hal_api.AnalogRead(pin_);
+  dbg_zero_.set(zero_.volts());
+}
+
+float AnalogSensor::read_diff_volts(HalApi &hal_api) const {
+  auto ret = (hal_api.AnalogRead(pin_) - zero_).volts();
+  dbg_voltage_.set(ret);
+  return ret;
+}
+
+PressureSensor::PressureSensor(const char *name, const char *help_supplement)
+    : dbg_pressure_("dp", Debug::Variable::Access::ReadOnly, 0.f, "cmH2O",
+                    "Differential pressure ") {
+  dbg_pressure_.prepend_name(name);
+  dbg_pressure_.append_help(help_supplement);
+}
+
+FlowSensor::FlowSensor(const char *name, const char *help_supplement)
+    : dbg_flow_("flow", Debug::Variable::Access::ReadOnly, 0.f, "mL/s", "Volumetric flow ") {
+  dbg_flow_.prepend_name(name);
+  dbg_flow_.append_help(help_supplement);
+}
+
+OxygenSensor::OxygenSensor(const char *name, const char *help_supplement)
+    : dbg_fio2_("fio2", Debug::Variable::Access::ReadOnly, 0.f, "ratio", "Fraction of oxygen ") {
+  dbg_fio2_.prepend_name(name);
+  dbg_fio2_.append_help(help_supplement);
+}

--- a/software/controller/lib/sensors/sensor_base.cpp
+++ b/software/controller/lib/sensors/sensor_base.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <cmath>
 
-AnalogSensor::AnalogSensor(const char *name, AnalogPin pin, const char *help_supplement)
+AnalogSensor::AnalogSensor(const char *name, const char *help_supplement, AnalogPin pin)
     : pin_(pin),
       dbg_zero_("zero", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage offset "),
       dbg_voltage_("voltage", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage reading ") {

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -1,0 +1,63 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "hal.h"
+#include "units.h"
+#include "vars.h"
+
+class AnalogSensor {
+ public:
+  AnalogSensor(const char *name, AnalogPin pin, const char *help_supplement);
+
+  void set_zero(HalApi &hal_api);
+
+  float read_diff_volts(HalApi &hal_api) const;
+
+ private:
+  AnalogPin pin_;
+  Voltage zero_;
+
+  mutable Debug::Variable::Float dbg_zero_;
+  mutable Debug::Variable::Float dbg_voltage_;
+};
+
+class PressureSensor {
+ public:
+  virtual Pressure read(HalApi &hal_api) const = 0;
+
+ protected:
+  PressureSensor(const char *name, const char *help_supplement);
+  mutable Debug::Variable::Float dbg_pressure_;
+};
+
+class FlowSensor {
+ public:
+  virtual VolumetricFlow read(HalApi &hal_api, float air_density) const = 0;
+
+ protected:
+  FlowSensor(const char *name, const char *help_supplement);
+  mutable Debug::Variable::Float dbg_flow_;
+};
+
+class OxygenSensor {
+ public:
+  virtual float read(HalApi &hal_api, Pressure p_ambient) const = 0;
+
+ protected:
+  OxygenSensor(const char *name, const char *help_supplement);
+  mutable Debug::Variable::Float dbg_fio2_;
+};

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 class AnalogSensor {
  public:
-  AnalogSensor(const char *name, AnalogPin pin, const char *help_supplement);
+  AnalogSensor(const char *name, const char *help_supplement, AnalogPin pin);
 
   void set_zero(HalApi &hal_api);
 

--- a/software/controller/lib/sensors/venturi.cpp
+++ b/software/controller/lib/sensors/venturi.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "venturi.h"
+
+#include <cmath>
+
+float pow2(float f) { return f * f; }
+
+// \TODO: put this in math header and have it tested
+// Returns an area in meters squared.
+float diameter_to_area_m2(Length diameter) {
+  return static_cast<float>(M_PI) / 4.0f * pow2(diameter.meters());
+};
+
+VenturiFlowSensor::VenturiFlowSensor(const char* name, const char* help_supplement,
+                                     PressureSensor* pressure_sensor, Length venturi_port_diameter,
+                                     Length venturi_choke_diameter, float venturi_correction)
+    : FlowSensor(name, help_supplement),
+      pressure_sensor_(pressure_sensor),
+      venturi_correction_(venturi_correction) {
+  port_area_ = diameter_to_area_m2(venturi_port_diameter);
+  choke_area_ = diameter_to_area_m2(venturi_choke_diameter);
+}
+
+/*
+ * @brief Method implements Bernoulli's equation assuming the Venturi Effect.
+ * https://en.wikipedia.org/wiki/Venturi_effect
+ *
+ * Solves for the volumetric flow rate since A1/A2, rho, and differential
+ * pressure are known. Q = sqrt(2/rho) * (A1*A2) * 1/sqrt(A1^2-A2^2) *
+ * sqrt(p1-p2); based on (p1 - p2) = (rho/2) * (v2^2 - v1^2); where A1 > A2
+ *
+ * @return the volumetric flow in [meters^3/s]. Can be negative, indicating
+ * direction of flow, depending on how the differential sensor is attached to
+ * the venturi.
+ */
+VolumetricFlow VenturiFlowSensor::read(HalApi& hal_api, float air_density) const {
+  auto ret = pressure_delta_to_flow(pressure_sensor_->read(hal_api), air_density);
+  dbg_flow_.set(ret.ml_per_sec());
+  return ret;
+}
+
+VolumetricFlow VenturiFlowSensor::pressure_delta_to_flow(Pressure delta, float air_density) const {
+  return cubic_m_per_sec(venturi_correction_ *
+                         std::copysign(std::sqrt(std::abs(delta.kPa()) * 1000.0f), delta.kPa()) *
+                         std::sqrt(2 / air_density) * port_area_ * choke_area_ /
+                         std::sqrt(pow2(port_area_) - pow2(choke_area_)));
+}

--- a/software/controller/lib/sensors/venturi.h
+++ b/software/controller/lib/sensors/venturi.h
@@ -1,0 +1,41 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "pressure_sensors.h"
+#include "sensor_base.h"
+
+class VenturiFlowSensor : public FlowSensor {
+ public:
+  VenturiFlowSensor(const char* name, const char* help_supplement, PressureSensor* pressure_sensor,
+                    Length venturi_port_diameter, Length venturi_choke_diameter,
+                    float venturi_correction);
+
+  /// \param air_density in units of kg/m^3, will depend on temperature and pressure
+  VolumetricFlow read(HalApi& hal_api, float air_density) const override;
+
+  /// This is exposed as static so the math can be tested without HAL
+  VolumetricFlow pressure_delta_to_flow(Pressure delta, float air_density) const;
+
+ private:
+  PressureSensor* pressure_sensor_;
+
+  float port_area_;
+  float choke_area_;
+
+  /// \TODO: define and explain this
+  float venturi_correction_;
+};

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -75,8 +75,8 @@ static Debug::Interface debug(&trace, 12, Debug::Command::Code::Mode, &mode_comm
 static SensorsProto AsSensorsProto(const SensorReadings &r, const ControllerState &c) {
   SensorsProto proto = SensorsProto_init_zero;
   proto.patient_pressure_cm_h2o = r.patient_pressure.cmH2O();
-  proto.inflow_pressure_diff_cm_h2o = r.air_inflow_pressure_diff.cmH2O();
-  proto.outflow_pressure_diff_cm_h2o = r.outflow_pressure_diff.cmH2O();
+  proto.inflow_pressure_diff_cm_h2o = 0;   // \TODO field unused and obsolete, should change proto
+  proto.outflow_pressure_diff_cm_h2o = 0;  // \TODO field unused and obsolete, should change proto
   proto.flow_ml_per_min = c.net_flow.ml_per_min();
   proto.volume_ml = c.patient_volume.ml();
   proto.breath_id = c.breath_id;

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -75,7 +75,7 @@ static Debug::Interface debug(&trace, 12, Debug::Command::Code::Mode, &mode_comm
 static SensorsProto AsSensorsProto(const SensorReadings &r, const ControllerState &c) {
   SensorsProto proto = SensorsProto_init_zero;
   proto.patient_pressure_cm_h2o = r.patient_pressure.cmH2O();
-  proto.inflow_pressure_diff_cm_h2o = r.inflow_pressure_diff.cmH2O();
+  proto.inflow_pressure_diff_cm_h2o = r.air_inflow_pressure_diff.cmH2O();
   proto.outflow_pressure_diff_cm_h2o = r.outflow_pressure_diff.cmH2O();
   proto.flow_ml_per_min = c.net_flow.ml_per_min();
   proto.volume_ml = c.patient_volume.ml();

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -92,7 +92,7 @@ static SensorsProto AsSensorsProto(const SensorReadings &r, const ControllerStat
 // quickly.  No busy waiting here.
 static void HighPriorityTask(void *arg) {
   // Read the sensors
-  SensorReadings sensor_readings = sensors.GetReadings();
+  SensorReadings sensor_readings = sensors.get_readings();
 
   // Run our PID loop
   auto [actuators_state, controller_state] =
@@ -143,7 +143,7 @@ static void HighPriorityTask(void *arg) {
 
   // Calibrate the sensors.
   // This needs to be done before the sensors are used.
-  sensors.Calibrate();
+  sensors.calibrate();
 
   // Current controller status.
   // Updated when we receive data from the GUI, when sensors read data, etc.

--- a/software/controller/test/controller/controller_test.cpp
+++ b/software/controller/test/controller/controller_test.cpp
@@ -21,6 +21,14 @@ limitations under the License.
 
 // TODO: There ought to be many more tests in here.
 
+// \TODO lots of assumptions here, and sign of too much coupling, should not need this here
+static constexpr float air_density{1.225f};  // kg/m^3
+constexpr static Length venturi_port_diameter{millimeters(15.05f)};
+constexpr static Length venturi_choke_diameter{millimeters(5.5f)};
+constexpr static float venturi_correction{0.97f};
+static VenturiFlowSensor typical_venturi{
+    "", "", nullptr, venturi_port_diameter, venturi_choke_diameter, venturi_correction};
+
 TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
   constexpr Time start = microsSinceStartup(0);
   constexpr int breaths_to_test = 5;
@@ -65,9 +73,9 @@ TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
     readings = {
         .patient_pressure = kPa(0),
         .fio2 = 0.21f,
-        .air_inflow = Sensors::PressureDeltaToFlow(air_inflow_pressure),
-        .oxygen_inflow = Sensors::PressureDeltaToFlow(oxy_inflow_pressure),
-        .outflow = Sensors::PressureDeltaToFlow(outflow_pressure),
+        .air_inflow = typical_venturi.pressure_delta_to_flow(air_inflow_pressure, air_density),
+        .oxygen_inflow = typical_venturi.pressure_delta_to_flow(oxy_inflow_pressure, air_density),
+        .outflow = typical_venturi.pressure_delta_to_flow(outflow_pressure, air_density),
     };
     VolumetricFlow uncorrected_flow =
         readings.air_inflow

--- a/software/controller/test/controller/controller_test.cpp
+++ b/software/controller/test/controller/controller_test.cpp
@@ -42,10 +42,10 @@ TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
 
   SensorReadings readings = {
       .patient_pressure = kPa(0),
-      .inflow_pressure_diff = kPa(0),
+      .air_inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
       .fio2 = 0.21f,
-      .inflow = ml_per_min(0),
+      .air_inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
   // need to Run once in order to initialize the volume integrators
@@ -64,13 +64,13 @@ TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
     Pressure outflow_pressure = cmH2O(0.4f + (breath_pos >= 0.5 ? 1.f : 0.f));
     readings = {
         .patient_pressure = kPa(0),
-        .inflow_pressure_diff = inflow_pressure,
+        .air_inflow_pressure_diff = inflow_pressure,
         .outflow_pressure_diff = outflow_pressure,
         .fio2 = 0.21f,
-        .inflow = Sensors::PressureDeltaToFlow(inflow_pressure),
+        .air_inflow = Sensors::PressureDeltaToFlow(inflow_pressure),
         .outflow = Sensors::PressureDeltaToFlow(outflow_pressure),
     };
-    VolumetricFlow uncorrected_flow = readings.inflow - readings.outflow;
+    VolumetricFlow uncorrected_flow = readings.air_inflow - readings.outflow;
     flow_integrator.AddFlow(now, uncorrected_flow);
 
     auto [unused_actuator_state, status] = c.Run(now, params, readings);
@@ -143,10 +143,10 @@ void actuatorsTestSequence(const std::vector<ActuatorsTest> &seq) {
   VentParams last_params = VentParams_init_zero;
   SensorReadings last_readings = {
       .patient_pressure = cmH2O(0),
-      .inflow_pressure_diff = kPa(0),
+      .air_inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
       .fio2 = 0,
-      .inflow = ml_per_min(0),
+      .air_inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
 
@@ -202,10 +202,10 @@ TEST(ControllerTest, ControlLaws) {
   // almost closed and exhale valve in its max openness state.
   SensorReadings readings_pip = {
       .patient_pressure = cmH2O(static_cast<float>(params.pip_cm_h2o)),
-      .inflow_pressure_diff = kPa(0),
+      .air_inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
       .fio2 = AmbientAir,
-      .inflow = ml_per_min(0),
+      .air_inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
 
@@ -215,10 +215,10 @@ TEST(ControllerTest, ControlLaws) {
   // oxygen), whatever the controller gains and desired params are.
   SensorReadings readings_below_pip = {
       .patient_pressure = VeryLowPressure,
-      .inflow_pressure_diff = kPa(0),
+      .air_inflow_pressure_diff = kPa(0),
       .outflow_pressure_diff = kPa(0),
       .fio2 = AmbientAir,
-      .inflow = ml_per_min(0),
+      .air_inflow = ml_per_min(0),
       .outflow = ml_per_min(0),
   };
 

--- a/software/controller/test/sensor_tests/sensors_test.cpp
+++ b/software/controller/test/sensor_tests/sensors_test.cpp
@@ -72,12 +72,14 @@ static SensorReadings update_readings(Duration dt, Pressure oxygen_influx_dp,
                                       Pressure patient_pressure, Pressure air_influx_dp,
                                       Pressure outflow_dp, Pressure p_amb, float fio2,
                                       Sensors *sensors) {
-  hal.TESTSetAnalogPin(AnalogPin::OxygenInflowPressureDiff,
+  hal.TESTSetAnalogPin(PinFor(Sensor::OxygenInflowPressureDiff),
                        MPXV5004_PressureToVoltage(oxygen_influx_dp));
-  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, MPXV5004_PressureToVoltage(patient_pressure));
-  hal.TESTSetAnalogPin(AnalogPin::AirInflowPressureDiff, MPXV5004_PressureToVoltage(air_influx_dp));
-  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, MPXV5004_PressureToVoltage(outflow_dp));
-  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(fio2, p_amb));
+  hal.TESTSetAnalogPin(PinFor(Sensor::PatientPressure),
+                       MPXV5004_PressureToVoltage(patient_pressure));
+  hal.TESTSetAnalogPin(PinFor(Sensor::AirInflowPressureDiff),
+                       MPXV5004_PressureToVoltage(air_influx_dp));
+  hal.TESTSetAnalogPin(PinFor(Sensor::OutflowPressureDiff), MPXV5004_PressureToVoltage(outflow_dp));
+  hal.TESTSetAnalogPin(PinFor(Sensor::FIO2), FIO2ToVoltage(fio2, p_amb));
   hal.Delay(dt);
   return sensors->GetReadings();
 }
@@ -94,12 +96,12 @@ TEST(SensorTests, FullScalePressureReading) {
 
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
-  hal.TESTSetAnalogPin(AnalogPin::OxygenInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::AirInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::OxygenInflowPressureDiff), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::PatientPressure), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::AirInflowPressureDiff), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::OutflowPressureDiff), voltage_at_0kPa);
   // Set fio2 signal to allow calibration
-  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(PinFor(Sensor::FIO2), FIO2ToVoltage(0.21f, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();
@@ -108,20 +110,20 @@ TEST(SensorTests, FullScalePressureReading) {
   // versus what the original pressure waveform was
   for (auto p : pressures) {
     SCOPED_TRACE("Pressure " + std::to_string(p.kPa()));
-    hal.TESTSetAnalogPin(AnalogPin::PatientPressure, MPXV5004_PressureToVoltage(p));
+    hal.TESTSetAnalogPin(PinFor(Sensor::PatientPressure), MPXV5004_PressureToVoltage(p));
     EXPECT_PRESSURE_NEAR(sensors.GetReadings().patient_pressure, p);
   }
 }
 
 TEST(SensorTests, FiO2Reading) {
   // calibrate O2 sensor at 21% fio2, 1atm
-  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(PinFor(Sensor::OxygenInflowPressureDiff), FIO2ToVoltage(0.21f, atm(1.0f)));
   // Set the other sensors to reasonable values to allow calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));
-  hal.TESTSetAnalogPin(AnalogPin::OxygenInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::AirInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::OxygenInflowPressureDiff), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::PatientPressure), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::AirInflowPressureDiff), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::OutflowPressureDiff), voltage_at_0kPa);
 
   Sensors sensors;
   sensors.Calibrate();
@@ -132,7 +134,7 @@ TEST(SensorTests, FiO2Reading) {
   // sweep all fio2 settings and 1 atm pressure
   for (auto fio2 : fio2_settings) {
     SCOPED_TRACE("fio2 " + std::to_string(fio2));
-    hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(fio2, atm(1.0f)));
+    hal.TESTSetAnalogPin(PinFor(Sensor::FIO2), FIO2ToVoltage(fio2, atm(1.0f)));
     EXPECT_NEAR(sensors.GetReadings().fio2, fio2, ComparisonToleranceFIO2);
   }
   // TODO: check the effect of ambient pressure once the system has a way to
@@ -163,12 +165,12 @@ TEST(SensorTests, TotalFlowCalculation) {
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));  //[V]
-  hal.TESTSetAnalogPin(AnalogPin::OxygenInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::AirInflowPressureDiff, voltage_at_0kPa);
-  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff, voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::OxygenInflowPressureDiff), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::PatientPressure), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::AirInflowPressureDiff), voltage_at_0kPa);
+  hal.TESTSetAnalogPin(PinFor(Sensor::OutflowPressureDiff), voltage_at_0kPa);
   // Set fio2 signal to allow calibration
-  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(PinFor(Sensor::FIO2), FIO2ToVoltage(0.21f, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();
@@ -191,18 +193,18 @@ TEST(SensorTests, Calibration) {
   // First set the simulated analog signals to randomly chosen signals
   // corresponding to conditions during calibration
   Pressure init_oxy_inflow_delta = kPa(0.09f);
-  hal.TESTSetAnalogPin(AnalogPin::OxygenInflowPressureDiff,
+  hal.TESTSetAnalogPin(PinFor(Sensor::OxygenInflowPressureDiff),
                        MPXV5004_PressureToVoltage(init_oxy_inflow_delta));
   Pressure init_pressure = kPa(0.23f);
-  hal.TESTSetAnalogPin(AnalogPin::PatientPressure, MPXV5004_PressureToVoltage(init_pressure));
+  hal.TESTSetAnalogPin(PinFor(Sensor::PatientPressure), MPXV5004_PressureToVoltage(init_pressure));
   Pressure init_air_inflow_delta = kPa(0.15f);
-  hal.TESTSetAnalogPin(AnalogPin::AirInflowPressureDiff,
+  hal.TESTSetAnalogPin(PinFor(Sensor::AirInflowPressureDiff),
                        MPXV5004_PressureToVoltage(init_air_inflow_delta));
   Pressure init_outflow_delta = kPa(-0.13f);
-  hal.TESTSetAnalogPin(AnalogPin::OutflowPressureDiff,
+  hal.TESTSetAnalogPin(PinFor(Sensor::OutflowPressureDiff),
                        MPXV5004_PressureToVoltage(init_outflow_delta));
   float init_fio2 = 0.15f;
-  hal.TESTSetAnalogPin(AnalogPin::FIO2, FIO2ToVoltage(init_fio2, atm(1.0f)));
+  hal.TESTSetAnalogPin(PinFor(Sensor::FIO2), FIO2ToVoltage(init_fio2, atm(1.0f)));
 
   Sensors sensors;
   sensors.Calibrate();

--- a/software/utils/debug/test_scenario.py
+++ b/software/utils/debug/test_scenario.py
@@ -137,7 +137,12 @@ class TestScenario:
             ts.capture_duration_secs = 30
             ts.capture_ignore_secs = 10
             ts.trace_period = 1
-            ts.trace_variable_names = ["pc_setpoint", "pressure", "volume", "net_flow"]
+            ts.trace_variable_names = [
+                "pc_setpoint",
+                "patient_pressure_dp",
+                "volume",
+                "net_flow",
+            ]
 
             for k in row_copy.keys():
                 if k in ventilator_settings:

--- a/software/utils/debug/test_scenarios/dummy.json
+++ b/software/utils/debug/test_scenarios/dummy.json
@@ -16,7 +16,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],

--- a/software/utils/debug/test_scenarios/iso_pressure_tests.json
+++ b/software/utils/debug/test_scenarios/iso_pressure_tests.json
@@ -19,7 +19,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -47,7 +47,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -75,7 +75,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -103,7 +103,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -131,7 +131,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -159,7 +159,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -187,7 +187,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -215,7 +215,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -243,7 +243,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -271,7 +271,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -299,7 +299,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -327,7 +327,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -355,7 +355,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -383,7 +383,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -411,7 +411,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -439,7 +439,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -467,7 +467,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -495,7 +495,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -523,7 +523,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -551,7 +551,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -579,7 +579,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],

--- a/software/utils/debug/test_scenarios/iso_volume_tests.json
+++ b/software/utils/debug/test_scenarios/iso_volume_tests.json
@@ -19,7 +19,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -45,7 +45,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -71,7 +71,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -97,7 +97,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -123,7 +123,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -149,7 +149,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -175,7 +175,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -201,7 +201,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -227,7 +227,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -253,7 +253,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -279,7 +279,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -305,7 +305,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -331,7 +331,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -357,7 +357,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -383,7 +383,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -409,7 +409,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -435,7 +435,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -461,7 +461,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -487,7 +487,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -513,7 +513,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],
@@ -539,7 +539,7 @@
         "trace_period": 1,
         "trace_variable_names": [
             "pc_setpoint",
-            "pressure",
+            "patient_pressure_dp",
             "volume",
             "net_flow"
         ],


### PR DESCRIPTION
# Description

* adds 5th ADC value to be read by the HAL and ADC modules - appears to have been partially implemented in the ADC module at the first position, so I have kept this convention on the level of the ADC mappings
* adds mappings for oxygen influx dP sensor in Sensors module
* removes the uncorrected flow debug variable from Sensors, as there is already one present in Controller
* removed unused dP values from sensors return struct, these used to be written to proto buffer message, but are never used, for now we zero the proto values, but should remove form definition in the future
* sensor logical mappings removed from class and made more explicit, low level pin mappings in HAL and ADC reflect physical labeling on PCBs
* New abstractions for `AnalogSensor`, `PressureSensor`, `Venturi`, etc.. -- all under the `lib/sensors` subdirectory. Should be easier to extend in the future for other sensor hardware. All of them manage their own debug variables.
* Controller debug variables are now class member variables.
* Controller tests now use logical sensor mappings -- previous assumption was that the mappings followed the same sequential order as in HAL/ADC :man_facepalming:
* There is now potential for improved more granular testing, since some of the dependencies have been disentangled.
* Added TODOs all over Sensors and ADC modules where clarification is needed.
* Interim board analog dP still appears to be not working. It is not clear if this is an electronics or software problem.

Updates #1155

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [ ] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
