### PR TITLE
address clangtidy's warnings

### DIFF
--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -95,39 +95,39 @@ static constexpr int MaxAdcReading =
 
 // Set sample time ([RM] 16.4.12).
 enum class ADCSampleTimeReg {
-  s2_5 = 0,    // 2.5 clock cycles
-  s6_5 = 1,    // 6.5 clock cycles
-  s12_5 = 2,   // 12.5 clock cycles
-  s24_5 = 3,   // 24.5 clock cycles
-  s47_5 = 4,   // 47.5 clock cycles
-  s92_5 = 5,   // 92.5 clock cycles
-  s247_5 = 6,  // 247.5 clock cycles
-  s640_5 = 7   // 640.5 clock cycles
+  S2p5 = 0,    // 2.5 clock cycles
+  S6p5 = 1,    // 6.5 clock cycles
+  S12p5 = 2,   // 12.5 clock cycles
+  S24p5 = 3,   // 24.5 clock cycles
+  S47p5 = 4,   // 47.5 clock cycles
+  S92p5 = 5,   // 92.5 clock cycles
+  S247p5 = 6,  // 247.5 clock cycles
+  S640p5 = 7   // 640.5 clock cycles
 };
 // I'm using 92.5 A/D clocks to sample.
 // A/D sample time in CPU clock cycles.  Fixed for now.
 // This is the time we give the analog input to charge the A/D sampling cap.
