### PR TITLE
fix error in debug script on trace save

### DIFF
--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -325,7 +325,7 @@ class ControllerDebugInterface:
     def trace_save(self, scenario_name="manual_trace"):
         test = TestData(test_scenario.TestScenario())
         test.traces = self.trace_download()
-        time_series = test.traces[0]
+        time_series = test.traces[0].data
         test.scenario.capture_duration_secs = (
             time_series[len(time_series) - 1] - time_series[0]
         )


### PR DESCRIPTION
# Description

Fixes issue encountered in testing:

`sn-7] trace save -p
Traceback (most recent call last):
  File "./debug_cli.py", line 136, in cli_loop
    return cmd.Cmd.cmdloop(self)
  File "/usr/lib/python3.6/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.6/cmd.py", line 217, in onecmd
    return func(arg)
  File "./debug_cli.py", line 675, in do_trace
    test = self.interface.trace_save()
  File "/data/RespiraWorks/VentilatorSoftware/software/utils/debug/controller_debug.py", line 330, in trace_save
    time_series[len(time_series) - 1] - time_series[0]
TypeError: object of type 'Trace' has no len()`

# General checklist:

- [ ] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [ ] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [ ] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [ ] All new content is linked, easily discoverable, does not require too many clicks
- [ ] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [ ] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [ ] I have tagged relevant reviewers

## Code checklist:

- [ ] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [ ] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [ ] I performed a clean build and verified that there were no warnings
- [ ] I ran our static analysis tools and verified there were no warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All source files have license headers
