### PR TITLE
Get readings for daughterboard analog pressure sensor

### DIFF
--- a/manufacturing/internals/README.md
+++ b/manufacturing/internals/README.md
@@ -134,13 +134,16 @@ Use the following principles to guide this process:
 Connect the tubing as follows
 * upstream port on the `air influx venturi` to upper port on the `INHALE FLOW` sensor on the PCB
 * downstream port on the `air influx venturi` to lower port on the `INHALE FLOW` sensor on the PCB
-* upstream port on the `oxygen influx venturi` to upper port on the pressure sensor on the daughter-card
-* downstream port on the `oxygen influx venturi` to lower port on the pressure sensor on the daughter-card
 * downstream port on the `exhale venturi` to lower port on the `EXHALE FLOW` sensor on the PCB
 * upstream port on the `exhale venturi` to wye splitter `[A22]`
-* wye splitter `[A22]` to the upper port on the `PATIENT PRESSURE` sensor on the PCB
+* wye splitter `[A22]` to the upper port on the pressure sensor on the daughter-card
 * wye splitter `[A22]` to the upper port on the `EXHALE FLOW` sensor on the PCB
-* the lower port on the `PATIENT PRESSURE` sensor remains open to atmosphere
+* the lower port on the pressure sensor on the daughter-card remains open to atmosphere
+* upstream port on the `oxygen influx venturi` to upper port on the `PATIENT PRESSURE` sensor on the PCB
+* downstream port on the `oxygen influx venturi` to lower port on the `PATIENT PRESSURE` sensor on the PCB
+
+>**TODO:** update drawings with updated tubing (O2 venturi on U3 / patient pressure on the daughter-card)
+> This allows us to take advantage of the higher maximum pressure of the MPXV5010DP sensor on the daughter-card.
 
 | Air influx                     | Oxygen influx                  | Outflow and patient pressure   |
 |:------------------------------:|:------------------------------:|:------------------------------:|

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -21,9 +21,9 @@ limitations under the License.
 //////////////////////////////////////////////////////////////////
 AnalogPin sensor_pin(Sensor s) {
   switch (s) {
-    case Sensor::OxygenInflowPressureDiff:
-      return AnalogPin::InterimBoardAnalogPressure;
     case Sensor::PatientPressure:
+      return AnalogPin::InterimBoardAnalogPressure;
+    case Sensor::OxygenInflowPressureDiff:
       return AnalogPin::U3PatientPressure;
     case Sensor::AirInflowPressureDiff:
       return AnalogPin::U4InhaleFlow;

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -65,7 +65,7 @@ class Sensors {
   SensorReadings get_readings() const;
 
  private:
-  /// \TODO: get this either from IDC constants header or something like that
+  /// \TODO: get this either from ADC constants header or something like that
   static constexpr float ADCVoltageRange{3.3f};
 
   // \TODO: create a physical constants header for custom parts like venturi
@@ -86,7 +86,7 @@ class Sensors {
   TeledyneR24 fio2_sensor_{"fio2", "Fraction of oxygen in supplied air", sensor_pin(Sensor::FIO2)};
   MPXV5004DP air_influx_sensor_dp_{"air_influx_", "for ambient air influx",
                                    sensor_pin(Sensor::AirInflowPressureDiff), ADCVoltageRange};
-  MPXV5004DP oxygen_influx_sensor_dp_{"oxygen_influx_", "for concentrated oxygen influx",
+  MPXV5010DP oxygen_influx_sensor_dp_{"oxygen_influx_", "for concentrated oxygen influx",
                                       sensor_pin(Sensor::OxygenInflowPressureDiff),
                                       ADCVoltageRange};
   MPXV5004DP outflow_sensor_dp_{"outflow_", "for outflow", sensor_pin(Sensor::OutflowPressureDiff),

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -81,12 +81,12 @@ class Sensors {
   static_assert(VenturiChokeDiameter > meters(0));
 
   // Fundamental sensors
-  MPXV5004DP patient_pressure_sensor_{"patient_pressure_", "for patient airway pressure",
+  MPXV5010DP patient_pressure_sensor_{"patient_pressure_", "for patient airway pressure",
                                       sensor_pin(Sensor::PatientPressure), ADCVoltageRange};
   TeledyneR24 fio2_sensor_{"fio2", "Fraction of oxygen in supplied air", sensor_pin(Sensor::FIO2)};
   MPXV5004DP air_influx_sensor_dp_{"air_influx_", "for ambient air influx",
                                    sensor_pin(Sensor::AirInflowPressureDiff), ADCVoltageRange};
-  MPXV5010DP oxygen_influx_sensor_dp_{"oxygen_influx_", "for concentrated oxygen influx",
+  MPXV5004DP oxygen_influx_sensor_dp_{"oxygen_influx_", "for concentrated oxygen influx",
                                       sensor_pin(Sensor::OxygenInflowPressureDiff),
                                       ADCVoltageRange};
   MPXV5004DP outflow_sensor_dp_{"outflow_", "for outflow", sensor_pin(Sensor::OutflowPressureDiff),

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -39,7 +39,7 @@ MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, AnalogPin 
 
 // Vout = Vss * (0.09 * P + 0.04) between 0 and 5 V :
 // https://www.nxp.com/docs/en/data-sheet/MPX5010.pdf
-// Vss = 5, therefore P = Vout * (1 / 0.45)
+// Vss = 5, therefore P = (Vout - Vzero) * (1 / 0.45)
 //
 // voltage_range is whatever the voltage is scaled to as captured by your ADC.
 // Therefore, if we multiply the received voltage by 5/voltage_range and divide it by 0.45, we get a

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -36,3 +36,14 @@ Pressure AnalogPressureSensor::read(HalApi &hal_api) const {
 MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, AnalogPin pin,
                        float voltage_range)
     : AnalogPressureSensor(name, help_supplement, pin, 5.f / voltage_range) {}
+
+// Vout = Vss * (0.09 * P + 0.04) between 0 and 5 V :
+// https://www.nxp.com/docs/en/data-sheet/MPX5010.pdf
+// Vss = 5, therefore P = Vout * (1 / 0.45)
+//
+// voltage_range is whatever the voltage is scaled to as captured by your ADC.
+// Therefore, if we multiply the received voltage by 5/voltage_range and divide it by 0.45, we get a
+// pressure in kPa.
+MPXV5010DP::MPXV5010DP(const char *name, const char *help_supplement, AnalogPin pin,
+                       float voltage_range)
+    : AnalogPressureSensor(name, help_supplement, pin, 5.f / voltage_range / 0.45f) {}

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -33,8 +33,16 @@ class MPXV5004DP : public AnalogPressureSensor {
  public:
   MPXV5004DP(const char *name, const char *help_supplement, AnalogPin pin, float voltage_range);
 
-  // min/max possible reading from MPXV5004GP pressure sensors
+  // min/max possible reading from MPXV5004DP pressure sensors
   // \TODO: are we supposed to use these somehow?
   constexpr static Pressure MinPressure{kPa(0.0f)};
   constexpr static Pressure MaxPressure{kPa(3.92f)};
+};
+
+class MPXV5010DP : public AnalogPressureSensor {
+ public:
+  MPXV5010DP(const char *name, const char *help_supplement, AnalogPin pin, float voltage_range);
+  // min/max possible reading from MPXV5010DP pressure sensors
+  constexpr static Pressure MinPressure{kPa(0.0f)};
+  constexpr static Pressure MaxPressure{kPa(10.0f)};
 };

--- a/software/controller/test/sensor_tests/sensors_test.cpp
+++ b/software/controller/test/sensor_tests/sensors_test.cpp
@@ -65,6 +65,14 @@ static Voltage MPXV5004_PressureToVoltage(Pressure pressure) {
   return volts(3.3f * (0.2f * pressure.kPa() + 0.2f));
 }
 
+// @brief This method models the pressure to voltage transfer function of the
+// MPXV5010 series sensors.  The raw voltage coming out of the sensor would be
+// 5 * 0.45 * (...), but our board scales it down to 3.3f * (...) so that the
+// pressure range (0-10kPa) is in the voltage range 0-3.3V.
+
+static Voltage MPXV5010_PressureToVoltage(Pressure pressure) {
+  return volts(3.3f * (0.09f * pressure.kPa() + 0.04f));
+}
 // This method models the oxygen sensor. Voltage reads partial pressure of O2
 // and needs ambient pressure to modulate output voltage.
 // Sensitivity is 0.061 V/pt at 1 atm and assumed to vary linearly with pressure
@@ -80,10 +88,11 @@ static SensorReadings update_readings(Duration dt, Pressure oxygen_influx_dp,
                                       Pressure patient_pressure, Pressure air_influx_dp,
                                       Pressure outflow_dp, Pressure p_amb, float fio2,
                                       Sensors *sensors) {
+  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure),
+                       MPXV5010_PressureToVoltage(patient_pressure));
+
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OxygenInflowPressureDiff),
                        MPXV5004_PressureToVoltage(oxygen_influx_dp));
-  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure),
-                       MPXV5004_PressureToVoltage(patient_pressure));
   hal.TESTSetAnalogPin(sensor_pin(Sensor::AirInflowPressureDiff),
                        MPXV5004_PressureToVoltage(air_influx_dp));
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OutflowPressureDiff),
@@ -101,12 +110,11 @@ TEST(SensorTests, FullScalePressureReading) {
 
   // Will pad the rest of the simulated analog signals with ambient pressure
   // readings (0 kPa) voltage equivalents
-  Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));  //[V]
-
+  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), MPXV5010_PressureToVoltage(kPa(0)));
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
+  Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));  //[V]
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OxygenInflowPressureDiff), voltage_at_0kPa);
-  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), voltage_at_0kPa);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::AirInflowPressureDiff), voltage_at_0kPa);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OutflowPressureDiff), voltage_at_0kPa);
   // Set fio2 signal to allow calibration