-static constexpr ADCSampleTimeReg AdcSampleTime{ADCSampleTimeReg::s92_5};
+static constexpr ADCSampleTimeReg AdcSampleTime{ADCSampleTimeReg::S92p5};
 
 // Time of an A/D conversion in CPU clock cycles (see [RM] 16.4.16):
 // sample time (in clock cycles, rounded up) + 12 (one per bit of resolution).
 static constexpr int AdcConversionTime = [] {
   switch (AdcSampleTime) {
-    case ADCSampleTimeReg::s2_5:
+    case ADCSampleTimeReg::S2p5:
       return 3 + AdcResolution;
-    case ADCSampleTimeReg::s6_5:
+    case ADCSampleTimeReg::S6p5:
       return 7 + AdcResolution;
-    case ADCSampleTimeReg::s12_5:
+    case ADCSampleTimeReg::S12p5:
       return 13 + AdcResolution;
-    case ADCSampleTimeReg::s24_5:
+    case ADCSampleTimeReg::S24p5:
       return 25 + AdcResolution;
-    case ADCSampleTimeReg::s47_5:
+    case ADCSampleTimeReg::S47p5:
       return 48 + AdcResolution;
-    case ADCSampleTimeReg::s92_5:
+    case ADCSampleTimeReg::S92p5:
       return 93 + AdcResolution;
-    case ADCSampleTimeReg::s247_5:
+    case ADCSampleTimeReg::S247p5:
       return 248 + AdcResolution;
-    case ADCSampleTimeReg::s640_5:
+    case ADCSampleTimeReg::S640p5:
       return 640 + AdcResolution;
   }
   // All cases covered above (and GCC checks this).
@@ -207,7 +207,6 @@ void HalApi::InitADC() {
       case 10:
         return 1;
       case 12:
-        return 0;
       default:
         return 0;
     }
@@ -263,7 +262,7 @@ void HalApi::InitADC() {
 }
 
 // Read the specified analog input.
-Voltage HalApi::AnalogRead(AnalogPin pin) {
+Voltage HalApi::AnalogRead(AnalogPin pin) const {
   int offset = [&] {
     switch (pin) {
       case AnalogPin::InterimBoardAnalogPressure:

--- a/software/controller/lib/hal/circular_buffer.h
+++ b/software/controller/lib/hal/circular_buffer.h
@@ -35,9 +35,7 @@ class CircularBuffer {
   volatile int head_{0}, tail_{0};
 
  public:
-  CircularBuffer() {
-    for (size_t i = 0; i <= N; ++i) buffer_[i] = T();
-  }
+  CircularBuffer() = default;
 
   // Return number of elements available in the buffer to read.
   size_t FullCount() const {
@@ -51,6 +49,8 @@ class CircularBuffer {
   // Return number of free spaces in the buffer where more
   // elements can be written.
   size_t FreeCount() const { return N - FullCount(); }
+
+  bool IsFull() const { return FullCount() == N; }
 
   // Get the oldest element from the buffer, popping it from the buffer.
   std::optional<T> Get() {

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -179,7 +179,7 @@ class HalApi {
   // Returns a voltage.  On STM32 this can range from 0 to 3.3V.
   //
   // In test mode, will return the last value set via TESTSetAnalogPin.
-  Voltage AnalogRead(AnalogPin pin);
+  Voltage AnalogRead(AnalogPin pin) const;
 
 #ifdef TEST_MODE
   void TESTSetAnalogPin(AnalogPin pin, Voltage value);
@@ -429,7 +429,7 @@ inline void HalApi::WatchdogHandler() {}
 
 inline Time HalApi::Now() { return time_; }
 inline void HalApi::Delay(Duration d) { time_ = time_ + d; }
-inline Voltage HalApi::AnalogRead(AnalogPin pin) { return analog_pin_values_.at(pin); }
+inline Voltage HalApi::AnalogRead(AnalogPin pin) const { return analog_pin_values_.at(pin); }
 inline void HalApi::TESTSetAnalogPin(AnalogPin pin, Voltage value) {
   analog_pin_values_[pin] = value;
 }

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -764,11 +764,11 @@ void HalApi::EnableClock(volatile void *ptr) {
     hal.DisableInterrupts();
     // TODO: could have a call to Fault() for debug purposes, but not in
     // production
+  } else {
+    // Enable the clock of the requested peripheral
+    RccReg *rcc = RccBase;
+    rcc->peripheral_clock_enable[ndx] |= (1 << bit);
   }
-
-  // Enable the clock of the requested peripheral
-  RccReg *rcc = RccBase;
-  rcc->peripheral_clock_enable[ndx] |= (1 << bit);
 }
 
 static void StepperISR() { StepMotor::DmaISR(); }

--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -85,7 +85,7 @@ bool Channel::SendRequest(const Request &request) {
 
   // Queue the request if possible: check that there is room in the index
   // buffer
-  if (buffer_.FreeCount() <= 0) {
+  if (buffer_.IsFull()) {
     return false;
   }
 

--- a/software/controller/lib/sensors/oxygen.cpp
+++ b/software/controller/lib/sensors/oxygen.cpp
@@ -22,7 +22,7 @@ TeledyneR24::TeledyneR24(const char *name, const char *help_supplement, AnalogPi
 //
 // Output scales with partial pressure of O2, so ambient pressure must be
 // compensated to get an accurate FIO2.
-float TeledyneR24::read(HalApi &hal_api, Pressure p_ambient) const {
+float TeledyneR24::read(const HalApi &hal_api, Pressure p_ambient) const {
   // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
   // http://www.medicalsolutiontechnology.com/wp-content/uploads/2012/09/GO-04-DATA-SHEET.pdf
   // Sensitivity of 0.060V/fio2, where fio2 is 0.0 to 1.0, at pressure = 1atm

--- a/software/controller/lib/sensors/oxygen.h
+++ b/software/controller/lib/sensors/oxygen.h
@@ -21,5 +21,5 @@ class TeledyneR24 : public OxygenSensor, public AnalogSensor {
  public:
   TeledyneR24(const char* name, const char* help_supplement, AnalogPin pin);
 
-  float read(HalApi& hal_api, Pressure p_ambient) const override;
+  float read(const HalApi& hal_api, Pressure p_ambient) const override;
 };

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -21,7 +21,7 @@ AnalogPressureSensor::AnalogPressureSensor(const char *name, const char *help_su
       AnalogSensor(name, help_supplement, pin),
       voltage_to_kPa_(voltage_to_kPa) {}
 
-Pressure AnalogPressureSensor::read(HalApi &hal_api) const {
+Pressure AnalogPressureSensor::read(const HalApi &hal_api) const {
   auto ret = kPa(AnalogSensor::read_diff_volts(hal_api) * voltage_to_kPa_);
   dbg_pressure_.set(ret.cmH2O());
   return ret;

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -22,7 +22,7 @@ class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
   AnalogPressureSensor(const char *name, const char *help_supplement, AnalogPin pin,
                        float voltage_to_kPa);
 
-  Pressure read(HalApi &hal_api) const override;
+  Pressure read(const HalApi &hal_api) const override;
 
  private:
   // Assume linear relationship, pending further research

--- a/software/controller/lib/sensors/sensor_base.cpp
+++ b/software/controller/lib/sensors/sensor_base.cpp
@@ -28,12 +28,12 @@ AnalogSensor::AnalogSensor(const char *name, const char *help_supplement, Analog
   dbg_voltage_.append_help(help_supplement);
 }
 
-void AnalogSensor::set_zero(HalApi &hal_api) {
+void AnalogSensor::set_zero(const HalApi &hal_api) {
   zero_ = hal_api.AnalogRead(pin_);
   dbg_zero_.set(zero_.volts());
 }
 
-float AnalogSensor::read_diff_volts(HalApi &hal_api) const {
+float AnalogSensor::read_diff_volts(const HalApi &hal_api) const {
   auto ret = (hal_api.AnalogRead(pin_) - zero_).volts();
   dbg_voltage_.set(ret);
   return ret;

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -23,9 +23,9 @@ class AnalogSensor {
  public:
   AnalogSensor(const char *name, const char *help_supplement, AnalogPin pin);
 
-  void set_zero(HalApi &hal_api);
+  void set_zero(const HalApi &hal_api);
 
-  float read_diff_volts(HalApi &hal_api) const;
+  float read_diff_volts(const HalApi &hal_api) const;
 
  private:
   AnalogPin pin_;
@@ -37,7 +37,7 @@ class AnalogSensor {
 
 class PressureSensor {
  public:
-  virtual Pressure read(HalApi &hal_api) const = 0;
+  virtual Pressure read(const HalApi &hal_api) const = 0;
 
  protected:
   PressureSensor(const char *name, const char *help_supplement);
@@ -46,7 +46,7 @@ class PressureSensor {
 
 class FlowSensor {
  public:
-  virtual VolumetricFlow read(HalApi &hal_api, float air_density) const = 0;
+  virtual VolumetricFlow read(const HalApi &hal_api, float air_density) const = 0;
 
  protected:
   FlowSensor(const char *name, const char *help_supplement);
@@ -55,7 +55,7 @@ class FlowSensor {
 
 class OxygenSensor {
  public:
-  virtual float read(HalApi &hal_api, Pressure p_ambient) const = 0;
+  virtual float read(const HalApi &hal_api, Pressure p_ambient) const = 0;
 
  protected:
   OxygenSensor(const char *name, const char *help_supplement);

--- a/software/controller/lib/sensors/venturi.cpp
+++ b/software/controller/lib/sensors/venturi.cpp
@@ -47,7 +47,7 @@ VenturiFlowSensor::VenturiFlowSensor(const char* name, const char* help_suppleme
  * direction of flow, depending on how the differential sensor is attached to
  * the venturi.
  */
-VolumetricFlow VenturiFlowSensor::read(HalApi& hal_api, float air_density) const {
+VolumetricFlow VenturiFlowSensor::read(const HalApi& hal_api, float air_density) const {
   auto ret = pressure_delta_to_flow(pressure_sensor_->read(hal_api), air_density);
   dbg_flow_.set(ret.ml_per_sec());
   return ret;

--- a/software/controller/lib/sensors/venturi.h
+++ b/software/controller/lib/sensors/venturi.h
@@ -25,7 +25,7 @@ class VenturiFlowSensor : public FlowSensor {
                     float venturi_correction);
 
   /// \param air_density in units of kg/m^3, will depend on temperature and pressure
-  VolumetricFlow read(HalApi& hal_api, float air_density) const override;
+  VolumetricFlow read(const HalApi& hal_api, float air_density) const override;
 
   /// This is exposed as static so the math can be tested without HAL
   VolumetricFlow pressure_delta_to_flow(Pressure delta, float air_density) const;


### PR DESCRIPTION
# Description
Fixes some overlooked static check warnings. Remaining ones are either deliberate or false positives.

Note: a [recent update](https://docs.platformio.org/en/latest//core/history.html#id2) in platformio upgraded the static checkers and it looks like clang-tidy (v10 --> v12) no longer works properly (even the deliberate warnings seem gone...)
I did run the previous version of clang-tidy on this branch and it did remove lots of warnings.

List of remaining warnings and rationale behind them:
### cppcheck (stm32):

- `lib/hal/i2c.cpp:358: [low:style] Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]` ==> deliberate
- `lib/hal/hal_stm32.cpp:145: [low:style] Same expression on both sides of '-'. [duplicateExpression]` ==> deliberate: expression is `m - 1` and `m` might change in the future.
- `lib/hal/hal_stm32.cpp:752: [low:style] Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]` ==> deliberate
- `lib/hal/adc.cpp:220: [low:style] The comparison 'OversampleLog2 < 4' is always false. [knownConditionTrueFalse]` ==> constant `OversampleLog2` might change in the future
- `lib/hal/adc.cpp:220: [low:style] Same value in both branches of ternary operator. [duplicateValueTernary]` ==> constant `OversampleLog2` might change in the future

### clangtidy (stm32):

- `lib/core/blower_fsm.cpp:204: [medium:warning] switch has 3 consecutive identical branches  [bugprone-branch-clone]` ==> false positive
- `lib/core/controller.h:139: [medium:warning] invalid case style for member 'dbg_loop_period_'  [readability-identifier-naming]` ==> false positive
- `lib/core/nvparams.cpp:166: [medium:warning] redundant boolean literal in conditional return statement  [readability-simplify-boolean-expr]` ==> false positive
- `lib/core/nvparams.cpp:173: [medium:warning] method 'Update' can be made const  [readability-make-member-function-const]` ==> false positive
- `lib/core/sensors.h:96: [medium:warning] invalid case style for member 'air_influx_sensor_'  [readability-identifier-naming]` ==> false positive
- `lib/core/sensors.h:99: [medium:warning] invalid case style for member 'oxygen_influx_sensor_'  [readability-identifier-naming]` ==> false positive
- `lib/core/sensors.h:103: [medium:warning] invalid case style for member 'outflow_sensor_'  [readability-identifier-naming]` ==> false positive
- `lib/debug/trace.cpp:71: [medium:warning] redundant boolean literal in conditional return statement  [readability-simplify-boolean-expr]` ==> false positive
- `lib/debug/trace.cpp:106: [medium:warning] redundant boolean literal in conditional return statement  [readability-simplify-boolean-expr]` ==> false positive
- `lib/hal/eeprom.cpp:22: [medium:warning] pointer parameter 'processed' can be pointer to const  [readability-non-const-parameter]` ==> false positive
- `lib/hal/eeprom.cpp:59: [medium:warning] pointer parameter 'processed' can be pointer to const  [readability-non-const-parameter]` ==> false positive
- `lib/hal/hal_stm32.cpp:254: [medium:warning] switch has 2 consecutive identical branches  [bugprone-branch-clone]` ==> false positive
- `lib/sensors/pressure_sensors.cpp:19: [medium:warning] invalid case style for parameter 'voltage_to_kPa'  [readability-identifier-naming]` ==> deliberate: the capitalization of kPa is meaningful
- `lib/sensors/pressure_sensors.h:23: [medium:warning] invalid case style for parameter 'voltage_to_kPa'  [readability-identifier-naming]` ==> deliberate: the capitalization of kPa is meaningful
- `lib/sensors/pressure_sensors.h:29: [medium:warning] invalid case style for private member 'voltage_to_kPa_'  [readability-identifier-naming]` ==> deliberate: the capitalization of kPa is meaningful


# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x]  I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
