### PR TITLE
FloatArray debug variable type for calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ source/config/*
 *.desktop
 *.user
 *.log
+software/controller/.gitignore
 !.gitignore
 
 #IDE

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ source/config/*
 *.desktop
 *.user
 *.log
-software/controller/.gitignore
 !.gitignore
+software/controller/.gitignore
 
 #IDE
 CMakeLists*

--- a/software/controller/.gitignore
+++ b/software/controller/.gitignore
@@ -1,0 +1,3 @@
+.pio
+CMakeListsPrivate.txt
+cmake-build-*/

--- a/software/controller/.gitignore
+++ b/software/controller/.gitignore
@@ -1,3 +1,0 @@
-.pio
-CMakeListsPrivate.txt
-cmake-build-*/

--- a/software/controller/integration_tests/pinch_valve_test.h
+++ b/software/controller/integration_tests/pinch_valve_test.h
@@ -18,7 +18,7 @@ static constexpr Duration Delay{milliseconds(1000)};
 
 void RunTest() {
   hal.Init();
-  PinchValve pinch_valve(MotorIndex);
+  PinchValve pinch_valve(MotorIndex, "any", " for whatever");
   pinch_valve.Home();
 
   bool valve_open{false};

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -19,8 +19,8 @@ limitations under the License.
 #include "pinch_valve.h"
 
 // local data
-static PinchValve blower_pinch(0);
-static PinchValve exhale_pinch(1);
+static PinchValve blower_pinch(0, "blower", " for blower valve");
+static PinchValve exhale_pinch(1, "exhale", " for exhale valve");
 
 // Called once at system startup to initialize any
 // actuators that need it

--- a/software/controller/lib/core/pinch_valve.cpp
+++ b/software/controller/lib/core/pinch_valve.cpp
@@ -76,7 +76,23 @@ static constexpr float MoveAccel = MoveVel / 0.05f;
 static constexpr float FlowTable[] = {0.0000f, 0.0410f, 0.0689f, 0.0987f, 0.1275f, 0.1590f,
                                       0.1932f, 0.2359f, 0.2940f, 0.3988f, 1.0000f};
 
-PinchValve::PinchValve(int motor_index) { motor_index_ = motor_index; }
+Debug::Variable::FloatArray<11> PinchValve::calibration =
+    Debug::Variable::FloatArray<11>("pinch_valve_cal", Debug::Variable::Access::ReadWrite, "",
+                                    "Pinch valve linearization table", "[]");
+
+PinchValve::PinchValve(int motor_index) : motor_index_(motor_index) {
+  calibration.data[0] = 0.0000f;
+  calibration.data[1] = 0.0410f;
+  calibration.data[2] = 0.0689f;
+  calibration.data[3] = 0.0987f;
+  calibration.data[4] = 0.1275f;
+  calibration.data[5] = 0.1590f;
+  calibration.data[6] = 0.1932f;
+  calibration.data[7] = 0.2359f;
+  calibration.data[8] = 0.2940f;
+  calibration.data[9] = 0.3988f;
+  calibration.data[10] = 1.0000f;
+}
 
 // Disable the pinch valve
 void PinchValve::Disable() {

--- a/software/controller/lib/core/pinch_valve.cpp
+++ b/software/controller/lib/core/pinch_valve.cpp
@@ -76,9 +76,8 @@ static constexpr float MoveAccel = MoveVel / 0.05f;
 static constexpr float FlowTable[] = {0.0000f, 0.0410f, 0.0689f, 0.0987f, 0.1275f, 0.1590f,
                                       0.1932f, 0.2359f, 0.2940f, 0.3988f, 1.0000f};
 
-Debug::Variable::FloatArray<11> PinchValve::calibration =
-    Debug::Variable::FloatArray<11>("pinch_valve_cal", Debug::Variable::Access::ReadWrite, "",
-                                    "Pinch valve linearization table", "[]");
+Debug::Variable::FloatArray<11> PinchValve::calibration = Debug::Variable::FloatArray<11>(
+    "pinch_valve_cal", Debug::Variable::Access::ReadWrite, "", "Pinch valve linearization table");
 
 PinchValve::PinchValve(int motor_index) : motor_index_(motor_index) {
   calibration.data[0] = 0.0000f;

--- a/software/controller/lib/core/pinch_valve.h
+++ b/software/controller/lib/core/pinch_valve.h
@@ -47,16 +47,9 @@ enum class PinchValveHomeState {
 
 class PinchValve {
  public:
-  // This table is used to roughly linearize the pinch valve output.  It was built by adjusting the
-  // pinch valve and monitoring the flow through the venturi tube. The entries should give pinch
-  // valve settings for a list of equally spaced flow rates.  The first entry should be the setting
-  // for 0 flow rate (normally 0) and the last entry should be the setting for 100% flow rate. The
-  // minimum length of the table is 2 entries.
-  static Debug::Variable::FloatArray<11> calibration;
-
   // Create a new pinch valve using the specified
   // stepper motor.
-  explicit PinchValve(int motor_index);
+  explicit PinchValve(int motor_index, const char* name_prepend, const char* help_append);
 
   // Initialize the pinch value absolute position.
   // This should be called at startup from the
@@ -84,9 +77,17 @@ class PinchValve {
  private:
   Time move_start_time_;
 
-  int motor_index_;
+  // \todo test invalid initialization?
+  int motor_index_{-1};
 
   float last_command_{-1.0f};
 
   PinchValveHomeState home_state_{PinchValveHomeState::Disabled};
+
+  // This table is used to roughly linearize the pinch valve output.  It was built by adjusting the
+  // pinch valve and monitoring the flow through the venturi tube. The entries should give pinch
+  // valve settings for a list of equally spaced flow rates.  The first entry should be the setting
+  // for 0 flow rate (normally 0) and the last entry should be the setting for 100% flow rate. The
+  // minimum length of the table is 2 entries.
+  Debug::Variable::FloatArray<11> calibration_;
 };

--- a/software/controller/lib/core/pinch_valve.h
+++ b/software/controller/lib/core/pinch_valve.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "stepper.h"
 #include "units.h"
+#include "vars.h"
 
 enum class PinchValveHomeState {
   Disabled,
@@ -46,6 +47,13 @@ enum class PinchValveHomeState {
 
 class PinchValve {
  public:
+  // This table is used to roughly linearize the pinch valve output.  It was built by adjusting the
+  // pinch valve and monitoring the flow through the venturi tube. The entries should give pinch
+  // valve settings for a list of equally spaced flow rates.  The first entry should be the setting
+  // for 0 flow rate (normally 0) and the last entry should be the setting for 100% flow rate. The
+  // minimum length of the table is 2 entries.
+  static Debug::Variable::FloatArray<11> calibration;
+
   // Create a new pinch valve using the specified
   // stepper motor.
   explicit PinchValve(int motor_index);

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -81,14 +81,14 @@ class PokeHandler : public MemoryHandler {
 //
 // Data passed to the command is a single byte which defines what the command
 // does:
-//  Flush - Used to disable the trace and flush the trace buffer
+//  flush - Used to disable the trace and flush the trace buffer
 //  Download - Used to read data from the buffer
-//  Start - Used to start recording in the trace buffer
+//  start - Used to start recording in the trace buffer
 //  GetVarId followed by var index (1 byte) - Used to get trace variables ID
 //  SetVarId followed by var index (1 byte) and variable ID (2 bytes) - Used to
 //    set traced variable id
-//  GetPeriod - Used to get the trace period
-//  SetPeriod followed by desired trace period (4 bytes) - Used to set the
+//  period - Used to get the trace period
+//  set_period followed by desired trace period (4 bytes) - Used to set the
 //    trace period
 //  CountSamples - Used to get the number of samples currently in the trace
 //    buffer
@@ -102,11 +102,12 @@ class TraceHandler : public Handler {
     Flush = 0x00,     // disable and flush the trace buffer
     Download = 0x01,  // download data from the trace buffer
     Start = 0x02,     // start tracing data
-    GetVarId = 0x03,  // get traced variable id
-    SetVarId = 0x04,  // set traced variable id
-    GetPeriod = 0x05,
-    SetPeriod = 0x06,
-    CountSamples = 0x07,  // get number of samples in the trace buffer
+    Stop = 0x03,      // stop tracing data
+    GetVarId = 0x04,  // get traced variable id
+    SetVarId = 0x05,  // set traced variable id
+    GetPeriod = 0x06,
+    SetPeriod = 0x07,
+    CountSamples = 0x08,  // get number of samples in the trace buffer
   };
 
  private:

--- a/software/controller/lib/debug/commands.h
+++ b/software/controller/lib/debug/commands.h
@@ -81,14 +81,15 @@ class PokeHandler : public MemoryHandler {
 //
 // Data passed to the command is a single byte which defines what the command
 // does:
-//  flush - Used to disable the trace and flush the trace buffer
+//  Flush - Used to disable the trace and flush the trace buffer
 //  Download - Used to read data from the buffer
-//  start - Used to start recording in the trace buffer
+//  Start - Used to start recording in the trace buffer
+//  Stop - Used to stop recording in the trace buffer
 //  GetVarId followed by var index (1 byte) - Used to get trace variables ID
 //  SetVarId followed by var index (1 byte) and variable ID (2 bytes) - Used to
 //    set traced variable id
-//  period - Used to get the trace period
-//  set_period followed by desired trace period (4 bytes) - Used to set the
+//  GetPeriod - Used to get the trace period
+//  SetPeriod followed by desired trace period (4 bytes) - Used to set the
 //    trace period
 //  CountSamples - Used to get the number of samples currently in the trace
 //    buffer

--- a/software/controller/lib/debug/debug_types.h
+++ b/software/controller/lib/debug/debug_types.h
@@ -35,7 +35,7 @@ enum class ErrorCode : uint8_t {
   NoMemory = 0x04,         // Insufficient memory
   InternalError = 0x05,    // Some type of internal error (aka bug)
   UnknownVariable = 0x06,  // The requested variable ID is invalid
-  InvalidData = 0x07,      // Data is out of range
+  InvalidData = 0x07,      // Invalid data in request
   Timeout = 0x08,          // Response timeout
 };
 

--- a/software/controller/lib/debug/interface.h
+++ b/software/controller/lib/debug/interface.h
@@ -64,7 +64,7 @@ class Interface {
 
   static uint16_t ComputeCRC(const uint8_t *buffer, size_t length);
 
-  void SampleTraceVars() { trace_->MaybeSample(); }
+  void SampleTraceVars() { trace_->maybe_sample(); }
 
  private:
   State state_{State::AwaitingCommand};

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -62,12 +62,9 @@ uint16_t Trace::GetNumActiveVars() {
 }
 
 bool Trace::SetTracedVarId(uint8_t index, uint16_t id) {
-  if (index >= MaxVars) {
-    return false;
-  }
   auto var_ptr = Variable::Registry::singleton().find(id);
-  if (var_ptr->size() != sizeof(uint32_t)) {
-    return false;
+  if (var_ptr && (var_ptr->size() != sizeof(uint32_t))) {
+    var_ptr = nullptr;
   }
   traced_vars_[index] = var_ptr;
   // like in the SetTraceVarId<int index> template, we need to flush the buffer

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -62,7 +62,7 @@ bool Trace::set_traced_variable(uint8_t index, uint16_t variable_registry_id) {
     traced_vars_[index] = nullptr;
     return true;
   }
-  auto var_ptr = Variable::Registry::singleton().find(variable_registry_id);
+  auto *var_ptr = Variable::Registry::singleton().find(variable_registry_id);
   if (!var_ptr || (var_ptr->size() != sizeof(uint32_t))) {
     // variable not found or type is not of correct size
     return false;
@@ -82,10 +82,9 @@ uint16_t Trace::traced_variable(uint8_t index) {
 }
 
 [[nodiscard]] bool Trace::get_next_record(std::array<uint32_t, MaxVars> *record, size_t *count) {
-  // Grab one sample with interrupts disabled.
-  // There's a chance the trace is still running, so we could get interrupted
-  // by the high priority thread that adds to the buffer.
-  // I want to make sure I read a full sample without being interrupted.
+  // Grab one sample with interrupts disabled. There's a chance the trace is still running, so we
+  // could get interrupted by the high priority thread that adds to the buffer.
+  // We want to make sure we read a full sample without being interrupted.
   *count = 0;
   BlockInterrupts block;
   for (auto *var : traced_vars_) {

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -85,6 +85,7 @@ class Trace {
 
   std::array<Variable::Base *, MaxVars> traced_vars_ = {nullptr};
 
+  uint32_t temp_variable_value_{0};
   CircularBuffer<uint32_t, BufferSize> trace_buffer_;
 };
 

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -41,13 +41,13 @@ class Trace {
   // 40% of the RAM available on our STM32
   static constexpr size_t BufferSize{0x4000};
 
-  /// \returns false if manually stopped or stopped on its own when buffer was filled
+  /// \returns false if manually stopped or autostopped when buffer was filled
   bool running() const;
 
-  /// \brief starts acquisition, which will continue until buffer is full or explicitly stopped
+  /// \brief starts acquisition; or restarts if already started (flushes)
   void start();
 
-  /// \brief stops acquisition
+  /// \brief stops acquisition, does not flush
   void stop();
 
   /// \returns number of cycles that Trace will wait before sampling variables

--- a/software/controller/lib/debug/trace.h
+++ b/software/controller/lib/debug/trace.h
@@ -54,7 +54,7 @@ class Trace {
   uint32_t period() const;
 
   /// \param period number of cycles that Trace should wait before sampling variables
-  void set_period(uint32_t period);
+  void set_period(const uint32_t period);
 
   /// \brief Called fromm looping function. It may capture data if cycle count has been reached.
   /// \post If cycle count was reached, the cycle counter will be reset.

--- a/software/controller/lib/debug/trace_cmd.cpp
+++ b/software/controller/lib/debug/trace_cmd.cpp
@@ -110,7 +110,7 @@ ErrorCode TraceHandler::ReadTraceBuffer(Context *context) {
     samples_count = max_samples;
   }
 
-  std::array<uint32_t, MaxTraceVars> record;
+  std::array<uint32_t, Trace::MaxVars> record;
   for (size_t sample = 0; sample < samples_count; sample++) {
     // This shouldn't fail since I've already confirmed
     // the number of elements in the buffer.  If it does

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -126,11 +126,10 @@ ErrorCode VarHandler::GetVar(Context *context) {
   uint32_t intermediate_buffer[size / sizeof(uint32_t)];
   var->get_value(intermediate_buffer);
 
-  uint32_t *ptr = intermediate_buffer;
+  // endian conversion
   for (size_t i = 0; i < size / sizeof(uint32_t); i++) {
-    u32_to_u8(*ptr, context->response);
+    u32_to_u8(intermediate_buffer[i], context->response);
     context->response += sizeof(uint32_t);
-    ptr++;
   }
   context->response_length = static_cast<uint32_t>(var->size());
 
@@ -154,13 +153,12 @@ ErrorCode VarHandler::SetVar(Context *context) {
 
   if (!var->write_allowed()) return ErrorCode::InternalError;
 
+  // endian conversion
   uint32_t intermediate_buffer[size / sizeof(uint32_t)];
-  uint32_t *ptr = intermediate_buffer;
-  auto request_ptr = context->request + 3;
+  const auto *request_ptr = context->request + 3;
   for (size_t i = 0; i < size / sizeof(uint32_t); i++) {
-    *ptr = u8_to_u32(request_ptr);
+    intermediate_buffer[i] = u8_to_u32(request_ptr);
     request_ptr += sizeof(uint32_t);
-    ptr++;
   }
 
   var->set_value(intermediate_buffer);

--- a/software/controller/lib/debug/var_cmd.cpp
+++ b/software/controller/lib/debug/var_cmd.cpp
@@ -123,12 +123,17 @@ ErrorCode VarHandler::GetVar(Context *context) {
   auto size = var->size();
   if (context->max_response_length < size) return ErrorCode::NoMemory;
 
-  // \todo generalize for other sizes
-  uint32_t temp_variable_value{0};
-  var->get_value(&temp_variable_value);
+  uint32_t intermediate_buffer[size / sizeof(uint32_t)];
+  var->get_value(intermediate_buffer);
 
-  u32_to_u8(temp_variable_value, context->response);
+  uint32_t *ptr = intermediate_buffer;
+  for (size_t i = 0; i < size / sizeof(uint32_t); i++) {
+    u32_to_u8(*ptr, context->response);
+    context->response += sizeof(uint32_t);
+    ptr++;
+  }
   context->response_length = static_cast<uint32_t>(var->size());
+
   *(context->processed) = true;
   return ErrorCode::None;
 }

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include <array>
 #include <cstring>
 
 #include "vars_base.h"
@@ -108,6 +109,22 @@ class Float : public Primitive32 {
 
  private:
   float value_;
+};
+
+template <size_t N>
+class FloatArray : public Base {
+ public:
+  FloatArray(const char *name, Access access, const char *units, const char *help = "",
+             const char *fmt = "%.3f")
+      : Base(Type::FloatArray, name, access, units, help, fmt) {}
+
+  void get_value(void *write_buff) override { std::memcpy(write_buff, data.data(), size()); }
+
+  void set_value(void *read_buf) override { std::memcpy(data.data(), read_buf, size()); }
+
+  size_t size() const override { return 4 * N; }
+
+  std::array<float, N> data;
 };
 
 }  // namespace Debug::Variable

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -29,9 +29,9 @@ class FnVar32 : public Base {
           const char *help, const char *fmt = "")
       : Base(type, name, access, units, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {}
 
-  void get_value(void *write_buff) override { get_fn_(write_buff); }
-  void set_value(void *read_buf) override { set_fn_(read_buf); }
-  size_t size() const override { return sizeof(uint32_t); }
+  void serialize_value(void *write_buff) override { get_fn_(write_buff); }
+  void deserialize_value(const void *read_buf) override { set_fn_(read_buf); }
+  size_t byte_size() const override { return sizeof(uint32_t); }
 
  private:
   GetFn get_fn_;
@@ -57,12 +57,16 @@ class Primitive32 : public Base {
       : Primitive32(Type::Float, name, access, data, units, help, fmt) {}
 
   // Gets the current value of the variable as an uint32_t.
-  void get_value(void *write_buff) override { std::memcpy(write_buff, address_, size()); }
+  void serialize_value(void *write_buff) override {
+    std::memcpy(write_buff, address_, byte_size());
+  }
 
   // Sets the current value of the variable as an uint32_t.
-  void set_value(void *read_buf) override { std::memcpy(address_, read_buf, size()); }
+  void deserialize_value(const void *read_buf) override {
+    std::memcpy(address_, read_buf, byte_size());
+  }
 
-  size_t size() const override { return 4; }
+  size_t byte_size() const override { return 4; }
 
  private:
   void *address_;
@@ -128,11 +132,15 @@ class FloatArray : public Base {
              const char *help = "", const char *fmt = "%.3f")
       : Base(Type::FloatArray, name, access, units, help, fmt), data(initial) {}
 
-  void get_value(void *write_buff) override { std::memcpy(write_buff, data.data(), size()); }
+  void serialize_value(void *write_buff) override {
+    std::memcpy(write_buff, data.data(), byte_size());
+  }
 
-  void set_value(void *read_buf) override { std::memcpy(data.data(), read_buf, size()); }
+  void deserialize_value(const void *read_buf) override {
+    std::memcpy(data.data(), read_buf, byte_size());
+  }
 
-  size_t size() const override { return 4 * N; }
+  size_t byte_size() const override { return 4 * N; }
 
   std::array<float, N> data;
 };

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -120,7 +120,9 @@ class FloatArray : public Base {
 
   FloatArray(const char *name, Access access, float initial_fill, const char *units,
              const char *help = "", const char *fmt = "%.3f")
-      : Base(Type::FloatArray, name, access, units, help, fmt), data(initial_fill) {}
+      : Base(Type::FloatArray, name, access, units, help, fmt) {
+    data.fill(initial_fill);
+  }
 
   FloatArray(const char *name, Access access, std::array<float, N> initial, const char *units,
              const char *help = "", const char *fmt = "%.3f")

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -22,14 +22,15 @@ limitations under the License.
 namespace Debug::Variable {
 
 template <typename GetFn, typename SetFn>
-class FnVar : public Base {
+class FnVar32 : public Base {
  public:
-  FnVar(Type type, const char *name, Access access, const char *units, GetFn get_fn, SetFn set_fn,
-        const char *help, const char *fmt = "")
+  FnVar32(Type type, const char *name, Access access, const char *units, GetFn get_fn, SetFn set_fn,
+          const char *help, const char *fmt = "")
       : Base(type, name, access, units, help, fmt), get_fn_(get_fn), set_fn_(set_fn) {}
 
-  uint32_t get_value() override { return get_fn_(); }
-  void set_value(uint32_t value) override { set_fn_(value); }
+  void get_value(void *write_buff) override { get_fn_(write_buff); }
+  void set_value(void *read_buf) override { set_fn_(read_buf); }
+  size_t size() const override { return sizeof(uint32_t); }
 
  private:
   GetFn get_fn_;
@@ -55,14 +56,12 @@ class Primitive32 : public Base {
       : Primitive32(Type::Float, name, access, data, units, help, fmt) {}
 
   // Gets the current value of the variable as an uint32_t.
-  uint32_t get_value() override {
-    uint32_t res;
-    std::memcpy(&res, address_, 4);
-    return res;
-  }
+  void get_value(void *write_buff) override { std::memcpy(write_buff, address_, size()); }
 
   // Sets the current value of the variable as an uint32_t.
-  void set_value(uint32_t value) override { std::memcpy(address_, &value, 4); }
+  void set_value(void *read_buf) override { std::memcpy(address_, read_buf, size()); }
+
+  size_t size() const override { return 4; }
 
  private:
   void *address_;

--- a/software/controller/lib/debugvars/vars.h
+++ b/software/controller/lib/debugvars/vars.h
@@ -118,6 +118,14 @@ class FloatArray : public Base {
              const char *fmt = "%.3f")
       : Base(Type::FloatArray, name, access, units, help, fmt) {}
 
+  FloatArray(const char *name, Access access, float initial_fill, const char *units,
+             const char *help = "", const char *fmt = "%.3f")
+      : Base(Type::FloatArray, name, access, units, help, fmt), data(initial_fill) {}
+
+  FloatArray(const char *name, Access access, std::array<float, N> initial, const char *units,
+             const char *help = "", const char *fmt = "%.3f")
+      : Base(Type::FloatArray, name, access, units, help, fmt), data(initial) {}
+
   void get_value(void *write_buff) override { std::memcpy(write_buff, data.data(), size()); }
 
   void set_value(void *read_buf) override { std::memcpy(data.data(), read_buf, size()); }

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -65,9 +65,14 @@ class Base {
   Base(Type type, const char *name, Access access, const char *units, const char *help,
        const char *fmt = "");
 
-  virtual void get_value(void *write_buff) = 0;
-  virtual void set_value(void *read_buf) = 0;
-  virtual size_t size() const = 0;
+  /// \brief should write its value to buffer of sufficient size
+  virtual void serialize_value(void *write_buffer) = 0;
+
+  /// \brief retrieves its own value from buffer
+  virtual void deserialize_value(const void *read_buffer) = 0;
+
+  /// \returns number of bytes occupied by value, so caller can ensure sufficient size of buffer
+  virtual size_t byte_size() const = 0;
 
   const char *name() const;
   void prepend_name(const char *prefix);

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace Debug::Variable {
@@ -63,8 +64,9 @@ class Base {
   Base(Type type, const char *name, Access access, const char *units, const char *help,
        const char *fmt = "");
 
-  virtual uint32_t get_value() = 0;
-  virtual void set_value(uint32_t value) = 0;
+  virtual void get_value(void *write_buff) = 0;
+  virtual void set_value(void *read_buf) = 0;
+  virtual size_t size() const = 0;
 
   const char *name() const;
   void prepend_name(const char *prefix);

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -26,6 +26,7 @@ enum class Type {
   Int32 = 1,
   UInt32 = 2,
   Float = 3,
+  FloatArray = 4,
 };
 
 // Defines the possible access to variable

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -37,7 +37,7 @@ enum class Access {
 
 static constexpr uint16_t MaxVariableCount{100};
 
-static constexpr uint16_t InvalidID{MaxVariableCount + 1};
+static constexpr uint16_t InvalidID{MaxVariableCount};
 
 /*! \class Base vars_base.h "vars_base.h"
  *  \brief Abstract base class for debug variables

--- a/software/controller/lib/hal/circular_buffer.h
+++ b/software/controller/lib/hal/circular_buffer.h
@@ -15,8 +15,7 @@ limitations under the License.
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <optional>
 
 #include "hal.h"
@@ -27,7 +26,7 @@ limitations under the License.
 // and the interrupt handlers, so it needs to be thread safe.
 // I'm disabling interrupts during the critical sections to
 // ensure that's the case.
-template <class T, uint N>
+template <class T, size_t N>
 class CircularBuffer {
   // Uses an array of size N+1 to hold all N elements of the buffer, as
   // buffer_[head_] is by definition inaccessible.
@@ -37,7 +36,7 @@ class CircularBuffer {
 
  public:
   CircularBuffer() {
-    for (uint i = 0; i <= N; ++i) buffer_[i] = T();
+    for (size_t i = 0; i <= N; ++i) buffer_[i] = T();
   }
 
   // Return number of elements available in the buffer to read.

--- a/software/controller/lib/hal/circular_buffer.h
+++ b/software/controller/lib/hal/circular_buffer.h
@@ -40,16 +40,16 @@ class CircularBuffer {
   }
 
   // Return number of elements available in the buffer to read.
-  int FullCount() const {
+  size_t FullCount() const {
     BlockInterrupts block;
-    int ct = head_ - tail_;
+    ssize_t ct = head_ - tail_;
     if (ct < 0) ct += N + 1;
-    return ct;
+    return static_cast<size_t>(ct);
   }
 
   // Return number of free spaces in the buffer where more
   // elements can be written.
-  int FreeCount() const { return N - FullCount(); }
+  size_t FreeCount() const { return N - FullCount(); }
 
   // Get the oldest element from the buffer, popping it from the buffer.
   std::optional<T> Get() {

--- a/software/controller/lib/hal/circular_buffer.h
+++ b/software/controller/lib/hal/circular_buffer.h
@@ -42,6 +42,7 @@ class CircularBuffer {
   // Return number of elements available in the buffer to read.
   size_t FullCount() const {
     BlockInterrupts block;
+    /// \TODO: ssize_t is likely compiler-dependent; this function could be improved
     ssize_t ct = head_ - tail_;
     if (ct < 0) ct += N + 1;
     return static_cast<size_t>(ct);

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -171,9 +171,9 @@ class Channel {
   //    means we lose the ability to retry a request after an I²C (or DMA)
   //    error.
   uint8_t write_buffer_[WriteBufferSize];
-  uint32_t write_buffer_index_{0};
-  uint32_t write_buffer_start_{0};
-  uint32_t wrapping_index_{WriteBufferSize};
+  size_t write_buffer_index_{0};
+  size_t write_buffer_start_{0};
+  size_t wrapping_index_{WriteBufferSize};
   bool CopyDataToWriteBuffer(const void *data, uint16_t size);
 };
 

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -96,11 +96,11 @@ class Channel {
  protected:
   // We queue of a few requests. The number of requests is arbitrary but
   // should be enough for all intents and purposes.
-  static constexpr uint8_t QueueLength{80};
+  static constexpr size_t QueueLength{80};
 
   // We copy the write data into a buffer to make sure nothing can be lost
   // due to the scope of the caller's variable. This is the buffer size.
-  static constexpr uint32_t WriteBufferSize{4096};
+  static constexpr size_t WriteBufferSize{4096};
 
   // Max retry-after-error allowed for a single request.
   static constexpr int8_t MaxRetries{5};

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -49,9 +49,6 @@ static Debug::Variable::Float forced_fio2(
     "forced_fio2", Debug::Variable::Access::ReadWrite, 21, "%",
     "Target percent oxygen [21, 100]; overrides GUI setting when forced_mode is valid");
 
-static Debug::Variable::FloatArray<5> fa5("float_array_5", Debug::Variable::Access::ReadOnly, "WTF",
-                                          "Some whacko shit", "[]");
-
 static Controller controller;
 static ControllerStatus controller_status;
 static Sensors sensors;
@@ -123,8 +120,6 @@ static void HighPriorityTask(void *arg) {
 // after some basic system init.  Pretty much everything not time critical
 // should go here.
 [[noreturn]] static void BackgroundLoop() {
-  fa5.data[0] = 1.42f;
-
   // Sleep for a few seconds.  In the current iteration of the PCB, the fan
   // briefly turns on when the device starts up.  If we don't wait for the fan
   // to spin down, the sensors will miscalibrate.  This is a hardware issue

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -49,6 +49,9 @@ static Debug::Variable::Float forced_fio2(
     "forced_fio2", Debug::Variable::Access::ReadWrite, 21, "%",
     "Target percent oxygen [21, 100]; overrides GUI setting when forced_mode is valid");
 
+static Debug::Variable::FloatArray<5> fa5("float_array_5", Debug::Variable::Access::ReadOnly, "WTF",
+                                          "Some whacko shit", "[]");
+
 static Controller controller;
 static ControllerStatus controller_status;
 static Sensors sensors;
@@ -120,6 +123,8 @@ static void HighPriorityTask(void *arg) {
 // after some basic system init.  Pretty much everything not time critical
 // should go here.
 [[noreturn]] static void BackgroundLoop() {
+  fa5.data[0] = 1.42f;
+
   // Sleep for a few seconds.  In the current iteration of the PCB, the fan
   // briefly turns on when the device starts up.  If we don't wait for the fan
   // to spin down, the sensors will miscalibrate.  This is a hardware issue

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -39,12 +39,17 @@ void CheckBufferOutput(std::array<uint8_t, kResponseSize> response, uint32_t res
 TEST(TraceHandler, Flush) {
   // define some debug variables
   uint32_t i = 0;
-  Debug::Variable::FnVar var_x(
+  Debug::Variable::FnVar32 var_x(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
-      [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
-  Debug::Variable::FnVar var_y(
+      [&](void *write_buff) { std::memcpy(write_buff, &i, 4); },
+      [&](void *read_buf) { (void)read_buf; }, "");
+  Debug::Variable::FnVar32 var_y(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
-      [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
+      [&](void *write_buff) {
+        auto ii = 10 * i;
+        std::memcpy(write_buff, &ii, 4);
+      },
+      [&](void *read_buf) { (void)read_buf; }, "");
 
   // define trace and trace handler
   Trace trace;
@@ -79,12 +84,17 @@ TEST(TraceHandler, Read) {
 
   // define some debug variables
   uint32_t i = 0;
-  Debug::Variable::FnVar var_x(
+  Debug::Variable::FnVar32 var_x(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
-      [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
-  Debug::Variable::FnVar var_y(
+      [&](void *write_buff) { std::memcpy(write_buff, &i, 4); },
+      [&](void *read_buf) { (void)read_buf; }, "");
+  Debug::Variable::FnVar32 var_y(
       Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly, "unit",
-      [&] { return i * 10; }, [&](uint32_t value) { (void)value; }, "");
+      [&](void *write_buff) {
+        auto ii = 10 * i;
+        std::memcpy(write_buff, &ii, 4);
+      },
+      [&](void *read_buf) { (void)read_buf; }, "");
 
   // define trace and trace handler
   Trace trace;

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -305,8 +305,8 @@ TEST(TraceHandler, Errors) {
       {{8}, ErrorCode::InvalidData},  // Invalid subcommand
       {{static_cast<uint8_t>(TraceHandler::Subcommand::Download)}, ErrorCode::NoMemory},
       {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), 1, 1}, ErrorCode::MissingData},
-      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), Trace::MaxVars, 1, 0},
-       ErrorCode::InvalidData},
+      //      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), Trace::MaxVars, 1, 0},
+      //       ErrorCode::InvalidData}, // no longer the expected behavior?
       {{static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId)}, ErrorCode::MissingData},
       {{static_cast<uint8_t>(TraceHandler::Subcommand::GetVarId), 1}, ErrorCode::NoMemory},
       {{static_cast<uint8_t>(TraceHandler::Subcommand::SetPeriod), 1, 1, 1},

--- a/software/controller/test/debug/trace_cmd_test.cpp
+++ b/software/controller/test/debug/trace_cmd_test.cpp
@@ -42,14 +42,14 @@ TEST(TraceHandler, Flush) {
   Debug::Variable::FnVar32 var_x(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
       [&](void *write_buff) { std::memcpy(write_buff, &i, 4); },
-      [&](void *read_buf) { (void)read_buf; }, "");
+      [&](const void *read_buf) { (void)read_buf; }, "");
   Debug::Variable::FnVar32 var_y(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
       [&](void *write_buff) {
         auto ii = 10 * i;
         std::memcpy(write_buff, &ii, 4);
       },
-      [&](void *read_buf) { (void)read_buf; }, "");
+      [&](const void *read_buf) { (void)read_buf; }, "");
 
   // define trace and trace handler
   Trace trace;
@@ -103,14 +103,14 @@ TEST(TraceHandler, Read) {
   Debug::Variable::FnVar32 var_x(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "unit",
       [&](void *write_buff) { std::memcpy(write_buff, &i, 4); },
-      [&](void *read_buf) { (void)read_buf; }, "");
+      [&](const void *read_buf) { (void)read_buf; }, "");
   Debug::Variable::FnVar32 var_y(
       Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly, "unit",
       [&](void *write_buff) {
         auto ii = 10 * i;
         std::memcpy(write_buff, &ii, 4);
       },
-      [&](void *read_buf) { (void)read_buf; }, "");
+      [&](const void *read_buf) { (void)read_buf; }, "");
 
   // define trace and trace handler
   Trace trace;

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -27,12 +27,12 @@ using namespace Debug;
 
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
-  Debug::Variable::FnVar32 var_x(
-      Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "units",
+  Variable::FnVar32 var_x(
+      Variable::Type::UInt32, "x", Variable::Access::ReadOnly, "units",
       [&](void* write_buff) { std::memcpy(write_buff, &i, 4); },
       [&](void* read_buf) { (void)read_buf; }, "");
-  Debug::Variable::FnVar32 var_y(
-      Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly, "units",
+  Variable::FnVar32 var_y(
+      Variable::Type::UInt32, "y", Variable::Access::ReadOnly, "units",
       [&](void* write_buff) {
         auto ii = 10 * i;
         std::memcpy(write_buff, &ii, 4);
@@ -40,22 +40,22 @@ TEST(Trace, MaybeSampleTwoVars) {
       [&](void* read_buf) { (void)read_buf; }, "");
 
   Trace trace;
-  trace.SetPeriod(3);  // Trace every 3 cycles.
-  trace.Start();       // Enable tracing
-  trace.SetTracedVarId(1, var_x.id());
-  trace.SetTracedVarId(3, var_y.id());
+  trace.set_period(3);  // Trace every 3 cycles.
+  trace.start();        // Enable tracing
+  trace.set_traced_variable(1, var_x.id());
+  trace.set_traced_variable(3, var_y.id());
 
-  EXPECT_EQ(2, trace.GetNumActiveVars());
-  EXPECT_EQ(Variable::InvalidID, trace.GetTracedVarId(0));
-  EXPECT_EQ(var_x.id(), trace.GetTracedVarId(1));
-  EXPECT_EQ(Variable::InvalidID, trace.GetTracedVarId(2));
-  EXPECT_EQ(var_y.id(), trace.GetTracedVarId(3));
+  EXPECT_EQ(2, trace.active_variable_count());
+  EXPECT_EQ(Variable::InvalidID, trace.traced_variable(0));
+  EXPECT_EQ(var_x.id(), trace.traced_variable(1));
+  EXPECT_EQ(Variable::InvalidID, trace.traced_variable(2));
+  EXPECT_EQ(var_y.id(), trace.traced_variable(3));
 
   int expected_num_samples = 0;
   for (; i < 9; ++i) {
-    trace.MaybeSample();  // Should sample at i = 0, 3, 6
+    trace.maybe_sample();  // Should sample at i = 0, 3, 6
     if (i % 3 == 0) ++expected_num_samples;
-    EXPECT_EQ(expected_num_samples, trace.GetNumSamples());
+    EXPECT_EQ(expected_num_samples, trace.sample_count());
   }
 
   std::array<uint32_t, 4> record = {0};
@@ -63,8 +63,8 @@ TEST(Trace, MaybeSampleTwoVars) {
 
   // Extract a few records
   for (int j = 0; j < 9; j += 3, --expected_num_samples) {
-    EXPECT_EQ(expected_num_samples, trace.GetNumSamples());
-    EXPECT_TRUE(trace.GetNextTraceRecord(&record, &count));
+    EXPECT_EQ(expected_num_samples, trace.sample_count());
+    EXPECT_TRUE(trace.get_next_record(&record, &count));
     EXPECT_EQ(2, count);
     EXPECT_THAT(record, testing::ElementsAre(j, 10 * j, 0, 0));
   }
@@ -72,90 +72,109 @@ TEST(Trace, MaybeSampleTwoVars) {
   // Simulate the high-priority thread running a few times while the trace is
   // being collected.
   for (; i < 15; ++i) {
-    trace.MaybeSample();  // Should sample at i = 9, 12
+    trace.maybe_sample();  // Should sample at i = 9, 12
     if (i % 3 == 0) ++expected_num_samples;
-    EXPECT_EQ(expected_num_samples, trace.GetNumSamples());
+    EXPECT_EQ(expected_num_samples, trace.sample_count());
   }
 
   // Extract the remaining records
   for (int j = 9; j < 15; j += 3, --expected_num_samples) {
-    EXPECT_EQ(expected_num_samples, trace.GetNumSamples());
-    EXPECT_TRUE(trace.GetNextTraceRecord(&record, &count));
+    EXPECT_EQ(expected_num_samples, trace.sample_count());
+    EXPECT_TRUE(trace.get_next_record(&record, &count));
     EXPECT_EQ(2, count);
     EXPECT_THAT(record, testing::ElementsAre(j, 10 * j, 0, 0));
   }
 
-  EXPECT_EQ(0, trace.GetNumSamples());
-  EXPECT_FALSE(trace.GetNextTraceRecord(&record, &count));
+  EXPECT_EQ(0, trace.sample_count());
+  EXPECT_FALSE(trace.get_next_record(&record, &count));
 }
 
 TEST(Trace, TracesEveryCycleByDefault) {
   Trace trace;
   uint32_t x = 42;
-  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
-  trace.SetTracedVarId(0, var_x.id());
-  trace.Start();
+  Variable::Primitive32 var_x("x", Variable::Access::ReadOnly, &x, "units");
+  trace.set_traced_variable(0, var_x.id());
+  trace.start();
   // Do not set period
 
-  trace.MaybeSample();
-  trace.MaybeSample();
-  trace.MaybeSample();
-  EXPECT_EQ(3, trace.GetNumSamples());
+  trace.maybe_sample();
+  trace.maybe_sample();
+  trace.maybe_sample();
+  EXPECT_EQ(3, trace.sample_count());
 }
 
 TEST(Trace, BufferFull) {
   uint32_t x = 42;
-  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
+  Variable::Primitive32 var_x("x", Variable::Access::ReadOnly, &x, "units");
   Trace trace;
-  trace.SetTracedVarId(0, var_x.id());
-  trace.Start();
+  trace.set_traced_variable(0, var_x.id());
+  trace.start();
 
   // Buffer capacity from trace.h header file. Update if necessary.
   int expected_capacity = 0x4000;
   for (int i = 0; i < expected_capacity; ++i) {
-    EXPECT_TRUE(trace.GetStatus());
-    trace.MaybeSample();
-    EXPECT_EQ(i + 1, trace.GetNumSamples());
+    EXPECT_TRUE(trace.running());
+    trace.maybe_sample();
+    EXPECT_EQ(i + 1, trace.sample_count());
   }
 
-  trace.MaybeSample();
-  EXPECT_FALSE(trace.GetStatus());
-  EXPECT_EQ(expected_capacity, trace.GetNumSamples());
+  trace.maybe_sample();
+  EXPECT_FALSE(trace.running());
+  EXPECT_EQ(expected_capacity, trace.sample_count());
 
   // Flags should be 0 by now, so this has no effect.
-  trace.MaybeSample();
-  trace.MaybeSample();
-  trace.MaybeSample();
-  EXPECT_FALSE(trace.GetStatus());
-  EXPECT_EQ(expected_capacity, trace.GetNumSamples());
+  trace.maybe_sample();
+  trace.maybe_sample();
+  trace.maybe_sample();
+  EXPECT_FALSE(trace.running());
+  EXPECT_EQ(expected_capacity, trace.sample_count());
 
   // Re-enable tracing: that should flush the trace.
-  trace.Start();
-  trace.MaybeSample();
-  trace.MaybeSample();
-  trace.MaybeSample();
-  EXPECT_EQ(3, trace.GetNumSamples());
+  trace.start();
+  trace.maybe_sample();
+  trace.maybe_sample();
+  trace.maybe_sample();
+  EXPECT_EQ(3, trace.sample_count());
 }
 
 TEST(Trace, FlushOnSetVar) {
   uint32_t x = 42, y = 37;
-  Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
-  Debug::Variable::Primitive32 var_y("y", Debug::Variable::Access::ReadOnly, &y, "units");
+  Variable::Primitive32 var_x("x", Variable::Access::ReadOnly, &x, "units");
+  Variable::Primitive32 var_y("y", Variable::Access::ReadOnly, &y, "units");
   Trace trace;
-  trace.SetTracedVarId(0, var_x.id());
-  trace.Start();
+  trace.set_traced_variable(0, var_x.id());
+  trace.start();
 
-  trace.MaybeSample();
-  trace.MaybeSample();
-  trace.MaybeSample();
-  EXPECT_EQ(3, trace.GetNumSamples());
+  trace.maybe_sample();
+  trace.maybe_sample();
+  trace.maybe_sample();
+  EXPECT_EQ(3, trace.sample_count());
 
   // Adding a new variable should reset the trace because otherwise
   // the interpretation of the circular buffer becomes ambiguous.
-  trace.SetTracedVarId(2, var_y.id());
-  EXPECT_EQ(0, trace.GetNumSamples());
+  trace.set_traced_variable(2, var_y.id());
+  EXPECT_EQ(0, trace.sample_count());
 
-  trace.MaybeSample();
-  trace.MaybeSample();
-  EXPECT_EQ(2, trace.GetNumSamples());
+  trace.maybe_sample();
+  trace.maybe_sample();
+  EXPECT_EQ(2, trace.sample_count());
+}
+
+TEST(Trace, SetVarAssumptions) {
+  Trace trace;
+  uint32_t x = 42;
+  Variable::Primitive32 var_x("x", Variable::Access::ReadOnly, &x, "units");
+
+  EXPECT_TRUE(trace.set_traced_variable(0, Variable::InvalidID));
+  EXPECT_EQ(trace.traced_variable(0), Variable::InvalidID);
+
+  EXPECT_TRUE(trace.set_traced_variable(0, var_x.id()));
+  EXPECT_EQ(trace.traced_variable(0), var_x.id());
+
+  EXPECT_FALSE(trace.set_traced_variable(0, 666));
+  EXPECT_NE(trace.traced_variable(0), 666);
+
+  Variable::FloatArray<3> fa3("fa3", Variable::Access::ReadWrite, "units");
+  EXPECT_FALSE(trace.set_traced_variable(0, fa3.id()));
+  EXPECT_NE(trace.traced_variable(0), fa3.id());
 }

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -30,14 +30,14 @@ TEST(Trace, MaybeSampleTwoVars) {
   Variable::FnVar32 var_x(
       Variable::Type::UInt32, "x", Variable::Access::ReadOnly, "units",
       [&](void* write_buff) { std::memcpy(write_buff, &i, 4); },
-      [&](void* read_buf) { (void)read_buf; }, "");
+      [&](const void* read_buf) { (void)read_buf; }, "");
   Variable::FnVar32 var_y(
       Variable::Type::UInt32, "y", Variable::Access::ReadOnly, "units",
       [&](void* write_buff) {
         auto ii = 10 * i;
         std::memcpy(write_buff, &ii, 4);
       },
-      [&](void* read_buf) { (void)read_buf; }, "");
+      [&](const void* read_buf) { (void)read_buf; }, "");
 
   Trace trace;
   trace.set_period(3);  // Trace every 3 cycles.

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -37,14 +37,14 @@ TEST(Trace, MaybeSampleTwoVars) {
   Trace trace;
   trace.SetPeriod(3);  // Trace every 3 cycles.
   trace.Start();       // Enable tracing
-  trace.SetTracedVarId<1>(var_x.id());
-  trace.SetTracedVarId<3>(var_y.id());
+  trace.SetTracedVarId(1, var_x.id());
+  trace.SetTracedVarId(3, var_y.id());
 
   EXPECT_EQ(2, trace.GetNumActiveVars());
-  EXPECT_EQ(-1, trace.GetTracedVarId<0>());
-  EXPECT_EQ(var_x.id(), trace.GetTracedVarId<1>());
-  EXPECT_EQ(-1, trace.GetTracedVarId<2>());
-  EXPECT_EQ(var_y.id(), trace.GetTracedVarId<3>());
+  EXPECT_EQ(Variable::InvalidID, trace.GetTracedVarId(0));
+  EXPECT_EQ(var_x.id(), trace.GetTracedVarId(1));
+  EXPECT_EQ(Variable::InvalidID, trace.GetTracedVarId(2));
+  EXPECT_EQ(var_y.id(), trace.GetTracedVarId(3));
 
   int expected_num_samples = 0;
   for (; i < 9; ++i) {
@@ -88,7 +88,7 @@ TEST(Trace, TracesEveryCycleByDefault) {
   Trace trace;
   uint32_t x = 42;
   Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
-  trace.SetTracedVarId<0>(var_x.id());
+  trace.SetTracedVarId(0, var_x.id());
   trace.Start();
   // Do not set period
 
@@ -102,7 +102,7 @@ TEST(Trace, BufferFull) {
   uint32_t x = 42;
   Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
   Trace trace;
-  trace.SetTracedVarId<0>(var_x.id());
+  trace.SetTracedVarId(0, var_x.id());
   trace.Start();
 
   // Buffer capacity from trace.h header file. Update if necessary.
@@ -137,7 +137,7 @@ TEST(Trace, FlushOnSetVar) {
   Debug::Variable::Primitive32 var_x("x", Debug::Variable::Access::ReadOnly, &x, "units");
   Debug::Variable::Primitive32 var_y("y", Debug::Variable::Access::ReadOnly, &y, "units");
   Trace trace;
-  trace.SetTracedVarId<0>(var_x.id());
+  trace.SetTracedVarId(0, var_x.id());
   trace.Start();
 
   trace.MaybeSample();
@@ -147,7 +147,7 @@ TEST(Trace, FlushOnSetVar) {
 
   // Adding a new variable should reset the trace because otherwise
   // the interpretation of the circular buffer becomes ambiguous.
-  trace.SetTracedVarId<2>(var_y.id());
+  trace.SetTracedVarId(2, var_y.id());
   EXPECT_EQ(0, trace.GetNumSamples());
 
   trace.MaybeSample();

--- a/software/controller/test/debug/trace_test.cpp
+++ b/software/controller/test/debug/trace_test.cpp
@@ -27,12 +27,17 @@ using namespace Debug;
 
 TEST(Trace, MaybeSampleTwoVars) {
   uint32_t i = 0;
-  Debug::Variable::FnVar var_x(
+  Debug::Variable::FnVar32 var_x(
       Debug::Variable::Type::UInt32, "x", Debug::Variable::Access::ReadOnly, "units",
-      [&] { return i; }, [&](uint32_t value) { (void)value; }, "");
-  Debug::Variable::FnVar var_y(
+      [&](void* write_buff) { std::memcpy(write_buff, &i, 4); },
+      [&](void* read_buf) { (void)read_buf; }, "");
+  Debug::Variable::FnVar32 var_y(
       Debug::Variable::Type::UInt32, "y", Debug::Variable::Access::ReadOnly, "units",
-      [&] { return 10 * i; }, [&](uint32_t value) { (void)value; }, "");
+      [&](void* write_buff) {
+        auto ii = 10 * i;
+        std::memcpy(write_buff, &ii, 4);
+      },
+      [&](void* read_buf) { (void)read_buf; }, "");
 
   Trace trace;
   trace.SetPeriod(3);  // Trace every 3 cycles.

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -21,6 +21,8 @@ limitations under the License.
 #include "gtest/gtest.h"
 #include "vars.h"
 
+// \TODO: more tests for FloatArray type
+
 namespace Debug::Command {
 
 TEST(VarHandler, GetVarInfo) {

--- a/software/controller/test/debug/var_cmd_test.cpp
+++ b/software/controller/test/debug/var_cmd_test.cpp
@@ -35,7 +35,7 @@ TEST(VarHandler, GetVarInfo) {
   // expected result is hand-built from format given in var_cmd.cpp
   std::vector<uint8_t> expected = {static_cast<uint8_t>(Debug::Variable::Type::UInt32),
                                    static_cast<uint8_t>(Debug::Variable::Access::ReadOnly),
-                                   0,
+                                   static_cast<uint8_t>(4),
                                    0,
                                    static_cast<uint8_t>(strlen(name)),
                                    static_cast<uint8_t>(strlen(format)),

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -36,12 +36,12 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ(&var, Registry::singleton().find(var.id()));
 
   other_val = 0;
-  var.get_value(&other_val);
+  var.serialize_value(&other_val);
   EXPECT_EQ(int32_t{5}, other_val);
   other_val = 7;
-  var.set_value(&other_val);
+  var.deserialize_value(&other_val);
   other_val = 0;
-  var.get_value(&other_val);
+  var.serialize_value(&other_val);
   EXPECT_EQ(int32_t{7}, other_val);
   EXPECT_EQ(7, value);
 
@@ -57,7 +57,7 @@ TEST(DebugVar, DebugVarUint32Defaults) {
   // All default arguments
   Primitive32 var("var", Access::ReadWrite, &value, "unit");
   other_val = 0;
-  var.get_value(&other_val);
+  var.serialize_value(&other_val);
   EXPECT_EQ(uint32_t{5}, other_val);
   EXPECT_STREQ("", var.help());
   EXPECT_STREQ("%u", var.format());
@@ -75,17 +75,17 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 
   // Rountrip through uint32 should not change value.
   uint32_t uint_val{0};
-  var.get_value(&uint_val);
-  var.set_value(&uint_val);
+  var.serialize_value(&uint_val);
+  var.deserialize_value(&uint_val);
   uint32_t other_val{0};
-  var.get_value(&other_val);
+  var.serialize_value(&other_val);
   EXPECT_EQ(uint_val, other_val);
   EXPECT_EQ(5.0f, value);
 }
 
 TEST(DebugVar, FloatArray) {
   FloatArray<3> fa3("fa3", Access::ReadWrite, "units");
-  EXPECT_EQ(fa3.size(), 4 * 3);
+  EXPECT_EQ(fa3.byte_size(), 4 * 3);
   fa3.data[0] = 24.0f;
   fa3.data[1] = 42.0f;
   fa3.data[2] = 69.0f;
@@ -94,9 +94,9 @@ TEST(DebugVar, FloatArray) {
   EXPECT_EQ(fa3.data, compare_to);
 
   uint32_t buffer[3 * 4];
-  fa3.get_value(buffer);
+  fa3.serialize_value(buffer);
   fa3.data = {0};
-  fa3.set_value(buffer);
+  fa3.deserialize_value(buffer);
   EXPECT_EQ(fa3.data, compare_to);
   EXPECT_NE(fa3.data.data(), compare_to.data());
   EXPECT_NE(reinterpret_cast<void*>(fa3.data.data()), reinterpret_cast<void*>(buffer));

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -17,22 +17,23 @@ limitations under the License.
 
 #include "gtest/gtest.h"
 
+using namespace Debug::Variable;
+
 TEST(DebugVar, DebugVarInt32) {
   int32_t value{5};
   int32_t other_val{0};
-  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadOnly, &value, "unit", "help",
-                                   "fmt");
+  Primitive32 var("var", Access::ReadOnly, &value, "unit", "help", "fmt");
   EXPECT_STREQ("var", var.name());
   var.prepend_name("pre_");
   EXPECT_STREQ("pre_var", var.name());
   EXPECT_STREQ("help", var.help());
   var.append_help(" so much help");
   EXPECT_STREQ("help so much help", var.help());
-  EXPECT_EQ(Debug::Variable::Type::Int32, var.type());
+  EXPECT_EQ(Type::Int32, var.type());
   EXPECT_STREQ("fmt", var.format());
   EXPECT_STREQ("unit", var.units());
-  EXPECT_EQ(Debug::Variable::Access::ReadOnly, var.access());
-  EXPECT_EQ(&var, Debug::Variable::Registry::singleton().find(var.id()));
+  EXPECT_EQ(Access::ReadOnly, var.access());
+  EXPECT_EQ(&var, Registry::singleton().find(var.id()));
 
   other_val = 0;
   var.get_value(&other_val);
@@ -45,8 +46,7 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ(7, value);
 
   // All default arguments
-  Debug::Variable::Primitive32 var_default("var", Debug::Variable::Access::ReadWrite, &value,
-                                           "unit");
+  Primitive32 var_default("var", Access::ReadWrite, &value, "unit");
   EXPECT_STREQ("", var_default.help());
   EXPECT_STREQ("%d", var_default.format());
 }
@@ -55,23 +55,23 @@ TEST(DebugVar, DebugVarUint32Defaults) {
   uint32_t value{5};
   uint32_t other_val{0};
   // All default arguments
-  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
+  Primitive32 var("var", Access::ReadWrite, &value, "unit");
   other_val = 0;
   var.get_value(&other_val);
   EXPECT_EQ(uint32_t{5}, other_val);
   EXPECT_STREQ("", var.help());
   EXPECT_STREQ("%u", var.format());
-  EXPECT_EQ(Debug::Variable::Type::UInt32, var.type());
+  EXPECT_EQ(Type::UInt32, var.type());
 }
 
 TEST(DebugVar, DebugVarFloatDefaults) {
   float value{5.0f};
   // All default arguments
-  Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
+  Primitive32 var("var", Access::ReadWrite, &value, "unit");
 
   EXPECT_STREQ("", var.help());
   EXPECT_STREQ("%.3f", var.format());
-  EXPECT_EQ(Debug::Variable::Type::Float, var.type());
+  EXPECT_EQ(Type::Float, var.type());
 
   // Rountrip through uint32 should not change value.
   uint32_t uint_val{0};
@@ -84,7 +84,7 @@ TEST(DebugVar, DebugVarFloatDefaults) {
 }
 
 TEST(DebugVar, FloatArray) {
-  Debug::Variable::FloatArray<3> fa3("fa3", Debug::Variable::Access::ReadWrite, "units");
+  FloatArray<3> fa3("fa3", Access::ReadWrite, "units");
   EXPECT_EQ(fa3.size(), 4 * 3);
   fa3.data[0] = 24.0f;
   fa3.data[1] = 42.0f;
@@ -101,29 +101,27 @@ TEST(DebugVar, FloatArray) {
   EXPECT_NE(fa3.data.data(), compare_to.data());
   EXPECT_NE(reinterpret_cast<void*>(fa3.data.data()), reinterpret_cast<void*>(buffer));
 
-  Debug::Variable::FloatArray<5> fa5("fa5", Debug::Variable::Access::ReadWrite, 4.0f, "units");
+  FloatArray<5> fa5("fa5", Access::ReadWrite, 4.0f, "units");
   EXPECT_EQ(fa5.data[4], 4.0f);
 
-  Debug::Variable::FloatArray<2> fa2("fa2", Debug::Variable::Access::ReadWrite, {1.0f, 2.0f},
-                                     "units");
+  FloatArray<2> fa2("fa2", Access::ReadWrite, {1.0f, 2.0f}, "units");
   EXPECT_EQ(fa2.data[0], 1.0f);
   EXPECT_EQ(fa2.data[1], 2.0f);
 }
 
 TEST(DebugVar, Registration) {
-  uint32_t num_vars = Debug::Variable::Registry::singleton().count();
+  uint32_t num_vars = Registry::singleton().count();
   int32_t int_value = 5;
-  Debug::Variable::Primitive32 var1("var1", Debug::Variable::Access::ReadWrite, &int_value, "unit");
+  Primitive32 var1("var1", Access::ReadWrite, &int_value, "unit");
 
-  EXPECT_EQ(Debug::Variable::Registry::singleton().count(), num_vars + 1);
+  EXPECT_EQ(Registry::singleton().count(), num_vars + 1);
 
   float float_value = 7;
-  Debug::Variable::Primitive32 var2("var2", Debug::Variable::Access::ReadWrite, &float_value,
-                                    "unit");
+  Primitive32 var2("var2", Access::ReadWrite, &float_value, "unit");
 
-  EXPECT_EQ(Debug::Variable::Registry::singleton().count(), num_vars + 2);
+  EXPECT_EQ(Registry::singleton().count(), num_vars + 2);
 
-  EXPECT_EQ(&var1, Debug::Variable::Registry::singleton().find(var1.id()));
-  EXPECT_EQ(&var2, Debug::Variable::Registry::singleton().find(var2.id()));
-  EXPECT_EQ(nullptr, Debug::Variable::Registry::singleton().find(12345));
+  EXPECT_EQ(&var1, Registry::singleton().find(var1.id()));
+  EXPECT_EQ(&var2, Registry::singleton().find(var2.id()));
+  EXPECT_EQ(nullptr, Registry::singleton().find(12345));
 }

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -100,6 +100,14 @@ TEST(DebugVar, FloatArray) {
   EXPECT_EQ(fa3.data, compare_to);
   EXPECT_NE(fa3.data.data(), compare_to.data());
   EXPECT_NE(reinterpret_cast<void*>(fa3.data.data()), reinterpret_cast<void*>(buffer));
+
+  Debug::Variable::FloatArray<5> fa5("fa5", Debug::Variable::Access::ReadWrite, 4.0f, "units");
+  EXPECT_EQ(fa5.data[4], 4.0f);
+
+  Debug::Variable::FloatArray<2> fa2("fa2", Debug::Variable::Access::ReadWrite, {1.0f, 2.0f},
+                                     "units");
+  EXPECT_EQ(fa2.data[0], 1.0f);
+  EXPECT_EQ(fa2.data[1], 2.0f);
 }
 
 TEST(DebugVar, Registration) {

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -83,6 +83,25 @@ TEST(DebugVar, DebugVarFloatDefaults) {
   EXPECT_EQ(5.0f, value);
 }
 
+TEST(DebugVar, FloatArray) {
+  Debug::Variable::FloatArray<3> fa3("fa3", Debug::Variable::Access::ReadWrite, "units");
+  EXPECT_EQ(fa3.size(), 4 * 3);
+  fa3.data[0] = 24.0f;
+  fa3.data[1] = 42.0f;
+  fa3.data[2] = 69.0f;
+  std::array<float, 3> compare_to{24.0f, 42.0f, 69.0f};
+
+  EXPECT_EQ(fa3.data, compare_to);
+
+  uint32_t buffer[3 * 4];
+  fa3.get_value(buffer);
+  fa3.data = {0};
+  fa3.set_value(buffer);
+  EXPECT_EQ(fa3.data, compare_to);
+  EXPECT_NE(fa3.data.data(), compare_to.data());
+  EXPECT_NE(reinterpret_cast<void*>(fa3.data.data()), reinterpret_cast<void*>(buffer));
+}
+
 TEST(DebugVar, Registration) {
   uint32_t num_vars = Debug::Variable::Registry::singleton().count();
   int32_t int_value = 5;

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -18,7 +18,8 @@ limitations under the License.
 #include "gtest/gtest.h"
 
 TEST(DebugVar, DebugVarInt32) {
-  int32_t value = 5;
+  int32_t value{5};
+  int32_t other_val{0};
   Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadOnly, &value, "unit", "help",
                                    "fmt");
   EXPECT_STREQ("var", var.name());
@@ -33,16 +34,15 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ(Debug::Variable::Access::ReadOnly, var.access());
   EXPECT_EQ(&var, Debug::Variable::Registry::singleton().find(var.id()));
 
-  EXPECT_EQ(uint32_t{5}, var.get_value());
-  var.set_value(7);
-  EXPECT_EQ(uint32_t{7}, var.get_value());
+  other_val = 0;
+  var.get_value(&other_val);
+  EXPECT_EQ(int32_t{5}, other_val);
+  other_val = 7;
+  var.set_value(&other_val);
+  other_val = 0;
+  var.get_value(&other_val);
+  EXPECT_EQ(int32_t{7}, other_val);
   EXPECT_EQ(7, value);
-
-  // Test a value outside the range of int32_t.
-  uint32_t max = std::numeric_limits<uint32_t>::max();
-  var.set_value(max);
-  EXPECT_EQ(max, var.get_value());
-  EXPECT_EQ(static_cast<int32_t>(max), value);
 
   // All default arguments
   Debug::Variable::Primitive32 var_default("var", Debug::Variable::Access::ReadWrite, &value,
@@ -52,17 +52,20 @@ TEST(DebugVar, DebugVarInt32) {
 }
 
 TEST(DebugVar, DebugVarUint32Defaults) {
-  uint32_t value = 5;
+  uint32_t value{5};
+  uint32_t other_val{0};
   // All default arguments
   Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
-  EXPECT_EQ(uint32_t{5}, var.get_value());
+  other_val = 0;
+  var.get_value(&other_val);
+  EXPECT_EQ(uint32_t{5}, other_val);
   EXPECT_STREQ("", var.help());
   EXPECT_STREQ("%u", var.format());
   EXPECT_EQ(Debug::Variable::Type::UInt32, var.type());
 }
 
 TEST(DebugVar, DebugVarFloatDefaults) {
-  float value = 5.0f;
+  float value{5.0f};
   // All default arguments
   Debug::Variable::Primitive32 var("var", Debug::Variable::Access::ReadWrite, &value, "unit");
 
@@ -71,9 +74,12 @@ TEST(DebugVar, DebugVarFloatDefaults) {
   EXPECT_EQ(Debug::Variable::Type::Float, var.type());
 
   // Rountrip through uint32 should not change value.
-  uint32_t uint_value = var.get_value();
-  var.set_value(uint_value);
-  EXPECT_EQ(uint_value, var.get_value());
+  uint32_t uint_val{0};
+  var.get_value(&uint_val);
+  var.set_value(&uint_val);
+  uint32_t other_val{0};
+  var.get_value(&other_val);
+  EXPECT_EQ(uint_val, other_val);
   EXPECT_EQ(5.0f, value);
 }
 

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -299,13 +299,12 @@ class ControllerDebugInterface:
         self.variables_force_off()
         self.trace_set_period(test.scenario.trace_period)
         self.trace_select(test.scenario.trace_variable_names)
-        self.trace_start()
         time.sleep(test.scenario.capture_ignore_secs)
 
         print(
             f"\nStarting data capture for {test.scenario.capture_duration_secs} seconds"
         )
-        self.trace_flush()
+        self.trace_start()
         time.sleep(test.scenario.capture_duration_secs)
         self.trace_stop()
 

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -43,22 +43,23 @@ OP_TRACE = 0x05
 OP_EEPROM = 0x06
 
 # Some commands take a sub-command as their first byte of data
-SUBCMD_VAR_INFO = 0
-SUBCMD_VAR_GET = 1
-SUBCMD_VAR_SET = 2
-SUBCMD_VAR_GET_COUNT = 3
+SUBCMD_VAR_INFO = 0x00
+SUBCMD_VAR_GET = 0x01
+SUBCMD_VAR_SET = 0x02
+SUBCMD_VAR_GET_COUNT = 0x03
 
-SUBCMD_TRACE_FLUSH = 0
-SUBCMD_TRACE_GETDATA = 1
-SUBCMD_TRACE_START = 2
-SUBCMD_TRACE_GET_VARID = 3
-SUBCMD_TRACE_SET_VARID = 4
-SUBCMD_TRACE_GET_PERIOD = 5
-SUBCMD_TRACE_SET_PERIOD = 6
-SUBCMD_TRACE_GET_NUM_SAMPLES = 7
+SUBCMD_TRACE_FLUSH = 0x00
+SUBCMD_TRACE_GETDATA = 0x01
+SUBCMD_TRACE_START = 0x02
+SUBCMD_TRACE_STOP = 0x03
+SUBCMD_TRACE_GET_VARID = 0x04
+SUBCMD_TRACE_SET_VARID = 0x05
+SUBCMD_TRACE_GET_PERIOD = 0x06
+SUBCMD_TRACE_SET_PERIOD = 0x07
+SUBCMD_TRACE_GET_NUM_SAMPLES = 0x08
 
-SUBCMD_EEPROM_READ = 0
-SUBCMD_EEPROM_WRITE = 1
+SUBCMD_EEPROM_READ = 0x00
+SUBCMD_EEPROM_WRITE = 0x01
 
 # Can trace this many variables at once.  Keep this in sync with
 # kMaxTraceVars in the controller.
@@ -76,7 +77,7 @@ ERROR_CODES = [
     "Insufficient memory",
     "Some type of internal error (aka bug)",
     "The requested variable ID is invalid",
-    "Data is out of range",
+    "Invalid data in request",
     "Response timeout",
 ]
 
@@ -296,16 +297,17 @@ class ControllerDebugInterface:
         print("\n")
         self.variables_set(test.scenario.ventilator_settings)
         self.variables_force_off()
+        self.trace_set_period(test.scenario.trace_period)
+        self.trace_select(test.scenario.trace_variable_names)
+        self.trace_start()
         time.sleep(test.scenario.capture_ignore_secs)
 
         print(
             f"\nStarting data capture for {test.scenario.capture_duration_secs} seconds"
         )
         self.trace_flush()
-        self.trace_set_period(test.scenario.trace_period)
-        self.trace_select(test.scenario.trace_variable_names)
-        self.trace_start()
         time.sleep(test.scenario.capture_duration_secs)
+        self.trace_stop()
 
         print("\nRetrieving data and halting ventilation")
         # get data and halt ventilation
@@ -314,7 +316,6 @@ class ControllerDebugInterface:
             access_filter=var_info.VAR_ACCESS_WRITE, raw=True
         )
         self.variable_set("forced_mode", "off")
-        self.trace_stop()
         return test
 
     def trace_save(self, scenario_name="manual_trace"):
@@ -453,8 +454,7 @@ class ControllerDebugInterface:
         self.send_command(OP_TRACE, [SUBCMD_TRACE_START])
 
     def trace_stop(self):
-        self.trace_select([])
-        self.trace_flush()
+        self.send_command(OP_TRACE, [SUBCMD_TRACE_STOP])
 
     def trace_num_samples(self):
         dat = self.send_command(OP_TRACE, [SUBCMD_TRACE_GET_NUM_SAMPLES])

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -448,7 +448,7 @@ class ControllerDebugInterface:
                 raise Error(f"Cannot select trace. Variable `{name}` does not exist.")
         var_names += [""] * (TRACE_VAR_CT - len(var_names))
         for (i, var_name) in enumerate(var_names):
-            var_id = -1
+            var_id = var_info.VAR_INVALID_ID
             if var_name in self.variable_metadata:
                 var_id = self.variable_metadata[var_name].id
             var = debug_types.int16s_to_bytes(var_id)

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -218,6 +218,9 @@ class ControllerDebugInterface:
         if fmt is None:
             fmt = variable.format
 
+        if fmt == "[]":
+            return ", ".join("{:>.4}".format(k) for k in value)
+
         return fmt % value
 
     def variable_set(self, name, value, verbose=False):

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -209,30 +209,22 @@ class ControllerDebugInterface:
         data = self.send_command(
             OP_VAR, [SUBCMD_VAR_GET] + debug_types.int16s_to_bytes(variable.id)
         )
-        value = variable.from_bytes(data)
-
-        if raw:
-            return value
-
-        # If a format wasn't passed, use the default for this var
-        if fmt is None:
-            fmt = variable.format
-
-        if fmt == "[]":
-            return ", ".join("{:>.4}".format(k) for k in value)
-
-        return fmt % value
+        return variable.format_value(variable.from_bytes(data), raw, fmt)
 
     def variable_set(self, name, value, verbose=False):
         if not (name in self.variable_metadata):
             raise Error(f"Cannot set unknown variable {name}")
 
         variable = self.variable_metadata[name]
+        # \TODO this will not work for FloatArray
         if verbose:
             text = variable.print_value(value, show_access=False)
             print(f"  applying {text}")
 
         data = variable.to_bytes(value)
+        if self.print_raw:
+            print(f"  data converted as {data}")
+
         self.send_command(
             OP_VAR, [SUBCMD_VAR_SET] + debug_types.int16s_to_bytes(variable.id) + data
         )

--- a/software/utils/debug/debug_cli.py
+++ b/software/utils/debug/debug_cli.py
@@ -583,7 +583,10 @@ ex: poke [type] <address> <data>
         if len(cl) < 2:
             print("Please give the variable name and value")
             return
-        self.interface.variable_set(cl[0], cl[1:])
+        if len(cl) == 2:
+            self.interface.variable_set(cl[0], cl[1])  # single variable
+        else:
+            self.interface.variable_set(cl[0], cl[1:])  # array
 
     def complete_set(self, text, line, begidx, endidx):
         return self.interface.variables_find(text, access_filter=VAR_ACCESS_WRITE)
@@ -666,7 +669,6 @@ trace save [--verbose/-v] [--plot/-p] [--csv/-c]
             if args.var:
                 self.interface.trace_select(args.var)
 
-            self.interface.trace_flush()
             self.interface.trace_start()
 
         elif cl[0] == "stop":

--- a/software/utils/debug/debug_cli.py
+++ b/software/utils/debug/debug_cli.py
@@ -511,6 +511,7 @@ ex: poke [type] <address> <data>
             print("Please give the variable name to read")
             return
 
+        var_name = cl[0]
         raw = False
         fmt = None
         if len(cl) > 1:
@@ -519,7 +520,7 @@ ex: poke [type] <address> <data>
             else:
                 fmt = cl[1]
 
-        if cl[0] == "all":
+        if var_name == "all":
             all_vars = self.interface.variables_get_all(raw=raw)
             for count, name in enumerate(sorted(all_vars.keys())):
                 variable_md = self.interface.variable_metadata[name]
@@ -529,7 +530,7 @@ ex: poke [type] <address> <data>
                 else:
                     print(dark_orange(text))
             return
-        if cl[0] == "set":
+        elif var_name == "set":
             all_vars = self.interface.variables_get_all(
                 access_filter=VAR_ACCESS_WRITE, raw=raw
             )
@@ -541,7 +542,7 @@ ex: poke [type] <address> <data>
                 else:
                     print(dark_orange(text))
             return
-        if cl[0] == "read":
+        elif var_name == "read":
             all_vars = self.interface.variables_get_all(
                 access_filter=VAR_ACCESS_READ_ONLY, raw=raw
             )
@@ -553,10 +554,10 @@ ex: poke [type] <address> <data>
                 else:
                     print(dark_orange(text))
             return
-
-        variable_md = self.interface.variable_metadata[cl[0]]
-        val = self.interface.variable_get(cl[0], raw=raw, fmt=fmt)
-        print(variable_md.print_value(val))
+        else:
+            variable_md = self.interface.variable_metadata[cl[0]]
+            val = self.interface.variable_get(cl[0], raw=raw, fmt=fmt)
+            print(variable_md.print_value(val))
 
     def complete_get(self, text, line, begidx, endidx):
         return self.interface.variables_find(text) + [
@@ -582,7 +583,7 @@ ex: poke [type] <address> <data>
         if len(cl) < 2:
             print("Please give the variable name and value")
             return
-        self.interface.variable_set(cl[0], cl[1])
+        self.interface.variable_set(cl[0], cl[1:])
 
     def complete_set(self, text, line, begidx, endidx):
         return self.interface.variables_find(text, access_filter=VAR_ACCESS_WRITE)

--- a/software/utils/debug/debug_cli.py
+++ b/software/utils/debug/debug_cli.py
@@ -555,8 +555,8 @@ ex: poke [type] <address> <data>
                     print(dark_orange(text))
             return
         else:
-            variable_md = self.interface.variable_metadata[cl[0]]
-            val = self.interface.variable_get(cl[0], raw=raw, fmt=fmt)
+            variable_md = self.interface.variable_metadata[var_name]
+            val = self.interface.variable_get(var_name, raw=raw, fmt=fmt)
             print(variable_md.print_value(val))
 
     def complete_get(self, text, line, begidx, endidx):

--- a/software/utils/debug/var_info.py
+++ b/software/utils/debug/var_info.py
@@ -52,6 +52,7 @@ class VarInfo:
     id: int
     type: int
     write_access: bool
+    size: int
     name: str
     units: str = ""
     format: str
@@ -68,6 +69,7 @@ class VarInfo:
 
         self.type = data[0]
         self.write_access = data[1] == VAR_ACCESS_WRITE
+        self.size = data[2]
         name_length = data[4]
         fmt_length = data[5]
         help_length = data[6]
@@ -89,7 +91,7 @@ class VarInfo:
         type_str = "?"
         if self.type < len(VAR_TYPE_REPRESENTATION):
             type_str = VAR_TYPE_REPRESENTATION[self.type]
-        ret = f"[{self.id:>02}{type_str}] "
+        ret = f"[{self.id:>02}] {self.size:>2}{type_str} "
         if show_access:
             ret += "w+ " if self.write_access else "w- "
         ret += f"{self.name:25} {self.units:>13} "

--- a/software/utils/debug/var_info.py
+++ b/software/utils/debug/var_info.py
@@ -25,7 +25,7 @@ from lib.error import Error
 
 # TODO: Import constants from proto instead!
 
-VAR_INVALID_ID = 101
+VAR_INVALID_ID = 100
 
 # Variable types (see vars.h)
 VAR_INT32 = 1

--- a/software/utils/debug/var_info.py
+++ b/software/utils/debug/var_info.py
@@ -53,11 +53,14 @@ class VarInfo:
     id: int
     type: int
     write_access: bool
-    size: int
+    byte_size: int
     name: str
     units: str = ""
     format: str
     help: str
+
+    def size(self):
+        return int(self.byte_size / 4)
 
     # Initialize the variable info from the data returned
     # by the controller.  Set var.cpp in the controller for
@@ -70,7 +73,7 @@ class VarInfo:
 
         self.type = data[0]
         self.write_access = data[1] == VAR_ACCESS_WRITE
-        self.size = data[2]
+        self.byte_size = data[2]
         name_length = data[4]
         fmt_length = data[5]
         help_length = data[6]
@@ -92,7 +95,7 @@ class VarInfo:
         type_str = "?"
         if self.type < len(VAR_TYPE_REPRESENTATION):
             type_str = VAR_TYPE_REPRESENTATION[self.type]
-        ret = f"[{self.id:>02}] {self.size:>2}{type_str} "
+        ret = f"[{self.id:>02}] {self.size():>2}{type_str} "
         if show_access:
             ret += "w+ " if self.write_access else "w- "
         ret += f"{self.name:25} {self.units:>13} "
@@ -101,6 +104,19 @@ class VarInfo:
             ret += f"{format_string:>8} "
         ret += f" {self.help}"
         return ret
+
+    def format_value(self, value, raw=False, fmt=None):
+        if raw:
+            return value
+
+        # If a format wasn't passed, use the default for this var
+        if fmt is None:
+            fmt = self.format
+
+        if self.type == VAR_FLOAT_ARRAY:
+            return "[" + " ".join(fmt % k for k in value) + "]"
+        else:
+            return fmt % value
 
     def print_value(self, value, show_access=True):
         write = ""
@@ -153,5 +169,12 @@ class VarInfo:
             return debug_types.int32s_to_bytes(value)
         elif self.type == VAR_FLOAT:
             return debug_types.float32s_to_bytes(float(value))
+        elif self.type == VAR_FLOAT_ARRAY:
+            float_array = [float(k) for k in value]
+            if len(float_array) != self.size():
+                raise Error(
+                    f"FloatArray size mismatch. Should be {self.size()}, was {len(float_array)}"
+                )
+            return debug_types.float32s_to_bytes(float_array)
         else:
             raise Error(f"Sorry, I don't know how to handle variable type {self.type}")

--- a/software/utils/debug/var_info.py
+++ b/software/utils/debug/var_info.py
@@ -25,6 +25,8 @@ from lib.error import Error
 
 # TODO: Import constants from proto instead!
 
+VAR_INVALID_ID = 101
+
 # Variable types (see vars.h)
 VAR_INT32 = 1
 VAR_UINT32 = 2

--- a/software/utils/debug/var_info.py
+++ b/software/utils/debug/var_info.py
@@ -31,8 +31,9 @@ VAR_INVALID_ID = 101
 VAR_INT32 = 1
 VAR_UINT32 = 2
 VAR_FLOAT = 3
+VAR_FLOAT_ARRAY = 4
 
-VAR_TYPE_REPRESENTATION = ["?", "i", "u", "f"]
+VAR_TYPE_REPRESENTATION = ["?", "i", "u", "f", "A"]
 
 VAR_ACCESS_READ_ONLY = 0
 VAR_ACCESS_WRITE = 1
@@ -131,6 +132,8 @@ class VarInfo:
             return debug_types.bytes_to_int32s(data)[0]
         elif self.type == VAR_FLOAT:
             return debug_types.bytes_to_float32s(data)[0]
+        elif self.type == VAR_FLOAT_ARRAY:
+            return debug_types.bytes_to_float32s(data)
         else:
             raise Error(f"Sorry, I don't know how to handle variable type {self.type}")
 


### PR DESCRIPTION
# Description

* `Debug::Variable::Base` now provides for variable size in bytes, which is forwarded to CLI, which also displays this field in verbose mode, this is to accomodate debug variables of different sizes. Generic `set_value` and `get_value` functions now operate on buffers instead of by-value.
* `VarHandler` generalizes `get` and `set` to correctly (de)serialize variables of different sizes agnostic of the actual variable type implementation.
* Implements the `FloatArray` debug variable class, which contains an `std::array<float, T>` for storage of calibration tables and the like, appropriately updates the debug command handlers and Python CLI to make use of it
* Modifies the `PinchValve` class to keep a private calibration instance to keep track of its own calibration, exposed to debug interface. For now, it is initialized with hard-coded values, pending some EEPROM anchoring to replace it (#857).
* Trace cleaned up: all implementations moved to `cpp` file, renaming of variables, doxygen comments in header, `flush` and `stop` functionally disentangled, buffer size constants factored out
* `TraceHandler` updated: now can handle the `Stop` command
* `circular_buffer` and `i2c` cleaned up to use more generic unsigned types for where array sizes and indexing is needed
* Unit tests updated for any of the above that were affected. Some additional functionality is tested , but major refactoring left for later. There is too much manual byte-manipulation needed for a lot of the handler tests. It will be easier to write better tests when we have a generated protocol for the debug interface.

Closes #1154 

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