@@ -119,7 +127,7 @@ TEST(SensorTests, FullScalePressureReading) {
   // versus what the original pressure waveform was
   for (auto p : pressures) {
     SCOPED_TRACE("Pressure " + std::to_string(p.kPa()));
-    hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), MPXV5004_PressureToVoltage(p));
+    hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), MPXV5010_PressureToVoltage(p));
     EXPECT_PRESSURE_NEAR(sensors.get_readings().patient_pressure, p);
   }
 }
@@ -128,10 +136,10 @@ TEST(SensorTests, FiO2Reading) {
   // calibrate O2 sensor at 21% fio2, 1atm
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OxygenInflowPressureDiff),
                        FIO2ToVoltage(0.21f, atm(1.0f)));
+  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), MPXV5010_PressureToVoltage(kPa(0)));
   // Set the other sensors to reasonable values to allow calibration
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OxygenInflowPressureDiff), voltage_at_0kPa);
-  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), voltage_at_0kPa);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::AirInflowPressureDiff), voltage_at_0kPa);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OutflowPressureDiff), voltage_at_0kPa);
 
@@ -179,9 +187,9 @@ TEST(SensorTests, TotalFlowCalculation) {
 
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage during calibration
+  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), MPXV5010_PressureToVoltage(kPa(0)));
   Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0));  //[V]
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OxygenInflowPressureDiff), voltage_at_0kPa);
-  hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure), voltage_at_0kPa);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::AirInflowPressureDiff), voltage_at_0kPa);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::OutflowPressureDiff), voltage_at_0kPa);
   // Set fio2 signal to allow calibration
@@ -215,7 +223,7 @@ TEST(SensorTests, Calibration) {
                        MPXV5004_PressureToVoltage(init_oxy_inflow_delta));
   Pressure init_pressure = kPa(0.23f);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::PatientPressure),
-                       MPXV5004_PressureToVoltage(init_pressure));
+                       MPXV5010_PressureToVoltage(init_pressure));
   Pressure init_air_inflow_delta = kPa(0.15f);
   hal.TESTSetAnalogPin(sensor_pin(Sensor::AirInflowPressureDiff),
                        MPXV5004_PressureToVoltage(init_air_inflow_delta));


### PR DESCRIPTION
# Description

This PR enables us to use the interim daughter-board's analog pressure sensor. Since it supports a bigger pressure range (0-10kPa) than the ones on the mainboard (0-4kPa), it is now used for patient pressure, which is expected to be bigger than the pressure differential across a venturi.
The mainboard U3 sensor (label from its former function "Patient Pressure") can now be used to compute oxygen flow from a third venturi placed on the oxygen limb, which should allow for better oxygen control.

The setup was tested on my own board hooking both U4 pressure sensor and daughter-card analog pressure sensor to the air inlet venturi (using pneumatic Y connectors), and checking that the resulting dp matched.

Closes #1153

Followup that needs to be done: update drawings all over the manufacturing readmes to take the new tubing into account.

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers


