### PR TITLE
Abstract GPIO pin and their mapping in higher layers

### DIFF
--- a/software/controller/integration_tests/blower_test.h
+++ b/software/controller/integration_tests/blower_test.h
@@ -8,8 +8,8 @@
 //      TBD - which python script to run?
 //
 
-#include "actuators.h"
 #include "hal.h"
+#include "pwm_actuator.h"
 #include "system_constants.h"
 #include "system_timer.h"
 #include "watchdog.h"

--- a/software/controller/integration_tests/blower_test.h
+++ b/software/controller/integration_tests/blower_test.h
@@ -21,8 +21,8 @@ static constexpr float InitialStep{0.002f};
 
 void RunTest() {
   hal.Init();
-  PwmActuator blower{PwmPin::Blower, Actuators::BlowerFreq, "blower_", " of the blower"};
-  blower.initialize_pwm(HalApi::GetCpuFreq());
+  PwmActuator blower{Actuators::BlowerChannel, Actuators::BlowerFreq, HalApi::GetCpuFreq(),
+                     "blower_", " of the blower"};
 
   float fan_power = FanMin;
   float step = InitialStep;

--- a/software/controller/integration_tests/blower_test.h
+++ b/software/controller/integration_tests/blower_test.h
@@ -10,6 +10,7 @@
 
 #include "actuators.h"
 #include "hal.h"
+#include "system_constants.h"
 #include "system_timer.h"
 #include "watchdog.h"
 
@@ -21,8 +22,7 @@ static constexpr float InitialStep{0.002f};
 
 void RunTest() {
   hal.Init();
-  PwmActuator blower{Actuators::BlowerChannel, Actuators::BlowerFreq, HalApi::GetCpuFreq(),
-                     "blower_", " of the blower"};
+  PwmActuator blower{BlowerChannel, BlowerFreq, HalApi::GetCpuFreq(), "blower_", " of the blower"};
 
   float fan_power = FanMin;
   float step = InitialStep;

--- a/software/controller/integration_tests/buzzer_test.h
+++ b/software/controller/integration_tests/buzzer_test.h
@@ -8,7 +8,9 @@
 // Automation:
 //      TBD - which python script to run?
 //
+#include "actuator_base.h"
 #include "hal.h"
+#include "system_constants.h"
 #include "system_timer.h"
 
 // test parameters
@@ -25,11 +27,14 @@ void RunTest() {
 
   bool buzzer_on{false};
 
+  PwmActuator buzzer{BuzzerChannel,    BuzzerFreq, HalApi::GetCpuFreq(), "buzzer_",
+                     " of the buzzer", BuzzerOff,  MaxBuzzerVolume};
+
   while (true) {
     if (buzzer_on) {
-      hal.buzzer->set(volume);
+      buzzer.set(volume);
     } else {
-      hal.buzzer->set(0);
+      buzzer.set(0);
     }
 
     SystemTimer::singleton().delay(Delay);

--- a/software/controller/integration_tests/buzzer_test.h
+++ b/software/controller/integration_tests/buzzer_test.h
@@ -27,9 +27,9 @@ void RunTest() {
 
   while (true) {
     if (buzzer_on) {
-      hal.buzzer.set(volume);
+      hal.buzzer->set(volume);
     } else {
-      hal.buzzer.set(0);
+      hal.buzzer->set(0);
     }
 
     SystemTimer::singleton().delay(Delay);

--- a/software/controller/integration_tests/buzzer_test.h
+++ b/software/controller/integration_tests/buzzer_test.h
@@ -8,8 +8,8 @@
 // Automation:
 //      TBD - which python script to run?
 //
-#include "actuator_base.h"
 #include "hal.h"
+#include "pwm_actuator.h"
 #include "system_constants.h"
 #include "system_timer.h"
 

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -46,9 +46,11 @@
 //      TBD - which python script to run?
 //
 
+#include "actuator_base.h"
 #include "commands.h"
 #include "hal.h"
 #include "interface.h"
+#include "system_constants.h"
 #include "system_timer.h"
 #include "vars.h"
 
@@ -97,7 +99,10 @@ void RunTest() {
     write_data[i] = Data;
   }
 
-  hal.buzzer->set(0.1f);
+  PwmActuator buzzer{BuzzerChannel,    BuzzerFreq, HalApi::GetCpuFreq(), "buzzer_",
+                     " of the buzzer", BuzzerOff,  MaxBuzzerVolume};
+
+  buzzer.set(0.1f);
   eeprom.ReadBytes(Address, Length, &eeprom_before, nullptr);
 
   eeprom.WriteBytes(Address, Length, &write_data, nullptr);
@@ -135,7 +140,7 @@ void RunTest() {
   while (true) {
     // stop the buzzer after 1 second if the test is a success
     if (!failed && SystemTimer::singleton().now() > microsSinceStartup(1000000)) {
-      hal.buzzer->set(0.0f);
+      buzzer.set(0.0f);
     }
 
     debug.Poll();

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -46,10 +46,10 @@
 //      TBD - which python script to run?
 //
 
-#include "actuator_base.h"
 #include "commands.h"
 #include "hal.h"
 #include "interface.h"
+#include "pwm_actuator.h"
 #include "system_constants.h"
 #include "system_timer.h"
 #include "vars.h"

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -97,7 +97,7 @@ void RunTest() {
     write_data[i] = Data;
   }
 
-  hal.buzzer.set(0.1f);
+  hal.buzzer->set(0.1f);
   eeprom.ReadBytes(Address, Length, &eeprom_before, nullptr);
 
   eeprom.WriteBytes(Address, Length, &write_data, nullptr);
@@ -135,7 +135,7 @@ void RunTest() {
   while (true) {
     // stop the buzzer after 1 second if the test is a success
     if (!failed && SystemTimer::singleton().now() > microsSinceStartup(1000000)) {
-      hal.buzzer.set(0.0f);
+      hal.buzzer->set(0.0f);
     }
 
     debug.Poll();

--- a/software/controller/integration_tests/psol_test.h
+++ b/software/controller/integration_tests/psol_test.h
@@ -8,8 +8,8 @@
 //      TBD - which python script to run?
 //
 
-#include "actuators.h"
 #include "hal.h"
+#include "pwm_actuator.h"
 #include "system_constants.h"
 #include "system_timer.h"
 #include "watchdog.h"

--- a/software/controller/integration_tests/psol_test.h
+++ b/software/controller/integration_tests/psol_test.h
@@ -21,8 +21,13 @@ static constexpr float InitialStep{TEST_PARAM_3};
 
 void RunTest() {
   hal.Init();
-  PwmActuator psol{PwmPin::Psol, Actuators::PSolFreq, "psol_", " of the proportional solenoid"};
-  psol.initialize_pwm(HalApi::GetCpuFreq());
+  PwmActuator psol{Actuators::PSolChannel,
+                   Actuators::PSolFreq,
+                   HalApi::GetCpuFreq(),
+                   "psol_",
+                   " of the proportional solenoid",
+                   0.35f,
+                   0.75f};
 
   float psol_position = PSolMin;
   float step = InitialStep;

--- a/software/controller/integration_tests/psol_test.h
+++ b/software/controller/integration_tests/psol_test.h
@@ -10,6 +10,7 @@
 
 #include "actuators.h"
 #include "hal.h"
+#include "system_constants.h"
 #include "system_timer.h"
 #include "watchdog.h"
 
@@ -21,13 +22,9 @@ static constexpr float InitialStep{TEST_PARAM_3};
 
 void RunTest() {
   hal.Init();
-  PwmActuator psol{Actuators::PSolChannel,
-                   Actuators::PSolFreq,
-                   HalApi::GetCpuFreq(),
-                   "psol_",
-                   " of the proportional solenoid",
-                   0.35f,
-                   0.75f};
+  PwmActuator psol{
+      PSolChannel, PSolFreq, HalApi::GetCpuFreq(), "psol_", " of the proportional solenoid",
+      PSolClosed,  PSolOpen};
 
   float psol_position = PSolMin;
   float step = InitialStep;

--- a/software/controller/lib/actuators/actuator_base.h
+++ b/software/controller/lib/actuators/actuator_base.h
@@ -17,8 +17,8 @@ limitations under the License.
 
 #include <stdint.h>
 
-#include "gpio.h"
 #include "interpolant.h"
+#include "pwm.h"
 
 class Actuator {
  public:

--- a/software/controller/lib/actuators/actuator_base.h
+++ b/software/controller/lib/actuators/actuator_base.h
@@ -17,8 +17,8 @@ limitations under the License.
 
 #include <stdint.h>
 
+#include "gpio.h"
 #include "interpolant.h"
-#include "pwm.h"
 
 class Actuator {
  public:

--- a/software/controller/lib/actuators/actuator_base.h
+++ b/software/controller/lib/actuators/actuator_base.h
@@ -18,7 +18,6 @@ limitations under the License.
 #include <stdint.h>
 
 #include "interpolant.h"
-#include "pwm.h"
 
 class Actuator {
  public:

--- a/software/controller/lib/actuators/actuators.h
+++ b/software/controller/lib/actuators/actuators.h
@@ -50,23 +50,25 @@ class Actuators {
   // The system should be kept in a safe state until this returns true.
   bool ready();
 
-  // links actuators calibration tables to nv_params.
-  void link(NVParams::Handler *nv_params, uint16_t blower_pinch_cal_offset,
+  // Creates pwm actuators and links actuators calibration tables to nv_params.
+  void Init(Frequency cpu_frequency, NVParams::Handler *nv_params, uint16_t blower_pinch_cal_offset,
             uint16_t exhale_pinch_cal_offset, uint16_t blower_cal_offset, uint16_t psol_cal_offset);
-
-  void Init(Frequency cpu_frequency);
 
   // Causes passed state to be applied to the actuators
   void execute(const ActuatorsState &desired_state);
 
-  static GPIO::PwmChannel BlowerChannel;
+  // Blower is hooked up to PB3 (see [PCB]),
+  // which can be linked to Timer2 chanel 2 using AF1 (see [DS], p77)
+  static constexpr GPIO::PwmChannel BlowerChannel = {
+      GPIO::Port::B, 3, GPIO::AlternativeFunction::AF1, PeripheralID::Timer2, 2};
   // Blower is driven by a 20kHz PWM, as a compromise between resolution and response time
   /// TODO: add/find a better rationale for this, maybe with the resulting response time/resolution
   static constexpr Frequency BlowerFreq = kilohertz(20);
 
-  // Blower is hooked up to PA11 (see [PCB]),
-  // which can be linked to Timer1 chanel 4 using AF1 (see [DS], p77)
-  static GPIO::PwmChannel PSolChannel;
+  // psol is hooked up to PA11 (see [PCB]),
+  // which can be linked to Timer1 chanel 4 using AF1 (see [DS], p76)
+  static constexpr GPIO::PwmChannel PSolChannel = {
+      GPIO::Port::A, 11, GPIO::AlternativeFunction::AF1, PeripheralID::Timer1, 4};
 
   // Psol is driven by a 5kHz PWM (\TODO: find rationale behind this?)
   static constexpr Frequency PSolFreq = kilohertz(5);

--- a/software/controller/lib/actuators/actuators.h
+++ b/software/controller/lib/actuators/actuators.h
@@ -59,21 +59,23 @@ class Actuators {
   // Causes passed state to be applied to the actuators
   void execute(const ActuatorsState &desired_state);
 
+  static GPIO::PwmChannel BlowerChannel;
   // Blower is driven by a 20kHz PWM, as a compromise between resolution and response time
   /// TODO: add/find a better rationale for this, maybe with the resulting response time/resolution
   static constexpr Frequency BlowerFreq = kilohertz(20);
-  // psol is driven by a 5kHz PWM
-  /// TODO: find the rationale behind this
+
+  // Blower is hooked up to PA11 (see [PCB]),
+  // which can be linked to Timer1 chanel 4 using AF1 (see [DS], p77)
+  static GPIO::PwmChannel PSolChannel;
+
+  // Psol is driven by a 5kHz PWM (\TODO: find rationale behind this?)
   static constexpr Frequency PSolFreq = kilohertz(5);
 
  private:
   PinchValve blower_pinch_;
   PinchValve exhale_pinch_;
+  // Blower and PSol use pwm pins and need to be instantiated after HAL, therefore we
+  // use std::optional to delay the instantiation within Init function.
   std::optional<PwmActuator> blower_{std::nullopt};
-
-  // Testing in Edwin's garage, we found that the psol was fully closed at
-  // somewhere between 0.75 and 0.80 (i.e. definitely zero at 0.75 and probably
-  // zero a bit above that) and fully open at 0.90.
-  // \TODO: the values in the comment are inconsistent with the code, have Edwin confirm those.
   std::optional<PwmActuator> psol_{std::nullopt};
 };

--- a/software/controller/lib/actuators/actuators.h
+++ b/software/controller/lib/actuators/actuators.h
@@ -69,11 +69,11 @@ class Actuators {
  private:
   PinchValve blower_pinch_;
   PinchValve exhale_pinch_;
-  PwmActuator blower_{PwmPin::Blower, BlowerFreq, "blower_", " of the blower"};
+  std::optional<PwmActuator> blower_{std::nullopt};
 
   // Testing in Edwin's garage, we found that the psol was fully closed at
   // somewhere between 0.75 and 0.80 (i.e. definitely zero at 0.75 and probably
   // zero a bit above that) and fully open at 0.90.
   // \TODO: the values in the comment are inconsistent with the code, have Edwin confirm those.
-  PwmActuator psol_{PwmPin::Psol, PSolFreq, "psol_", " of the proportional solenoid", 0.35f, 0.75f};
+  std::optional<PwmActuator> psol_{std::nullopt};
 };

--- a/software/controller/lib/actuators/pwm_actuator.h
+++ b/software/controller/lib/actuators/pwm_actuator.h
@@ -23,8 +23,8 @@ limitations under the License.
 class PwmActuator : public Actuator {
  public:
   PwmActuator(GPIO::PwmChannel channel, Frequency pwm_freq, Frequency cpu_frequency,
-              const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f);
-    : Actuator(name, help, cal_0, cal_1), pwm_pin_(channel, pwm_freq, cpu_frequency) {};
+              const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f)
+      : Actuator(name, help, cal_0, cal_1), pwm_pin_(channel, pwm_freq, cpu_frequency){};
 
   void set(const float value) { pwm_pin_.set(get_value(value)); }
 

--- a/software/controller/lib/actuators/pwm_actuator.h
+++ b/software/controller/lib/actuators/pwm_actuator.h
@@ -22,8 +22,8 @@ limitations under the License.
 
 class PwmActuator : public Actuator {
  public:
-  PwmActuator(GPIO::PwmChannel channel, const Frequency pwm_freq, const Frequency cpu_frequency,
-              const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f)
+  PwmActuator(GPIO::PwmChannel channel, Frequency pwm_freq, Frequency cpu_frequency,
+              const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f);
     : Actuator(name, help, cal_0, cal_1), pwm_pin_(channel, pwm_freq, cpu_frequency) {};
 
   void set(const float value) { pwm_pin_.set(get_value(value)); }

--- a/software/controller/lib/actuators/pwm_actuator.h
+++ b/software/controller/lib/actuators/pwm_actuator.h
@@ -26,7 +26,7 @@ class PwmActuator : public Actuator {
               const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f)
       : Actuator(name, help, cal_0, cal_1), pwm_pin_(channel, pwm_freq, cpu_frequency){};
 
-  void set(const float value) { pwm_pin_.set(get_value(value)); }
+  void set(const float value) { pwm_pin_.set(Actuator::get_value(value)); }
 
  private:
   GPIO::PwmPin pwm_pin_;

--- a/software/controller/lib/actuators/pwm_actuator.h
+++ b/software/controller/lib/actuators/pwm_actuator.h
@@ -22,15 +22,12 @@ limitations under the License.
 
 class PwmActuator : public Actuator {
  public:
-  PwmActuator(GPIO::Port port, uint8_t pin, const GPIO::AlternativeFunction func,
-              const Frequency pwm_freq, TimerReg *timer, uint8_t channel,
-              const PeripheralID peripheral, const Frequency cpu_frequency, const char *name,
-              const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f);
-      : Actuator(name, help, cal_0, cal_1),
-      pwm_pin_(port, pin, func, pwm_freq, timer, channel, peripheral, cpu_frequency){};
+  PwmActuator(GPIO::PwmChannel channel, const Frequency pwm_freq, const Frequency cpu_frequency,
+              const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f)
+    : Actuator(name, help, cal_0, cal_1), pwm_pin_(channel, pwm_freq, cpu_frequency) {};
 
   void set(const float value) { pwm_pin_.set(get_value(value)); }
 
  private:
-  GPIO::AnalogOutputPin pwm_pin_;
+  GPIO::PwmPin pwm_pin_;
 };

--- a/software/controller/lib/actuators/pwm_actuator.h
+++ b/software/controller/lib/actuators/pwm_actuator.h
@@ -22,14 +22,15 @@ limitations under the License.
 
 class PwmActuator : public Actuator {
  public:
-  PwmActuator(const PwmPin pin, const Frequency pwm_freq, const char *name, const char *help,
-              float cal_0 = 0.0f, float cal_1 = 1.0f)
-      : Actuator(name, help, cal_0, cal_1), pwm_(pin, pwm_freq){};
+  PwmActuator(GPIO::Port port, uint8_t pin, const GPIO::AlternativeFunction func,
+              const Frequency pwm_freq, TimerReg *timer, uint8_t channel,
+              const PeripheralID peripheral, const Frequency cpu_frequency, const char *name,
+              const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f);
+      : Actuator(name, help, cal_0, cal_1),
+      pwm_pin_(port, pin, func, pwm_freq, timer, channel, peripheral, cpu_frequency){};
 
-  void initialize_pwm(Frequency cpu_frequency) { pwm_.initialize(cpu_frequency); }
-
-  void set(const float value) { pwm_.set(get_value(value)); }
+  void set(const float value) { pwm_pin_.set(get_value(value)); }
 
  private:
-  PWM pwm_;
+  GPIO::AnalogOutputPin pwm_pin_;
 };

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include "system_constants.h"
 
 void Actuators::execute(const ActuatorsState &desired_state) {
-  if (!ready()) return;
   // set blower PWM
   blower_->set(desired_state.blower_power);
 

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -44,7 +44,7 @@ void Actuators::init(Frequency cpu_frequency, NVParams::Handler *nv_params,
   blower_.emplace(BlowerChannel, BlowerFreq, cpu_frequency, "blower_", " of the blower");
 
   psol_.emplace(PSolChannel, PSolFreq, cpu_frequency, "psol_", " of the proportional solenoid",
-                psol_value_closed, psol_value_open);
+                PSolClosed, PSolOpen);
 
   // In case init was called with nullptr, these fail silently
   blower_pinch_.LinkCalibration(nv_params, blower_pinch_cal_offset);

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -45,6 +45,9 @@ void Actuators::init(Frequency cpu_frequency, NVParams::Handler *nv_params,
   psol_.emplace(PSolChannel, PSolFreq, cpu_frequency, "psol_", " of the proportional solenoid",
                 PSolClosed, PSolOpen);
 
+  buzzer.emplace(BuzzerChannel, BuzzerFreq, cpu_frequency, "buzzer_", "of the buzzer", BuzzerOff,
+                 MaxBuzzerVolume);
+
   // In case init was called with nullptr, these fail silently
   blower_pinch_.LinkCalibration(nv_params, blower_pinch_cal_offset);
   exhale_pinch_.LinkCalibration(nv_params, exhale_pinch_cal_offset);

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "actuators.h"
 
+#include "system_constants.h"
+
 void Actuators::execute(const ActuatorsState &desired_state) {
   if (!ready()) return;
   // set blower PWM
@@ -41,12 +43,8 @@ void Actuators::init(Frequency cpu_frequency, NVParams::Handler *nv_params,
   // For now, the blower uses default calibration values, linearly spaced between 0 and 1
   blower_.emplace(BlowerChannel, BlowerFreq, cpu_frequency, "blower_", " of the blower");
 
-  // Testing in Edwin's garage, we found that the psol was fully closed at
-  // somewhere between 0.75 and 0.80 (i.e. definitely zero at 0.75 and probably
-  // zero a bit above that) and fully open at 0.90.
-  // \TODO: the values in the comment are inconsistent with the code, have Edwin confirm those.
   psol_.emplace(PSolChannel, PSolFreq, cpu_frequency, "psol_", " of the proportional solenoid",
-                0.35f, 0.75f);
+                psol_value_closed, psol_value_open);
 
   // In case init was called with nullptr, these fail silently
   blower_pinch_.LinkCalibration(nv_params, blower_pinch_cal_offset);

--- a/software/controller/lib/core/actuators.h
+++ b/software/controller/lib/core/actuators.h
@@ -51,7 +51,7 @@ class Actuators {
   bool ready();
 
   // Creates pwm actuators and links actuators calibration tables to nv_params.
-  void Init(Frequency cpu_frequency, NVParams::Handler *nv_params, uint16_t blower_pinch_cal_offset,
+  void init(Frequency cpu_frequency, NVParams::Handler *nv_params, uint16_t blower_pinch_cal_offset,
             uint16_t exhale_pinch_cal_offset, uint16_t blower_cal_offset, uint16_t psol_cal_offset);
 
   // Causes passed state to be applied to the actuators
@@ -77,7 +77,7 @@ class Actuators {
   PinchValve blower_pinch_;
   PinchValve exhale_pinch_;
   // Blower and PSol use pwm pins and need to be instantiated after HAL, therefore we
-  // use std::optional to delay the instantiation within Init function.
+  // use std::optional to delay the instantiation within init function.
   std::optional<PwmActuator> blower_{std::nullopt};
   std::optional<PwmActuator> psol_{std::nullopt};
 };

--- a/software/controller/lib/core/actuators.h
+++ b/software/controller/lib/core/actuators.h
@@ -60,8 +60,12 @@ class Actuators {
  private:
   PinchValve blower_pinch_;
   PinchValve exhale_pinch_;
-  // Blower and PSol use pwm pins and need to be instantiated after HAL, therefore we
+  // Blower, PSol and buzzer use pwm pins and need to be instantiated after HAL, therefore we
   // use std::optional to delay the instantiation within init function.
   std::optional<PwmActuator> blower_{std::nullopt};
   std::optional<PwmActuator> psol_{std::nullopt};
+
+ public:
+  // buzzer is made public to allow easier manipulation (not through actuators.execute()).
+  std::optional<PwmActuator> buzzer{std::nullopt};
 };

--- a/software/controller/lib/core/actuators.h
+++ b/software/controller/lib/core/actuators.h
@@ -57,22 +57,6 @@ class Actuators {
   // Causes passed state to be applied to the actuators
   void execute(const ActuatorsState &desired_state);
 
-  // Blower is hooked up to PB3 (see [PCB]),
-  // which can be linked to Timer2 chanel 2 using AF1 (see [DS], p77)
-  static constexpr GPIO::PwmChannel BlowerChannel = {
-      GPIO::Port::B, 3, GPIO::AlternativeFunction::AF1, PeripheralID::Timer2, 2};
-  // Blower is driven by a 20kHz PWM, as a compromise between resolution and response time
-  /// TODO: add/find a better rationale for this, maybe with the resulting response time/resolution
-  static constexpr Frequency BlowerFreq = kilohertz(20);
-
-  // psol is hooked up to PA11 (see [PCB]),
-  // which can be linked to Timer1 chanel 4 using AF1 (see [DS], p76)
-  static constexpr GPIO::PwmChannel PSolChannel = {
-      GPIO::Port::A, 11, GPIO::AlternativeFunction::AF1, PeripheralID::Timer1, 4};
-
-  // Psol is driven by a 5kHz PWM (\TODO: find rationale behind this?)
-  static constexpr Frequency PSolFreq = kilohertz(5);
-
  private:
   PinchValve blower_pinch_;
   PinchValve exhale_pinch_;

--- a/software/controller/lib/core/blower_fsm.cpp
+++ b/software/controller/lib/core/blower_fsm.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 
 #include "controller.h"
+#include "system_constants.h"
 #include "vars.h"
 
 // dbg_pa_* are pressure assist configuration vars.

--- a/software/controller/lib/core/blower_fsm.h
+++ b/software/controller/lib/core/blower_fsm.h
@@ -87,10 +87,6 @@ struct BlowerSystemState {
   bool is_end_of_breath = false;
 };
 
-// Transition from PEEP to PIP pressure over this length of time.  Citation:
-// https://respiraworks.slack.com/archives/C011CJQV4Q7/p1591763842312500?thread_ts=1591759016.310200&cid=C011CJQV4Q7
-inline constexpr Duration RiseTime = milliseconds(100);
-
 // A "breath finite state machine" where the blower is always off.
 //
 // All breath FSMs should implement the following "duck-typed API".

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -19,9 +19,9 @@ limitations under the License.
 
 #include <algorithm>
 
-static constexpr Duration LoopPeriod = milliseconds(10);
+#include "system_constants.h"
 
-Duration Controller::GetLoopPeriod() { return LoopPeriod; }
+Duration Controller::GetLoopPeriod() { return MainLoopPeriod; }
 
 std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentParams &params,
                                                            const SensorReadings &sensor_readings) {

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <math.h>
 
+#include <algorithm>
+
 static constexpr Duration LoopPeriod = milliseconds(10);
 
 /*static*/ Duration Controller::GetLoopPeriod() { return LoopPeriod; }

--- a/software/controller/lib/core/controller.cpp
+++ b/software/controller/lib/core/controller.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 
 static constexpr Duration LoopPeriod = milliseconds(10);
 
-/*static*/ Duration Controller::GetLoopPeriod() { return LoopPeriod; }
+Duration Controller::GetLoopPeriod() { return LoopPeriod; }
 
 std::pair<ActuatorsState, ControllerState> Controller::Run(Time now, const VentParams &params,
                                                            const SensorReadings &sensor_readings) {

--- a/software/controller/lib/core/flow_integrator.cpp
+++ b/software/controller/lib/core/flow_integrator.cpp
@@ -15,8 +15,7 @@ limitations under the License.
 
 #include "flow_integrator.h"
 
-// TODO: VolumeIntegrationInterval was not chosen carefully.
-static constexpr Duration VolumeIntegrationInterval = milliseconds(5);
+#include "system_constants.h"
 
 FlowIntegrator::FlowIntegrator() = default;
 

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -42,19 +42,19 @@ Sensors::Sensors() = default;
 
 // NOTE - I can't do this in the constructor because the Hal needs to be initialized
 // and we need to be able to write to the registers
-void Sensors::init(ADC *adc, Frequency cpu_frequency) {
+void Sensors::init(Frequency cpu_frequency) {
   // Here we create all sensors and initialize the adc.
   patient_pressure_sensor_.emplace("patient_pressure_", "for patient airway pressure",
-                                   GPIO::Port::C, 0, adc, adc_channel(Sensor::PatientPressure),
+                                   GPIO::Port::C, 0, &adc_, adc_channel(Sensor::PatientPressure),
                                    ADCVoltageRange);
-  fio2_sensor_.emplace("fio2", "Fraction of oxygen in supplied air", GPIO::Port::C, 3, adc,
+  fio2_sensor_.emplace("fio2", "Fraction of oxygen in supplied air", GPIO::Port::C, 3, &adc_,
                        adc_channel(Sensor::FIO2));
-  air_influx_sensor_dp_.emplace("air_influx_", "for ambient air influx", GPIO::Port::A, 4, adc,
+  air_influx_sensor_dp_.emplace("air_influx_", "for ambient air influx", GPIO::Port::A, 4, &adc_,
                                 adc_channel(Sensor::AirInflowPressureDiff), ADCVoltageRange);
   oxygen_influx_sensor_dp_.emplace("oxygen_influx_", "for concentrated oxygen influx",
-                                   GPIO::Port::A, 1, adc,
+                                   GPIO::Port::A, 1, &adc_,
                                    adc_channel(Sensor::OxygenInflowPressureDiff), ADCVoltageRange);
-  outflow_sensor_dp_.emplace("outflow_", "for outflow", GPIO::Port::B, 0, adc,
+  outflow_sensor_dp_.emplace("outflow_", "for outflow", GPIO::Port::B, 0, &adc_,
                              adc_channel(Sensor::OutflowPressureDiff), ADCVoltageRange);
   // These require existing DP sensors to link to
   air_influx_sensor_.emplace("air_influx_", "for ambient air influx",
@@ -67,7 +67,7 @@ void Sensors::init(ADC *adc, Frequency cpu_frequency) {
                           VenturiPortDiameter, VenturiChokeDiameter, VenturiCorrection);
 
   /// \TODO: fault somehow if this returns false
-  [[maybe_unused]] bool buffer_size_sufficient = adc->initialize(cpu_frequency);
+  [[maybe_unused]] bool buffer_size_sufficient = adc_.initialize(cpu_frequency);
 
   // We wait 20ms from power-on-reset for pressure sensors to warm up.
   //

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -45,16 +45,16 @@ Sensors::Sensors() = default;
 void Sensors::init(Frequency cpu_frequency) {
   // Here we create all sensors and initialize the adc.
   patient_pressure_sensor_.emplace("patient_pressure_", "for patient airway pressure",
-                                   GPIO::Port::C, 0, &adc_, adc_channel(Sensor::PatientPressure),
+                                   GPIO::Port::C, 0, &adc, adc_channel(Sensor::PatientPressure),
                                    ADCVoltageRange);
-  fio2_sensor_.emplace("fio2", "Fraction of oxygen in supplied air", GPIO::Port::C, 3, &adc_,
+  fio2_sensor_.emplace("fio2", "Fraction of oxygen in supplied air", GPIO::Port::C, 3, &adc,
                        adc_channel(Sensor::FIO2));
-  air_influx_sensor_dp_.emplace("air_influx_", "for ambient air influx", GPIO::Port::A, 4, &adc_,
+  air_influx_sensor_dp_.emplace("air_influx_", "for ambient air influx", GPIO::Port::A, 4, &adc,
                                 adc_channel(Sensor::AirInflowPressureDiff), ADCVoltageRange);
   oxygen_influx_sensor_dp_.emplace("oxygen_influx_", "for concentrated oxygen influx",
-                                   GPIO::Port::A, 1, &adc_,
+                                   GPIO::Port::A, 1, &adc,
                                    adc_channel(Sensor::OxygenInflowPressureDiff), ADCVoltageRange);
-  outflow_sensor_dp_.emplace("outflow_", "for outflow", GPIO::Port::B, 0, &adc_,
+  outflow_sensor_dp_.emplace("outflow_", "for outflow", GPIO::Port::B, 0, &adc,
                              adc_channel(Sensor::OutflowPressureDiff), ADCVoltageRange);
   // These require existing DP sensors to link to
   air_influx_sensor_.emplace("air_influx_", "for ambient air influx",
@@ -67,7 +67,7 @@ void Sensors::init(Frequency cpu_frequency) {
                           VenturiPortDiameter, VenturiChokeDiameter, VenturiCorrection);
 
   /// \TODO: fault somehow if this returns false
-  [[maybe_unused]] bool buffer_size_sufficient = adc_.initialize(cpu_frequency);
+  [[maybe_unused]] bool buffer_size_sufficient = adc.initialize(cpu_frequency);
 
   // We wait 20ms from power-on-reset for pressure sensors to warm up.
   //

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -15,29 +15,7 @@ limitations under the License.
 
 #include "sensors.h"
 
-#include "system_constants.h"
 #include "system_timer.h"
-
-//////////////////////////////////////////////////////////////////
-//                   SENSOR LOGICAL MAPPINGS                    //
-//   Change these if you route your sensor tubing differently   //
-//////////////////////////////////////////////////////////////////
-GPIO::AdcChannel adc_channel(Sensor s) {
-  switch (s) {
-    case Sensor::PatientPressure:
-      return InterimBoardAnalogPressure;
-    case Sensor::OxygenInflowPressureDiff:
-      return U3PatientPressure;
-    case Sensor::AirInflowPressureDiff:
-      return U4InhaleFlow;
-    case Sensor::OutflowPressureDiff:
-      return U5ExhaleFlow;
-    case Sensor::FIO2:
-      return InterimBoardOxygenSensor;
-  }
-  // Switch above covers all cases.
-  __builtin_unreachable();
-}
 
 Sensors::Sensors() = default;
 

--- a/software/controller/lib/core/sensors.cpp
+++ b/software/controller/lib/core/sensors.cpp
@@ -46,16 +46,17 @@ Sensors::Sensors() = default;
 void Sensors::init(Frequency cpu_frequency) {
   // Here we create all sensors and initialize the adc.
   patient_pressure_sensor_.emplace("patient_pressure_", "for patient airway pressure",
-                                   adc_channel(Sensor::PatientPressure), &adc, ADCVoltageRange);
+                                   adc_channel(Sensor::PatientPressure), &adc, ADC::VoltageRange);
   fio2_sensor_.emplace("fio2", "Fraction of oxygen in supplied air", adc_channel(Sensor::FIO2),
                        &adc);
   air_influx_sensor_dp_.emplace("air_influx_", "for ambient air influx",
-                                adc_channel(Sensor::AirInflowPressureDiff), &adc, ADCVoltageRange);
+                                adc_channel(Sensor::AirInflowPressureDiff), &adc,
+                                ADC::VoltageRange);
   oxygen_influx_sensor_dp_.emplace("oxygen_influx_", "for concentrated oxygen influx",
                                    adc_channel(Sensor::OxygenInflowPressureDiff), &adc,
-                                   ADCVoltageRange);
+                                   ADC::VoltageRange);
   outflow_sensor_dp_.emplace("outflow_", "for outflow", adc_channel(Sensor::OutflowPressureDiff),
-                             &adc, ADCVoltageRange);
+                             &adc, ADC::VoltageRange);
 
   // These require existing DP sensors to link to
   air_influx_sensor_.emplace("air_influx_", "for ambient air influx",

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -66,11 +66,12 @@ class Sensors {
   // Read the sensors.
   SensorReadings get_readings() const;
 
+  // for testing purposes, I made this a public member
+  ADC adc;
+
  private:
   /// \TODO: get this either from ADC constants header or something like that
   static constexpr float ADCVoltageRange{3.3f};
-
-  ADC adc_;
 
   // \TODO: create a physical constants header for custom parts like venturi
   // Diameters and correction coefficient relating to 3/4in Venturi, see https://bit.ly/2ARuReg.

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -85,14 +85,16 @@ class Sensors {
   static_assert(VenturiPortDiameter > VenturiChokeDiameter);
   static_assert(VenturiChokeDiameter > meters(0));
 
-  // Fundamental sensors
+  // Fundamental sensors. Because those use GPIO Pins, we need to delay instantiation to after
+  // the Hal has been properly initialized. We use std::optional to achieve that, and emplace them
+  // within init function
   std::optional<MPXV5010DP> patient_pressure_sensor_{std::nullopt};
   std::optional<TeledyneR24> fio2_sensor_{std::nullopt};
   std::optional<MPXV5004DP> air_influx_sensor_dp_{std::nullopt};
   std::optional<MPXV5004DP> oxygen_influx_sensor_dp_{std::nullopt};
   std::optional<MPXV5004DP> outflow_sensor_dp_{std::nullopt};
 
-  // These require existing DP sensors to link to
+  // These require existing DP sensors to link to.
   std::optional<VenturiFlowSensor> air_influx_sensor_{std::nullopt};
   std::optional<VenturiFlowSensor> oxygen_influx_sensor_{std::nullopt};
   std::optional<VenturiFlowSensor> outflow_sensor_{std::nullopt};

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -76,9 +76,6 @@ class Sensors {
   ADC adc;
 
  private:
-  /// \TODO: get this either from ADC constants header or something like that
-  static constexpr float ADCVoltageRange{3.3f};
-
   // Fundamental sensors. Because those use GPIO Pins, we need to delay instantiation to after
   // the Hal has been properly initialized. We use std::optional to achieve that, and emplace them
   // within init function

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -54,6 +54,8 @@ class Sensors {
   // stored in EEPROM, this function should be called immediately after init, but
   // it shouldn't stay that way (to accomodate for ventilator restart while linked
   // to a patient)
+  /// TODO: store calibration in EEPROM and have this called only upon user request
+  /// to make certain the vent is not linked to a patient
   void calibrate();
 
   // Read the sensors.

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -61,7 +61,7 @@ class Sensors {
   // Performs general init and sensor calibration.  This function should
   // be called on system startup before any other sensor functions
   // are called.
-  void init(ADC *adc, Frequency cpu_frequency);
+  void init(Frequency cpu_frequency);
 
   // Read the sensors.
   SensorReadings get_readings() const;
@@ -69,6 +69,8 @@ class Sensors {
  private:
   /// \TODO: get this either from ADC constants header or something like that
   static constexpr float ADCVoltageRange{3.3f};
+
+  ADC adc_;
 
   // \TODO: create a physical constants header for custom parts like venturi
   // Diameters and correction coefficient relating to 3/4in Venturi, see https://bit.ly/2ARuReg.

--- a/software/controller/lib/core/sensors.h
+++ b/software/controller/lib/core/sensors.h
@@ -19,21 +19,8 @@ limitations under the License.
 
 #include "oxygen.h"
 #include "pressure_sensors.h"
+#include "system_constants.h"
 #include "venturi.h"
-
-// Keep this in sync with the Sensor enum below
-constexpr static uint16_t NumSensors{5};
-
-enum class Sensor {
-  PatientPressure,
-  AirInflowPressureDiff,
-  OxygenInflowPressureDiff,
-  OutflowPressureDiff,
-  FIO2,
-};
-
-// Logical mappings: conceptual sensor -> ADC channel
-GPIO::AdcChannel adc_channel(Sensor s);
 
 struct SensorReadings {
   Pressure patient_pressure;

--- a/software/controller/lib/core/system_constants.cpp
+++ b/software/controller/lib/core/system_constants.cpp
@@ -1,0 +1,36 @@
+/* Copyright 2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "system_constants.h"
+//////////////////////////////////////////////////////////////////
+//                   SENSOR LOGICAL MAPPINGS                    //
+//   Change these if you route your sensor tubing differently   //
+//////////////////////////////////////////////////////////////////
+GPIO::AdcChannel adc_channel(Sensor s) {
+  switch (s) {
+    case Sensor::PatientPressure:
+      return InterimBoardAnalogPressure;
+    case Sensor::OxygenInflowPressureDiff:
+      return U3PatientPressure;
+    case Sensor::AirInflowPressureDiff:
+      return U4InhaleFlow;
+    case Sensor::OutflowPressureDiff:
+      return U5ExhaleFlow;
+    case Sensor::FIO2:
+      return InterimBoardOxygenSensor;
+  }
+  // Switch above covers all cases.
+  __builtin_unreachable();
+}

--- a/software/controller/lib/core/system_constants.h
+++ b/software/controller/lib/core/system_constants.h
@@ -44,16 +44,16 @@ static constexpr GPIO::AdcChannel U5ExhaleFlow{GPIO::Port::B, 0, 15};
 
 // Blower is hooked up to PB3 (see [PCB]),
 // which can be linked to Timer2 chanel 2 using AF1 (see [DS], p77)
-static constexpr GPIO::PwmChannel BlowerChannel = {GPIO::Port::B, 3, GPIO::AlternativeFunction::AF1,
-                                                   PeripheralID::Timer2, 2};
+static constexpr GPIO::PwmChannel BlowerChannel{GPIO::Port::B, 3, GPIO::AlternativeFunction::AF1,
+                                                PeripheralID::Timer2, 2};
 // Blower is driven by a 20kHz PWM, as a compromise between resolution and response time
 /// TODO: add/find a better rationale for this, maybe with the resulting response time/resolution
 static constexpr Frequency BlowerFreq{kilohertz(20)};
 
 // psol is hooked up to PA11 (see [PCB]),
 // which can be linked to Timer1 chanel 4 using AF1 (see [DS], p76)
-static constexpr GPIO::PwmChannel PSolChannel = {GPIO::Port::A, 11, GPIO::AlternativeFunction::AF1,
-                                                 PeripheralID::Timer1, 4};
+static constexpr GPIO::PwmChannel PSolChannel{GPIO::Port::A, 11, GPIO::AlternativeFunction::AF1,
+                                              PeripheralID::Timer1, 4};
 // Psol is driven by a 5kHz PWM (\TODO: find rationale behind this?)
 static constexpr Frequency PSolFreq{kilohertz(5)};
 // Testing in Edwin's garage, we found that the psol was fully closed at
@@ -65,8 +65,8 @@ static constexpr float PSolOpen{0.75f};
 
 // Buzzer is hooked up to PB4 (see [PCB]),
 // which can be linked to Timer3 chanel 1 using AF2 (see [DS], p77)
-static constexpr GPIO::PwmChannel BuzzerChannel = {GPIO::Port::B, 4, GPIO::AlternativeFunction::AF2,
-                                                   PeripheralID::Timer3, 1};
+static constexpr GPIO::PwmChannel BuzzerChannel{GPIO::Port::B, 4, GPIO::AlternativeFunction::AF2,
+                                                PeripheralID::Timer3, 1};
 // Buzzer is driven by a 2.4kHz PWM, which produces a medium to high pitch noise, which seems
 // adequate for an alarm of some sort.
 static constexpr Frequency BuzzerFreq{kilohertz(2.4f)};

--- a/software/controller/lib/core/system_constants.h
+++ b/software/controller/lib/core/system_constants.h
@@ -1,0 +1,77 @@
+/* Copyright 2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// All constants related to the ventilator design should live here. These
+// include pin mappings, venturi geometry, ...
+
+// Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
+
+#include "gpio.h"
+#include "units.h"
+
+/**************************************************************************************
+ *                                ELECTRICAL CONSTANTS                                *
+ **************************************************************************************/
+
+// The analog sensor on the daughterboard is hooked up to PC0 (see [PCB]) aka ADC1_IN1 (see [DS])
+static constexpr GPIO::AdcChannel InterimBoardAnalogPressure{GPIO::Port::C, 0, 1};
+
+// The O2 sensor on the daughterboardis hooked up to PC3 (see [PCB]), aka ADC1_IN2 (see [DS])
+static constexpr GPIO::AdcChannel InterimBoardOxygenSensor{GPIO::Port::C, 3, 2};
+
+// "U4 Inhale Flow" sensor on the PCB is pin PA4 (see [PCB]), aka ADC1_IN9 (see [DS])
+static constexpr GPIO::AdcChannel U4InhaleFlow{GPIO::Port::A, 4, 9};
+
+// "U3 Patient Pressure" sensor on the PCB, i.e PA1 (see [PCB]), aka ADC1_IN6 (see [DS])
+static constexpr GPIO::AdcChannel U3PatientPressure{GPIO::Port::A, 1, 6};
+
+// "U5 Exhale Flow" sensor on the PCB is pin PB0 (see [PCB]), aka ADC1_IN15 (see [DS])
+static constexpr GPIO::AdcChannel U5ExhaleFlow{GPIO::Port::B, 0, 15};
+
+// Blower is hooked up to PB3 (see [PCB]),
+// which can be linked to Timer2 chanel 2 using AF1 (see [DS], p77)
+static constexpr GPIO::PwmChannel BlowerChannel = {GPIO::Port::B, 3, GPIO::AlternativeFunction::AF1,
+                                                   PeripheralID::Timer2, 2};
+// Blower is driven by a 20kHz PWM, as a compromise between resolution and response time
+/// TODO: add/find a better rationale for this, maybe with the resulting response time/resolution
+static constexpr Frequency BlowerFreq = kilohertz(20);
+
+// psol is hooked up to PA11 (see [PCB]),
+// which can be linked to Timer1 chanel 4 using AF1 (see [DS], p76)
+static constexpr GPIO::PwmChannel PSolChannel = {GPIO::Port::A, 11, GPIO::AlternativeFunction::AF1,
+                                                 PeripheralID::Timer1, 4};
+// Psol is driven by a 5kHz PWM (\TODO: find rationale behind this?)
+static constexpr Frequency PSolFreq = kilohertz(5);
+// Testing in Edwin's garage, we found that the psol was fully closed at
+// somewhere between 0.75 and 0.80 (i.e. definitely zero at 0.75 and probably
+// zero a bit above that) and fully open at 0.90.
+// \TODO: the values in the comment are inconsistent with the code, have Edwin confirm those.
+static constexpr float psol_value_closed = 0.35f;
+static constexpr float psol_value_open = 0.75f;
+
+/**************************************************************************************
+ *                                 PHYSICAL CONSTANTS                                 *
+ **************************************************************************************/
+
+// Diameters and correction coefficient relating to 3/4in Venturi, see https://bit.ly/2ARuReg.
+// Correction factor of 0.97 is based on ISO recommendations for Reynolds of roughly 10^4 and
+// machined (rather than cast) surfaces. Data fit is in good agreement based on comparison to
+// Fleisch pneumotachograph; see https://github.com/RespiraWorks/Ventilator/pull/476
+static constexpr Length VenturiPortDiameter{millimeters(15.05f)};
+static constexpr Length VenturiChokeDiameter{millimeters(5.5f)};
+static constexpr float VenturiCorrection{0.97f};
+
+static_assert(VenturiPortDiameter > VenturiChokeDiameter);
+static_assert(VenturiChokeDiameter > meters(0));

--- a/software/controller/lib/core/system_constants.h
+++ b/software/controller/lib/core/system_constants.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 // Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 
+#pragma once
+
 #include "gpio.h"
 #include "units.h"
 
@@ -58,8 +60,8 @@ static constexpr Frequency PSolFreq = kilohertz(5);
 // somewhere between 0.75 and 0.80 (i.e. definitely zero at 0.75 and probably
 // zero a bit above that) and fully open at 0.90.
 // \TODO: the values in the comment are inconsistent with the code, have Edwin confirm those.
-static constexpr float psol_value_closed = 0.35f;
-static constexpr float psol_value_open = 0.75f;
+static constexpr float PSolClosed = 0.35f;
+static constexpr float PSolOpen = 0.75f;
 
 /**************************************************************************************
  *                                 PHYSICAL CONSTANTS                                 *
@@ -75,3 +77,17 @@ static constexpr float VenturiCorrection{0.97f};
 
 static_assert(VenturiPortDiameter > VenturiChokeDiameter);
 static_assert(VenturiChokeDiameter > meters(0));
+
+/**************************************************************************************
+ *                                FUNCTIONAL CONSTANTS                                *
+ **************************************************************************************/
+
+// Loop period of our main controller loop
+static constexpr Duration MainLoopPeriod = milliseconds(10);
+
+// Transition from PEEP to PIP pressure hapens over this length of time.  Citation:
+// https://respiraworks.slack.com/archives/C011CJQV4Q7/p1591763842312500?thread_ts=1591759016.310200&cid=C011CJQV4Q7
+inline constexpr Duration RiseTime = milliseconds(100);
+
+// TODO: VolumeIntegrationInterval (for volume integrator) was not chosen carefully.
+static constexpr Duration VolumeIntegrationInterval = milliseconds(5);

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -275,7 +275,7 @@ void SetAdcSequence(AdcReg *adc, const uint8_t sequence_number, const uint8_t ch
   adc->adc[0].sequence.words[index] |= channel << (sequence_number % 5) * 6;
 };
 
-bool ADC::add_channel(AdcChannel channel) {
+bool ADC::add_channel(const uint8_t channel) {
   if (n_channels_ >= MaxAdcChannels) return false;
   channels_[n_channels_++] = channel;
   return true;
@@ -390,7 +390,7 @@ bool ADC::initialize(const Frequency cpu_frequency) {
 }
 
 // Read the specified analog input.
-Voltage ADC::read(const AdcChannel channel) const {
+Voltage ADC::read(const uint8_t channel) const {
   size_t offset =
       std::distance(channels_.begin(), std::find(channels_.begin(), channels_.end(), channel));
 
@@ -411,9 +411,9 @@ Voltage ADC::read(const AdcChannel channel) const {
 
 bool ADC::initialize(const Frequency cpu_frequency) { return true; }
 
-Voltage ADC::read(const AdcChannel channel) const { return analog_pin_values_.at(channel); }
+Voltage ADC::read(const uint8_t channel) const { return analog_pin_values_.at(channel); }
 
-void ADC::TESTSetAnalogPin(const AdcChannel channel, Voltage value) {
+void ADC::TESTSetAnalogPin(const uint8_t channel, Voltage value) {
   analog_pin_values_[channel] = value;
 }
 

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -276,12 +276,6 @@ void ADC::SetAdcSequence(const uint8_t sequence_number, const uint8_t channel) {
   adc->adc[0].sequence.words[index] |= channel << (sequence_number % 5) * 6;
 };
 
-bool ADC::add_channel(const uint8_t channel) {
-  if (n_channels_ >= MaxAdcChannels) return false;
-  channels_[n_channels_++] = channel;
-  return true;
-};
-
 bool ADC::initialize(const Frequency cpu_frequency) {
   adc_sample_history_ = static_cast<uint32_t>(SampleHistoryTime * cpu_frequency /
                                               AdcConversionTime / OversampleCount / MaxAdcChannels);
@@ -420,12 +414,16 @@ void ADC::TESTSetAnalogPin(const uint8_t channel, Voltage value) {
 
 #endif
 
+bool ADC::add_channel(const uint8_t channel) {
+  if (n_channels_ >= MaxAdcChannels) return false;
+  channels_[n_channels_++] = channel;
+  return true;
+};
+
 namespace GPIO {
 AnalogInputPin::AnalogInputPin(AdcChannel channel, ADC *adc)
     : Pin(channel.port, channel.pin, PinMode::Analog), adc_(adc), channel_(channel) {
-#if defined(BARE_STM32)
   adc_->add_channel(channel_.adc_channel);
-#endif
 }
 
 Voltage AnalogInputPin::read() const { return adc_->read(channel_.adc_channel); }

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -288,7 +288,7 @@ bool ADC::initialize(const Frequency cpu_frequency) {
   // This scaler converts the sum of the A/D readings (a total of
   // adc_sample_history_) into a voltage.  The A/D is scaled so a value of 0
   // corresponds to 0 volts, and MaxAdcReading corresponds to 3.3V
-  adc_scaler_ = 3.3f / static_cast<float>(MaxAdcReading * adc_sample_history_);
+  adc_scaler_ = VoltageRange.volts() / static_cast<float>(MaxAdcReading * adc_sample_history_);
 
   if (adc_sample_history_ > AdcSampleHistoryHardMax) return false;
 

--- a/software/controller/lib/hal/adc.h
+++ b/software/controller/lib/hal/adc.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <array>
 
+#include "gpio.h"
 #include "units.h"
 
 #if !defined(BARE_STM32)
@@ -68,11 +69,28 @@ class ADC {
   // Presized under some assumptions, see implementation for initialize()
   volatile uint16_t oversample_buffer_[AdcSampleHistoryHardMax * MaxAdcChannels];
 
+  // helper functions to manipulate ADC registers
+  void SetAdcSampleTime(uint8_t channel, uint32_t sample_time);
+  void SetAdcSequence(uint8_t sequence_number, uint8_t channel);
+
 #if !defined(BARE_STM32)
  public:
-  void TESTSetAnalogPin(uint8_t pin, Voltage value);
+  void TESTSetAnalogPin(uint8_t channel, Voltage value);
 
  private:
   std::map<uint8_t, Voltage> analog_pin_values_;
 #endif
 };
+
+namespace GPIO {
+// Analog input pin, linked to an ADC channel.
+class AnalogInputPin : public Pin {
+ public:
+  AnalogInputPin(AdcChannel channel, ADC *adc);
+  Voltage read() const;
+
+ private:
+  ADC *adc_{nullptr};
+  AdcChannel channel_;
+};
+}  // namespace GPIO

--- a/software/controller/lib/hal/adc.h
+++ b/software/controller/lib/hal/adc.h
@@ -65,10 +65,12 @@ class ADC {
   std::array<uint8_t, MaxAdcChannels> channels_;
   uint8_t n_channels_{0};
 
-  //\TODO: possibly have parent allocate memory depending on number of samples
+  /// \TODO: possibly have parent allocate memory depending on number of samples
   // Presized under some assumptions, see implementation for initialize()
   volatile uint16_t oversample_buffer_[AdcSampleHistoryHardMax * MaxAdcChannels];
 
+// \TODO: subclass as STM32 and mock classes to make this easier to read, and have the
+// mock class be part of the tests rather than the main code.
 #if defined(BARE_STM32)
   // helper functions to manipulate ADC registers
   void SetAdcSampleTime(uint8_t channel, uint32_t sample_time);

--- a/software/controller/lib/hal/adc.h
+++ b/software/controller/lib/hal/adc.h
@@ -25,17 +25,6 @@ limitations under the License.
 
 // Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
 
-// Location of analog sensors as labeled on the PCB(s). Note that this does not necessarily define
-// their function and further mapping should be done in the higher layers of the software.
-// Please refer to [PCB] as the ultimate source of which pin is used for which function.
-enum class AdcChannel {
-  InterimBoardAnalogPressure = 1,  // PC0 (ADC1_IN1)  interim board: analog pressure
-  InterimBoardOxygenSensor = 2,    // PC3 (ADC1_IN2)  interim board: oxygen sensor
-  U3PatientPressure = 6,           // PA1 (ADC1_IN6)  U3 patient pressure
-  U4InhaleFlow = 9,                // PA4 (ADC1_IN9)  U4 inhale flow
-  U5ExhaleFlow = 15,               // PB0 (ADC1_IN15) U5 exhale flow
-};
-
 /// \TODO: could be explicit singleton?
 class ADC {
  public:
@@ -48,10 +37,10 @@ class ADC {
   // Reads from analog sensor using an analog-to-digital converter.
   // Returns a voltage.  On STM32 this can range from 0 to 3.3V.
   // In test mode, will return the last value set via TESTSetAnalogPin.
-  Voltage read(AdcChannel pin) const;
+  Voltage read(uint8_t channel) const;
 
   // Add a new channel to the ADC
-  bool add_channel(AdcChannel channel);
+  bool add_channel(uint8_t channel);
 
  private:
   // Total number of A/D inputs we're sampling
@@ -69,7 +58,7 @@ class ADC {
   float adc_scaler_{1.0f};
 
   // Array of ADC channels we use.
-  std::array<AdcChannel, MaxAdcChannels> channels_;
+  std::array<uint8_t, MaxAdcChannels> channels_;
   uint8_t n_channels_{0};
 
   //\TODO: possibly have parent allocate memory depending on number of samples
@@ -78,9 +67,9 @@ class ADC {
 
 #if !defined(BARE_STM32)
  public:
-  void TESTSetAnalogPin(AdcChannel pin, Voltage value);
+  void TESTSetAnalogPin(uint8_t pin, Voltage value);
 
  private:
-  std::map<AdcChannel, Voltage> analog_pin_values_;
+  std::map<uint8_t, Voltage> analog_pin_values_;
 #endif
 };

--- a/software/controller/lib/hal/adc.h
+++ b/software/controller/lib/hal/adc.h
@@ -15,20 +15,25 @@ limitations under the License.
 
 #pragma once
 
+#include <array>
+
 #include "units.h"
 
 #if !defined(BARE_STM32)
 #include <map>
 #endif
 
+// Reference abbreviations ([RM], [PCB], etc) are defined in hal/README.md
+
 // Location of analog sensors as labeled on the PCB(s). Note that this does not necessarily define
 // their function and further mapping should be done in the higher layers of the software.
-enum class AnalogPin {
-  InterimBoardAnalogPressure,
-  U3PatientPressure,
-  U4InhaleFlow,
-  U5ExhaleFlow,
-  InterimBoardOxygenSensor,
+// Please refer to [PCB] as the ultimate source of which pin is used for which function.
+enum class AdcChannel {
+  InterimBoardAnalogPressure = 1,  // PC0 (ADC1_IN1)  interim board: analog pressure
+  InterimBoardOxygenSensor = 2,    // PC3 (ADC1_IN2)  interim board: oxygen sensor
+  U3PatientPressure = 6,           // PA1 (ADC1_IN6)  U3 patient pressure
+  U4InhaleFlow = 9,                // PA4 (ADC1_IN9)  U4 inhale flow
+  U5ExhaleFlow = 15,               // PB0 (ADC1_IN15) U5 exhale flow
 };
 
 /// \TODO: could be explicit singleton?
@@ -43,12 +48,15 @@ class ADC {
   // Reads from analog sensor using an analog-to-digital converter.
   // Returns a voltage.  On STM32 this can range from 0 to 3.3V.
   // In test mode, will return the last value set via TESTSetAnalogPin.
-  Voltage read(AnalogPin pin) const;
+  Voltage read(AdcChannel pin) const;
+
+  // Add a new channel to the ADC
+  bool add_channel(AdcChannel channel);
 
  private:
   // Total number of A/D inputs we're sampling
   // \TODO: consider templating this or somehow linking it to mapping enum size
-  static constexpr int AdcChannels{5};
+  static constexpr int MaxAdcChannels{5};
 
   // We need the sample history to be small for two reasons:
   // - We sum to a 32-bit float and will lose precision if we add in too many samples
@@ -60,15 +68,19 @@ class ADC {
   uint32_t adc_sample_history_{1};
   float adc_scaler_{1.0f};
 
+  // Array of ADC channels we use.
+  std::array<AdcChannel, MaxAdcChannels> channels_;
+  uint8_t n_channels_{0};
+
   //\TODO: possibly have parent allocate memory depending on number of samples
   // Presized under some assumptions, see implementation for initialize()
-  volatile uint16_t oversample_buffer_[AdcSampleHistoryHardMax * AdcChannels];
+  volatile uint16_t oversample_buffer_[AdcSampleHistoryHardMax * MaxAdcChannels];
 
 #if !defined(BARE_STM32)
  public:
-  void TESTSetAnalogPin(AnalogPin pin, Voltage value);
+  void TESTSetAnalogPin(AdcChannel pin, Voltage value);
 
  private:
-  std::map<AnalogPin, Voltage> analog_pin_values_;
+  std::map<AdcChannel, Voltage> analog_pin_values_;
 #endif
 };

--- a/software/controller/lib/hal/adc.h
+++ b/software/controller/lib/hal/adc.h
@@ -69,11 +69,12 @@ class ADC {
   // Presized under some assumptions, see implementation for initialize()
   volatile uint16_t oversample_buffer_[AdcSampleHistoryHardMax * MaxAdcChannels];
 
+#if defined(BARE_STM32)
   // helper functions to manipulate ADC registers
   void SetAdcSampleTime(uint8_t channel, uint32_t sample_time);
   void SetAdcSequence(uint8_t sequence_number, uint8_t channel);
 
-#if !defined(BARE_STM32)
+#else
  public:
   void TESTSetAnalogPin(uint8_t channel, Voltage value);
 

--- a/software/controller/lib/hal/adc.h
+++ b/software/controller/lib/hal/adc.h
@@ -42,6 +42,9 @@ class ADC {
   // Add a new channel to the ADC
   bool add_channel(uint8_t channel);
 
+  // Voltage range for the ADC
+  static constexpr Voltage VoltageRange{volts(3.3f)};
+
  private:
   // Total number of A/D inputs we're sampling
   // \TODO: consider templating this or somehow linking it to mapping enum size

--- a/software/controller/lib/hal/gpio.cpp
+++ b/software/controller/lib/hal/gpio.cpp
@@ -126,14 +126,14 @@ AlternatePin::AlternatePin(Port port, uint8_t pin, AlternativeFunction func, Pul
   pull_type(pull);
 }
 
-AnalogInputPin::AnalogInputPin(Port port, uint8_t pin, ADC *adc, AdcChannel channel)
-    : Pin(port, pin, PinMode::Analog), adc_(adc), channel_(channel) {
+AnalogInputPin::AnalogInputPin(AdcChannel channel, ADC *adc)
+    : Pin(channel.port, channel.pin, PinMode::Analog), adc_(adc), channel_(channel) {
 #if defined(BARE_STM32)
-  adc_->add_channel(channel_);
+  adc_->add_channel(channel_.adc_channel);
 #endif
 }
 
-Voltage AnalogInputPin::read() const { return adc_->read(channel_); }
+Voltage AnalogInputPin::read() const { return adc_->read(channel_.adc_channel); }
 
 PwmPin::PwmPin(PwmChannel channel, const Frequency pwm_freq, const Frequency cpu_frequency)
     : AlternatePin(channel.port, channel.pin, channel.function),

--- a/software/controller/lib/hal/gpio.cpp
+++ b/software/controller/lib/hal/gpio.cpp
@@ -135,14 +135,12 @@ AnalogInputPin::AnalogInputPin(Port port, uint8_t pin, ADC *adc, AdcChannel chan
 
 Voltage AnalogInputPin::read() const { return adc_->read(channel_); }
 
-AnalogOutputPin::AnalogOutputPin(Port port, uint8_t pin, const AlternativeFunction func,
-                                 const Frequency pwm_freq, TimerReg *timer, uint8_t channel,
-                                 const PeripheralID peripheral, const Frequency cpu_frequency)
-    : Pin(port, pin, PinMode::AlternateFunction),
-      pwm_(pwm_freq, timer, channel, peripheral, cpu_frequency) {
-  alternate_function(func);
+PwmPin::PwmPin(PwmChannel channel, const Frequency pwm_freq, const Frequency cpu_frequency)
+    : AlternatePin(channel.port, channel.pin, channel.function),
+      pwm_(pwm_freq, channel.peripheral, channel.timer_channel, cpu_frequency) {
+  alternate_function(channel.function);
 }
 
-void AnalogOutputPin::set(float value) { pwm_.set(value); }
+void PwmPin::set(float value) { pwm_.set(value); }
 
 }  // namespace GPIO

--- a/software/controller/lib/hal/gpio.cpp
+++ b/software/controller/lib/hal/gpio.cpp
@@ -26,6 +26,45 @@ Reference abbreviations [RM], [DS], etc are defined in hal/README.md.
 
 namespace GPIO {
 
+// General Purpose I/O
+// [RM] 8.4 GPIO Registers (pg 267)
+struct RegisterStructure {
+  uint32_t mode;                   // Mode register [RM] 8.4.1
+  uint32_t output_type;            // Output type register [RM] 8.4.2
+  uint32_t output_speed;           // Output speed register [RM] 8.4.3
+  uint32_t pullup_pulldown;        // Pull-up/pull-down register [RM] 8.4.4
+  uint32_t input_data;             // Input data register [RM] 8.4.5
+  uint32_t output_data;            // Output data register [RM] 8.4.6
+  uint16_t set;                    // Bit set register [RM] 8.4.7
+  uint16_t clear;                  // Bit reset register [RM] 8.4.7
+  uint32_t flash_lock;             // Configuration lock register [RM] 8.4.8
+  uint32_t alternate_function[2];  // Alternate function low/high register [RM] 8.4.{9,10}
+  uint32_t reset;                  // Reset register [RM] 8.4.11
+};
+
+typedef volatile RegisterStructure Register;
+
+RegisterStructure *base_address(const Port port) {
+  uint32_t address = [port]() -> uint32_t {
+    switch (port) {
+      case GPIO::Port::A:
+        return 0x48000000;
+      case GPIO::Port::B:
+        return 0x48000400;
+      case GPIO::Port::C:
+        return 0x48000800;
+      case GPIO::Port::D:
+        return 0x48000C00;
+      case GPIO::Port::E:
+        return 0x48001000;
+      case GPIO::Port::H:
+        return 0x48001C00;
+    }
+    __builtin_unreachable();
+  }();
+  return reinterpret_cast<RegisterStructure *>(address);
+}
+
 void enable_all_clocks() {
   // Enable all the GPIO clocks
   enable_peripheral_clock(PeripheralID::GPIOA);
@@ -36,48 +75,61 @@ void enable_all_clocks() {
   enable_peripheral_clock(PeripheralID::GPIOH);
 }
 
-Pin::Pin(Port port, uint8_t pin, PinMode mode) : pin_(pin) {
+Pin::Pin(Port port, uint8_t pin, PinMode mode) : port_(port), pin_(pin) {
 #if defined(BARE_STM32)
-  gpio_ = reinterpret_cast<RegisterStructure *>(port);
+  auto *gpio = base_address(port_);
   // reset the mode bits to 0
-  gpio_->mode &= ~(0b11 << (pin_ * 2));
+  gpio->mode &= ~(0b11 << (pin_ * 2));
   // set the mode bits to the desired value
-  gpio_->mode |= (static_cast<uint32_t>(mode) << (pin_ * 2));
+  gpio->mode |= (static_cast<uint32_t>(mode) << (pin_ * 2));
 #endif
 };
 
 #if defined(BARE_STM32)
 void Pin::output_type(OutType output_type) {
+  auto *gpio = base_address(port_);
   if (output_type == OutType::OpenDrain)
-    gpio_->output_type |= 1 << pin_;
+    gpio->output_type |= 1 << pin_;
   else
-    gpio_->output_type &= ~(1 << pin_);
+    gpio->output_type &= ~(1 << pin_);
 }
 
 void Pin::output_speed(OutSpeed speed) {
+  auto *gpio = base_address(port_);
   auto s = static_cast<uint32_t>(speed);
-  gpio_->output_speed &= ~(0b11 << (2 * pin_));
-  gpio_->output_speed |= (s << (2 * pin_));
+  gpio->output_speed &= ~(0b11 << (2 * pin_));
+  gpio->output_speed |= (s << (2 * pin_));
 }
 
 void Pin::pull_type(PullType pull) {
+  auto *gpio = base_address(port_);
   // Get the current value within the register, masking the bits we want to alter
-  uint32_t x = gpio_->pullup_pulldown & ~(3 << (2 * pin_));
+  uint32_t x = gpio->pullup_pulldown & ~(3 << (2 * pin_));
   // Only alter the appropriate bits
   x |= static_cast<uint32_t>(pull) << (2 * pin_);
-  gpio_->pullup_pulldown = x;
+  gpio->pullup_pulldown = x;
 }
 
 void Pin::alternate_function(AlternativeFunction func) {
+  auto *gpio = base_address(port_);
   uint8_t index = (pin_ < 8) ? 0 : 1;
-  gpio_->alternate_function[index] |= (static_cast<uint32_t>(func) << ((pin_ & 0b111) * 4));
+  gpio->alternate_function[index] |= (static_cast<uint32_t>(func) << ((pin_ & 0b111) * 4));
 }
 
-void DigitalOutputPin::set() { gpio_->set = static_cast<uint16_t>(1 << pin_); }
+void DigitalOutputPin::set() {
+  auto *gpio = base_address(port_);
+  gpio->set = static_cast<uint16_t>(1 << pin_);
+}
 
-void DigitalOutputPin::clear() { gpio_->clear = static_cast<uint16_t>(1 << pin_); }
+void DigitalOutputPin::clear() {
+  auto *gpio = base_address(port_);
+  gpio->clear = static_cast<uint16_t>(1 << pin_);
+}
 
-bool DigitalInputPin::get() const { return gpio_->input_data & (1 << pin_); }
+bool DigitalInputPin::get() const {
+  auto *gpio = base_address(port_);
+  return gpio->input_data & (1 << pin_);
+}
 
 #else
 // \TODO add a real mock for those?
@@ -86,12 +138,12 @@ void Pin::output_speed(OutSpeed speed) {}
 void Pin::pull_type(PullType pull) {}
 void Pin::alternate_function(AlternativeFunction func) {}
 
-void DigitalOutputPin::set() { value_ = 1; }
-void DigitalOutputPin::clear() { value_ = 0; }
+void DigitalOutputPin::set() { value_ = true; }
+void DigitalOutputPin::clear() { value_ = false; }
 bool DigitalOutputPin::get() const { return value_; }
 
-void DigitalInputPin::set() { value_ = 1; }
-void DigitalInputPin::clear() { value_ = 0; }
+void DigitalInputPin::set() { value_ = true; }
+void DigitalInputPin::clear() { value_ = false; }
 bool DigitalInputPin::get() const { return value_; }
 
 #endif
@@ -125,22 +177,5 @@ AlternatePin::AlternatePin(Port port, uint8_t pin, AlternativeFunction func, Pul
   alternate_function(func);
   pull_type(pull);
 }
-
-AnalogInputPin::AnalogInputPin(AdcChannel channel, ADC *adc)
-    : Pin(channel.port, channel.pin, PinMode::Analog), adc_(adc), channel_(channel) {
-#if defined(BARE_STM32)
-  adc_->add_channel(channel_.adc_channel);
-#endif
-}
-
-Voltage AnalogInputPin::read() const { return adc_->read(channel_.adc_channel); }
-
-PwmPin::PwmPin(PwmChannel channel, const Frequency pwm_freq, const Frequency cpu_frequency)
-    : AlternatePin(channel.port, channel.pin, channel.function),
-      pwm_(pwm_freq, channel.peripheral, channel.timer_channel, cpu_frequency) {
-  alternate_function(channel.function);
-}
-
-void PwmPin::set(float value) { pwm_.set(value); }
 
 }  // namespace GPIO

--- a/software/controller/lib/hal/gpio.h
+++ b/software/controller/lib/hal/gpio.h
@@ -161,11 +161,19 @@ class AlternatePin : public Pin {
                OutSpeed speed = OutSpeed::Slow, OutType type = OutType::PushPull);
 };
 
+// Helper struct that allows us to manipulate an analog input pin as a collection of everything
+// that helps define it: a physical pin (port and number) and an ADC channel number.
+// See Table 16 [DS] for physical pin to ADC channel mapping.
+struct AdcChannel {
+  Port port;
+  uint8_t pin;
+  uint8_t adc_channel;
+};
+
 // Analog input pin, linked to an ADC channel.
-// See Table 16 [DS] for physical pin to ADC Channel mapping.
 class AnalogInputPin : public Pin {
  public:
-  AnalogInputPin(Port port, uint8_t pin, ADC *adc, AdcChannel channel);
+  AnalogInputPin(AdcChannel channel, ADC *adc);
   Voltage read() const;
 
  private:
@@ -173,7 +181,7 @@ class AnalogInputPin : public Pin {
   AdcChannel channel_;
 };
 
-// Helper struct that allows us to manipulate a PWM pin as a collection of all functions that helps
+// Helper struct that allows us to manipulate a PWM pin as a collection of everything that helps
 // define it: a physical pin (port and number), an alternate function and a timer channel (timer
 // peripheral and channel number).
 // See Table 17 and 18 [DS] for physical pin to timer channel mapping.

--- a/software/controller/lib/hal/gpio.h
+++ b/software/controller/lib/hal/gpio.h
@@ -111,6 +111,7 @@ class DigitalOutputPin : public Pin {
                    OutType type = OutType::PushPull);
   void set();
   void clear();
+/// \TODO: make this part of a mock subclass rather than the main one
 #if !defined(BARE_STM32)
   bool get() const;
 
@@ -124,6 +125,7 @@ class DigitalInputPin : public Pin {
  public:
   DigitalInputPin(Port port, uint8_t pin, PullType pull = PullType::None);
   bool get() const;
+/// \TODO: make this part of a mock subclass rather than the main one
 #if !defined(BARE_STM32)
   void set();
   void clear();
@@ -135,7 +137,6 @@ class DigitalInputPin : public Pin {
 
 // Alternate function Pin, varying in function from serial bus handling to pwm output
 // See Table 17 and 18 [DS] for alternate functions mapping
-// Note that this is subclassed as PwmPin to output pwm signals.
 class AlternatePin : public Pin {
  public:
   AlternatePin(Port port, uint8_t pin, AlternativeFunction func, PullType pull = PullType::None,
@@ -156,6 +157,7 @@ struct AdcChannel {
 // define it: a physical pin (port and number), an alternate function and a timer channel (timer
 // peripheral and channel number).
 // See Table 17 and 18 [DS] for physical pin to timer channel mapping.
+// Functionality behind this is defined in pwm.h
 struct PwmChannel {
   Port port;
   uint8_t pin;

--- a/software/controller/lib/hal/gpio_mock.cpp
+++ b/software/controller/lib/hal/gpio_mock.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2020-2021, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines GPIO functions for HAL (Hardware Abstraction Layer) for the
+STM32L452 processor used on the controller.
+
+Reference abbreviations [RM], [DS], etc are defined in hal/README.md.
+*/
+#if !defined(BARE_STM32)
+
+#include "clocks.h"
+#include "gpio.h"
+
+namespace GPIO {
+
+void enable_all_clocks() {}
+
+Pin::Pin(Port port, uint8_t pin, PinMode mode) : port_(port), pin_(pin){};
+
+void Pin::output_type(OutType output_type) {}
+
+void Pin::output_speed(OutSpeed speed) {}
+
+void Pin::pull_type(PullType pull) {}
+
+void Pin::alternate_function(AlternativeFunction func) {}
+
+DigitalOutputPin::DigitalOutputPin(Port port, uint8_t pin, bool start_high, OutSpeed speed,
+                                   OutType type)
+    : Pin(port, pin, PinMode::Output), value_(start_high) {}
+void DigitalOutputPin::set() { value_ = true; }
+
+void DigitalOutputPin::clear() { value_ = false; }
+
+bool DigitalOutputPin::get() const { return value_; }
+
+DigitalInputPin::DigitalInputPin(Port port, uint8_t pin, PullType pull)
+    : Pin(port, pin, PinMode::Input) {}
+void DigitalInputPin::set() { value_ = true; }
+
+void DigitalInputPin::clear() { value_ = false; }
+
+bool DigitalInputPin::get() const { return value_; }
+
+AlternatePin::AlternatePin(Port port, uint8_t pin, AlternativeFunction func, PullType pull,
+                           OutSpeed speed, OutType type)
+    : Pin(port, pin, PinMode::AlternateFunction) {}
+}  // namespace GPIO
+#endif

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -33,7 +33,6 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
-#include <optional>
 
 #include "led_indicators.h"
 #include "units.h"

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -35,8 +35,6 @@ limitations under the License.
 #include <cstdint>
 #include <optional>
 
-#include "adc.h"
-#include "gpio.h"
 #include "led_indicators.h"
 #include "units.h"
 
@@ -71,8 +69,6 @@ class HalApi {
  public:
   /// \TODO: likely these should not even be members
   LEDIndicators LEDs;
-
-  std::optional<GPIO::PwmPin> buzzer{std::nullopt};
 
   static Frequency GetCpuFreq();
 

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -72,7 +72,7 @@ class HalApi {
   /// \TODO: likely these should not even be members
   LEDIndicators LEDs;
 
-  std::optional<GPIO::AnalogOutputPin> buzzer{std::nullopt};
+  std::optional<GPIO::PwmPin> buzzer{std::nullopt};
 
   static Frequency GetCpuFreq();
 

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -33,10 +33,11 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 
 #include "adc.h"
+#include "gpio.h"
 #include "led_indicators.h"
-#include "pwm.h"
 #include "units.h"
 
 /// \TODO: Mock port interface should be with the tests, not main code
@@ -69,14 +70,9 @@ class TestSerialPort {
 class HalApi {
  public:
   /// \TODO: likely these should not even be members
-  ADC adc;
   LEDIndicators LEDs;
-  // \TODO: previous implementation of buzzer used a 0.8 scaling factor to produce max volume
-  // when we used set(1). We need to bring that back somehow (e.g make buzzer a pwm driven actuator
-  // with calibration from 0 to 0.8, which works, but buzzer isn't really an actuator so making it
-  // a member of Actuators feels wrong, and the initialization overhead is a bit much to live in
-  // main in my view).
-  PWM buzzer{PwmPin::Buzzer, kilohertz(2.4f)};
+
+  std::optional<GPIO::AnalogOutputPin> buzzer{std::nullopt};
 
   static Frequency GetCpuFreq();
 

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -122,7 +122,13 @@ void HalApi::Init() {
   LEDs.initialize();
   /// \TODO: ensure CPUFrequency is a multiple of 10 MHz
   SystemTimer::singleton().initialize(CPUFrequency);
-  buzzer.initialize(CPUFrequency);
+  // \TODO: previous implementation of buzzer used a 0.8 scaling factor to produce max volume
+  // when we used set(1). We need to bring that back somehow (e.g make buzzer a pwm driven actuator
+  // with calibration from 0 to 0.8, which works, but buzzer isn't really an actuator so making it
+  // a member of Actuators feels wrong, and the initialization overhead is a bit much to live in
+  // main in my view).
+  buzzer.emplace(GPIO::Port::B, 4, GPIO::AlternativeFunction::AF2, kilohertz(2.4f), Timer3Base, 1,
+                 PeripheralID::Timer3, CPUFrequency);
   InitUARTs();
   I2C::initialize();
   Interrupts::singleton().EnableInterrupts();

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -122,8 +122,6 @@ void HalApi::Init() {
   LEDs.initialize();
   /// \TODO: ensure CPUFrequency is a multiple of 10 MHz
   SystemTimer::singleton().initialize(CPUFrequency);
-  /// \TODO: fault somehow if this returns false
-  [[maybe_unused]] bool buffer_size_sufficient = adc.initialize(CPUFrequency);
   buzzer.initialize(CPUFrequency);
   InitUARTs();
   I2C::initialize();
@@ -154,8 +152,8 @@ void HalApi::Init() {
  *****************************************************************/
 void HalApi::init_PCB_ID_pins() {
   // Configure PCB ID pins as inputs.
-  GPIO::pin_mode(GPIO::Port::B, 1, GPIO::PinMode::Input);
-  GPIO::pin_mode(GPIO::Port::A, 12, GPIO::PinMode::Input);
+  GPIO::DigitalInputPin(GPIO::Port::B, 1);
+  GPIO::DigitalInputPin(GPIO::Port::A, 12);
 }
 
 /******************************************************************
@@ -272,20 +270,14 @@ void HalApi::InitUARTs() {
   enable_peripheral_clock(PeripheralID::DMA1);
 #endif
   // [DS] Table 17 (pg 76)
-  GPIO::alternate_function(GPIO::Port::A, /*pin =*/2,
-                           GPIO::AlternativeFunction::AF7);  // USART2_TX
-  GPIO::alternate_function(GPIO::Port::A, /*pin =*/3,
-                           GPIO::AlternativeFunction::AF7);  // USART2_RX
+  GPIO::AlternatePin(GPIO::Port::A, 2, GPIO::AlternativeFunction::AF7);  // USART2_TX
+  GPIO::AlternatePin(GPIO::Port::A, 3, GPIO::AlternativeFunction::AF7);  // USART2_RX
 
   // [DS] Table 17 (pg 77)
-  GPIO::alternate_function(GPIO::Port::B, /*pin =*/10,
-                           GPIO::AlternativeFunction::AF7);  // USART3_TX
-  GPIO::alternate_function(GPIO::Port::B, /*pin =*/11,
-                           GPIO::AlternativeFunction::AF7);  // USART3_RX
-  GPIO::alternate_function(GPIO::Port::B, /*pin =*/13,
-                           GPIO::AlternativeFunction::AF7);  // USART3_CTS
-  GPIO::alternate_function(GPIO::Port::B, /*pin =*/14,
-                           GPIO::AlternativeFunction::AF7);  // USART3_RTS_DE
+  GPIO::AlternatePin(GPIO::Port::B, 10, GPIO::AlternativeFunction::AF7);  // USART3_TX
+  GPIO::AlternatePin(GPIO::Port::B, 11, GPIO::AlternativeFunction::AF7);  // USART3_RX
+  GPIO::AlternatePin(GPIO::Port::B, 13, GPIO::AlternativeFunction::AF7);  // USART3_CTS
+  GPIO::AlternatePin(GPIO::Port::B, 14, GPIO::AlternativeFunction::AF7);  // USART3_RTS_DE
 
 #ifdef UART_VIA_DMA
   dma_uart.initialize(CPUFrequency, UARTBaudRate);

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -122,13 +122,19 @@ void HalApi::Init() {
   LEDs.initialize();
   /// \TODO: ensure CPUFrequency is a multiple of 10 MHz
   SystemTimer::singleton().initialize(CPUFrequency);
+
   // \TODO: previous implementation of buzzer used a 0.8 scaling factor to produce max volume
   // when we used set(1). We need to bring that back somehow (e.g make buzzer a pwm driven actuator
   // with calibration from 0 to 0.8, which works, but buzzer isn't really an actuator so making it
   // a member of Actuators feels wrong, and the initialization overhead is a bit much to live in
   // main in my view).
-  buzzer.emplace(GPIO::Port::B, 4, GPIO::AlternativeFunction::AF2, kilohertz(2.4f), Timer3Base, 1,
-                 PeripheralID::Timer3, CPUFrequency);
+
+  // buzzer is hooked up to PB4 (see [PCB]),
+  // which can be linked to Timer3 chanel 1 using AF2 (see [DS], p77)
+  GPIO::PwmChannel buzzer_channel = {GPIO::Port::B, 4, GPIO::AlternativeFunction::AF2,
+                                     PeripheralID::Timer3, 1};
+  buzzer.emplace(buzzer_channel, kilohertz(2.4f), CPUFrequency);
+
   InitUARTs();
   I2C::initialize();
   Interrupts::singleton().EnableInterrupts();

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -122,19 +122,6 @@ void HalApi::Init() {
   LEDs.initialize();
   /// \TODO: ensure CPUFrequency is a multiple of 10 MHz
   SystemTimer::singleton().initialize(CPUFrequency);
-
-  // \TODO: previous implementation of buzzer used a 0.8 scaling factor to produce max volume
-  // when we used set(1). We need to bring that back somehow (e.g make buzzer a pwm driven actuator
-  // with calibration from 0 to 0.8, which works, but buzzer isn't really an actuator so making it
-  // a member of Actuators feels wrong, and the initialization overhead is a bit much to live in
-  // main in my view).
-
-  // buzzer is hooked up to PB4 (see [PCB]),
-  // which can be linked to Timer3 chanel 1 using AF2 (see [DS], p77)
-  GPIO::PwmChannel buzzer_channel = {GPIO::Port::B, 4, GPIO::AlternativeFunction::AF2,
-                                     PeripheralID::Timer3, 1};
-  buzzer.emplace(buzzer_channel, kilohertz(2.4f), CPUFrequency);
-
   InitUARTs();
   I2C::initialize();
   Interrupts::singleton().EnableInterrupts();

--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -43,19 +43,10 @@ void initialize() {
 
   // The following pins are used as i2c1 bus on the rev-1 PCB (see [PCB]):
   // Set Pin Function to I²C, [DS] Table 17 (pg 77)
-  GPIO::alternate_function(GPIO::Port::B, /*pin =*/8,
-                           GPIO::AlternativeFunction::AF4);  // I2C1_SCL
-  GPIO::alternate_function(GPIO::Port::B, /*pin =*/9,
-                           GPIO::AlternativeFunction::AF4);  // I2C1_SDA
-  // Set output speed to Fast
-  GPIO::output_speed(GPIO::Port::B, 8, GPIO::OutSpeed::Fast);
-  GPIO::output_speed(GPIO::Port::B, 9, GPIO::OutSpeed::Fast);
-  // Set open drain mode
-  GPIO::output_type(GPIO::Port::B, 8, GPIO::OutType::OpenDrain);
-  GPIO::output_type(GPIO::Port::B, 9, GPIO::OutType::OpenDrain);
-  // Set Pull Up resistors
-  GPIO::pull_up(GPIO::Port::B, 8);
-  GPIO::pull_up(GPIO::Port::B, 9);
+  GPIO::AlternatePin(GPIO::Port::B, 8, GPIO::AlternativeFunction::AF4, GPIO::PullType::Up,
+                     GPIO::OutSpeed::Fast, GPIO::OutType::OpenDrain);  // I2C1_SCL
+  GPIO::AlternatePin(GPIO::Port::B, 9, GPIO::AlternativeFunction::AF4, GPIO::PullType::Up,
+                     GPIO::OutSpeed::Fast, GPIO::OutType::OpenDrain);  // I2C1_SDA
 
   Interrupts::singleton().EnableInterrupt(InterruptVector::I2c1Event, IntPriority::Low);
   Interrupts::singleton().EnableInterrupt(InterruptVector::I2c1Error, IntPriority::Low);

--- a/software/controller/lib/hal/led_indicators.cpp
+++ b/software/controller/lib/hal/led_indicators.cpp
@@ -18,10 +18,6 @@ limitations under the License.
 #include <algorithm>
 #include <cassert>
 
-#include "gpio.h"
-
-#if defined(BARE_STM32)
-
 /******************************************************************
  * LED outputs.
  *  PC13 - red
@@ -29,58 +25,8 @@ limitations under the License.
  *  PC15 - green
  *****************************************************************/
 void LEDIndicators::initialize() {
-  using IOPort = GPIO::Port;
-  using IOMode = GPIO::PinMode;
-
   // Configure LED pins as outputs
-  GPIO::pin_mode(IOPort::C, 13, IOMode::Output);
-  GPIO::pin_mode(IOPort::C, 14, IOMode::Output);
-  GPIO::pin_mode(IOPort::C, 15, IOMode::Output);
-
-  // Turn all three LEDs off initially
-  GPIO::clear_pin(IOPort::C, 13);
-  GPIO::clear_pin(IOPort::C, 14);
-  GPIO::clear_pin(IOPort::C, 15);
+  red_led_.emplace(GPIO::Port::C, 13);
+  yellow_led_.emplace(GPIO::Port::C, 14);
+  green_led_.emplace(GPIO::Port::C, 15);
 }
-
-// Set or clear the specified digital output
-void LEDIndicators::set(BinaryPin binary_pin, VoltageLevel value) {
-  auto [port, pin] = [&]() -> std::pair<GPIO::Port, uint8_t> {
-    switch (binary_pin) {
-      case BinaryPin::RedLED:
-        return {GPIO::Port::C, 13};
-      case BinaryPin::YellowLED:
-        return {GPIO::Port::C, 14};
-      case BinaryPin::GreenLED:
-        return {GPIO::Port::C, 15};
-    }
-    // All cases covered above (and GCC checks this).
-    __builtin_unreachable();
-  }();
-
-  switch (value) {
-    case VoltageLevel::High:
-      GPIO::set_pin(port, pin);
-      break;
-
-    case VoltageLevel::Low:
-      GPIO::clear_pin(port, pin);
-      break;
-  }
-}
-
-#else
-
-void LEDIndicators::initialize() {}
-void LEDIndicators::set(BinaryPin pin, VoltageLevel value) {
-  if (binary_pin_modes_[pin] != GPIO::PinMode::Output) {
-    assert(false && "Can only write to an OUTPUT pin");
-  }
-  binary_pin_values_[pin] = value;
-}
-
-void LEDIndicators::set_pin_mode(BinaryPin pin, GPIO::PinMode mode) {
-  binary_pin_modes_[pin] = mode;
-}
-
-#endif

--- a/software/controller/lib/hal/led_indicators.cpp
+++ b/software/controller/lib/hal/led_indicators.cpp
@@ -26,7 +26,7 @@ limitations under the License.
  *****************************************************************/
 void LEDIndicators::initialize() {
   // Configure LED pins as outputs
-  red_led_.emplace(GPIO::Port::C, 13);
-  yellow_led_.emplace(GPIO::Port::C, 14);
-  green_led_.emplace(GPIO::Port::C, 15);
+  red_led.emplace(GPIO::Port::C, 13);
+  yellow_led.emplace(GPIO::Port::C, 14);
+  green_led.emplace(GPIO::Port::C, 15);
 }

--- a/software/controller/lib/hal/led_indicators.h
+++ b/software/controller/lib/hal/led_indicators.h
@@ -16,44 +16,15 @@ limitations under the License.
 #pragma once
 
 #include <cstdint>
-
-#if !defined(BARE_STM32)
-#include <map>
+#include <optional>
 
 #include "gpio.h"
-#endif
-
-// Binary pins set by the controller -- these are booleans, High or Low.
-//
-// PWM pins can of course be HIGH or LOW too, but we separate out purely on/off
-// pins from PWM pins for reasons of "strong typing".
-//
-// Pins default to Input, so if you add a new pin here, be sure to update
-// HalApi::Init() and set it to Output!
-enum class BinaryPin {
-  RedLED,
-  YellowLED,
-  GreenLED,
-};
-
-// Voltage level of a digital pin.
-// Usage: VoltageLevel::High, Low
-enum class VoltageLevel { High, Low };
 
 class LEDIndicators {
  public:
   void initialize();
 
-  // Sets `binary_pin` to high or low.
-  void set(BinaryPin binary_pin, VoltageLevel value);
-
-#if !defined(BARE_STM32)
- public:
-  /// \TODO: is this the best thing to test? Isn't this implementation-specific?
-  void set_pin_mode(BinaryPin pin, GPIO::PinMode mode);
-
- private:
-  std::map<BinaryPin, GPIO::PinMode> binary_pin_modes_;
-  std::map<BinaryPin, VoltageLevel> binary_pin_values_;
-#endif
+  std::optional<GPIO::DigitalOutputPin> red_led_;
+  std::optional<GPIO::DigitalOutputPin> yellow_led_;
+  std::optional<GPIO::DigitalOutputPin> green_led_;
 };

--- a/software/controller/lib/hal/led_indicators.h
+++ b/software/controller/lib/hal/led_indicators.h
@@ -24,7 +24,7 @@ class LEDIndicators {
  public:
   void initialize();
 
-  std::optional<GPIO::DigitalOutputPin> red_led_;
-  std::optional<GPIO::DigitalOutputPin> yellow_led_;
-  std::optional<GPIO::DigitalOutputPin> green_led_;
+  std::optional<GPIO::DigitalOutputPin> red_led;
+  std::optional<GPIO::DigitalOutputPin> yellow_led;
+  std::optional<GPIO::DigitalOutputPin> green_led;
 };

--- a/software/controller/lib/hal/pwm.cpp
+++ b/software/controller/lib/hal/pwm.cpp
@@ -33,9 +33,31 @@ limitations under the License.
 #include <algorithm>
 #if defined(BARE_STM32)
 
-PWM::PWM(const Frequency pwm_freq, TimerReg *timer, uint8_t channel, const PeripheralID peripheral,
+// helper function to get the proper timer register based on timer peripheral ID
+TimerReg *register_for(const PeripheralID peripheral) {
+  switch (peripheral) {
+    case PeripheralID::Timer1:
+      return Timer1Base;
+    case PeripheralID::Timer2:
+      return Timer2Base;
+    case PeripheralID::Timer3:
+      return Timer3Base;
+    case PeripheralID::Timer6:
+      return Timer6Base;
+    case PeripheralID::Timer7:
+      return Timer7Base;
+    case PeripheralID::Timer15:
+      return Timer15Base;
+    case PeripheralID::Timer16:
+      return Timer16Base;
+    default:
+      return nullptr;
+  }
+}
+
+PWM::PWM(const Frequency pwm_freq, const PeripheralID peripheral, uint8_t channel,
          const Frequency cpu_frequency)
-    : pwm_freq_(pwm_freq), timer_(timer), channel_(channel) {
+    : pwm_freq_(pwm_freq), timer_(register_for(peripheral)), channel_(channel) {
   enable_peripheral_clock(peripheral);
 
   // Set the frequency
@@ -77,9 +99,9 @@ void PWM::set(const float duty) {
 
 #else
 
-PWM::PWM(const Frequency pwm_freq, TimerReg *timer, uint8_t channel, const PeripheralID peripheral,
+PWM::PWM(const Frequency pwm_freq, const PeripheralID peripheral, uint8_t channel,
          const Frequency cpu_frequency)
-    : pwm_freq_(pwm_freq), timer_(timer), channel_(channel){};
+    : pwm_freq_(pwm_freq), timer_(nullptr), channel_(channel){};
 
 void PWM::set(float duty) { value_ = std::clamp(duty, 0.0f, 1.0f); }
 

--- a/software/controller/lib/hal/pwm.cpp
+++ b/software/controller/lib/hal/pwm.cpp
@@ -69,7 +69,7 @@ void PWM::initialize(const Frequency cpu_frequency) {
 
   enable_peripheral_clock(peripheral);
 
-  GPIO::alternate_function(port, pin_number, alternate_function);
+  GPIO::AlternatePin(port, pin_number, alternate_function);
 
   // Set the frequency
   timer_->auto_reload = static_cast<uint32_t>(cpu_frequency.hertz() / pwm_freq_.hertz()) - 1;

--- a/software/controller/lib/hal/pwm.cpp
+++ b/software/controller/lib/hal/pwm.cpp
@@ -108,3 +108,13 @@ void PWM::set(float duty) { value_ = std::clamp(duty, 0.0f, 1.0f); }
 float PWM::get() const { return value_; }
 
 #endif
+
+namespace GPIO {
+PwmPin::PwmPin(PwmChannel channel, const Frequency pwm_freq, const Frequency cpu_frequency)
+    : AlternatePin(channel.port, channel.pin, channel.function),
+      pwm_(pwm_freq, channel.peripheral, channel.timer_channel, cpu_frequency) {
+  alternate_function(channel.function);
+}
+
+void PwmPin::set(float value) { pwm_.set(value); }
+}  // namespace GPIO

--- a/software/controller/lib/hal/pwm.h
+++ b/software/controller/lib/hal/pwm.h
@@ -17,40 +17,20 @@ limitations under the License.
 
 #include <cstdint>
 
+#include "clocks.h"
 #include "timers.h"
 #include "units.h"
 
-#if !defined(BARE_STM32)
-#include <map>
-
-#include "gpio.h"
-#endif
-
-// Pulse-width modulated outputs from the controller.  These can be set to
-// values in [0-255].
-//
-// Pins default to input, and will be set to output as part of the initialize method
-
-/// \TODO: abstract PwmPin definition out of here, and in a higher layer.
-enum class PwmPin {
-  Blower,
-  Buzzer,
-  Psol,
-};
-
 class PWM {
  public:
-  PWM(const PwmPin pin, const Frequency pwm_freq) : pin_(pin), pwm_freq_(pwm_freq){};
-
-  void initialize(Frequency cpu_frequency);
+  PWM(const Frequency pwm_freq, TimerReg* timer, uint8_t channel, const PeripheralID peripheral,
+      const Frequency cpu_frequency);
 
   // Causes `pin` to output a square wave with the given duty cycle (range [0, 1], with preemptive
   // clamping before setting the registers).
   void set(float duty);
 
  private:
-  PwmPin pin_;
-
   // The selection of PWM frequency is a trade-off between latency and
   // resolution.  Higher frequencies give lower latency and lower resolution.
   //
@@ -63,16 +43,12 @@ class PWM {
   // part in 4000 (80000000/20000) or about 12 bits.
   Frequency pwm_freq_;
 
-  TimerReg* timer_{nullptr};
-  uint8_t channel_{0};
-
+  TimerReg* timer_;
+  uint8_t channel_;
 #if !defined(BARE_STM32)
- public:
-  /// \TODO: is this the best thing to test? Isn't this implementation-specific?
-  void set_pin_mode(GPIO::PinMode mode);
+  float value_;
 
- private:
-  std::map<PwmPin, GPIO::PinMode> pwm_pin_modes_;
-  std::map<PwmPin, float> pwm_pin_values_;
+ public:
+  float get() const;
 #endif
 };

--- a/software/controller/lib/hal/pwm.h
+++ b/software/controller/lib/hal/pwm.h
@@ -23,7 +23,7 @@ limitations under the License.
 
 class PWM {
  public:
-  PWM(const Frequency pwm_freq, TimerReg* timer, uint8_t channel, const PeripheralID peripheral,
+  PWM(const Frequency pwm_freq, const PeripheralID peripheral, uint8_t channel,
       const Frequency cpu_frequency);
 
   // Causes `pin` to output a square wave with the given duty cycle (range [0, 1], with preemptive
@@ -46,7 +46,7 @@ class PWM {
   TimerReg* timer_;
   uint8_t channel_;
 #if !defined(BARE_STM32)
-  float value_;
+  float value_{0};
 
  public:
   float get() const;

--- a/software/controller/lib/hal/pwm.h
+++ b/software/controller/lib/hal/pwm.h
@@ -17,14 +17,13 @@ limitations under the License.
 
 #include <cstdint>
 
-#include "clocks.h"
+#include "gpio.h"
 #include "timers.h"
 #include "units.h"
 
 class PWM {
  public:
-  PWM(const Frequency pwm_freq, const PeripheralID peripheral, uint8_t channel,
-      const Frequency cpu_frequency);
+  PWM(Frequency pwm_freq, PeripheralID peripheral, uint8_t channel, Frequency cpu_frequency);
 
   // Causes `pin` to output a square wave with the given duty cycle (range [0, 1], with preemptive
   // clamping before setting the registers).
@@ -52,3 +51,15 @@ class PWM {
   float get() const;
 #endif
 };
+
+namespace GPIO {
+// PWM pin, handling to its own pwm signal.
+class PwmPin : public AlternatePin {
+ public:
+  PwmPin(PwmChannel channel, Frequency pwm_freq, Frequency cpu_frequency);
+  void set(float value);
+
+ private:
+  PWM pwm_;
+};
+}  // namespace GPIO

--- a/software/controller/lib/hal/pwm.h
+++ b/software/controller/lib/hal/pwm.h
@@ -44,6 +44,7 @@ class PWM {
 
   TimerReg* timer_;
   uint8_t channel_;
+/// \TODO: move to a separate mock class
 #if !defined(BARE_STM32)
   float value_{0};
 
@@ -53,7 +54,7 @@ class PWM {
 };
 
 namespace GPIO {
-// PWM pin, handling to its own pwm signal.
+// PWM pin, handling its own pwm signal.
 class PwmPin : public AlternatePin {
  public:
   PwmPin(PwmChannel channel, Frequency pwm_freq, Frequency cpu_frequency);

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -47,6 +47,9 @@ limitations under the License.
 #pragma once
 
 #include <cstdint>
+#include <optional>
+
+#include "gpio.h"
 
 // These are the simple opcodes for the stepper driver.
 // Not included here are set/get parameter which include
@@ -295,6 +298,9 @@ class StepMotor {
   static uint8_t dma_buff_[MaxMotors];
   static uint8_t param_len_[32];
   static StepCommState coms_state_;
+
+  // pointer to the chip select pin that we need to manually manipulate to speak with the motors.
+  static std::optional<GPIO::DigitalOutputPin> chip_select_;
 
   // This queue is used for sending commands from the high
   // priority loop.  The command is copied to this queue and

--- a/software/controller/lib/sensors/analog_sensor.cpp
+++ b/software/controller/lib/sensors/analog_sensor.cpp
@@ -1,0 +1,39 @@
+/* Copyright 2020-2022, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "analog_sensor.h"
+
+AnalogSensor::AnalogSensor(const char *name, const char *help_supplement,
+                           const GPIO::AdcChannel &channel, ADC *adc)
+    : pin_(channel, adc),
+      dbg_zero_("zero", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage offset "),
+      dbg_voltage_("voltage", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage reading ") {
+  dbg_zero_.prepend_name(name);
+  dbg_zero_.append_help(help_supplement);
+
+  dbg_voltage_.prepend_name(name);
+  dbg_voltage_.append_help(help_supplement);
+}
+
+void AnalogSensor::set_zero() {
+  zero_ = pin_.read();
+  dbg_zero_.set(zero_.volts());
+}
+
+float AnalogSensor::read_diff_volts() const {
+  auto ret = (pin_.read() - zero_).volts();
+  dbg_voltage_.set(ret);
+  return ret;
+}

--- a/software/controller/lib/sensors/analog_sensor.h
+++ b/software/controller/lib/sensors/analog_sensor.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,13 +15,23 @@ limitations under the License.
 
 #pragma once
 
-#include "analog_sensor.h"
-#include "sensor_base.h"
+#include "adc.h"
+#include "units.h"
+#include "vars.h"
 
-class TeledyneR24 : public OxygenSensor, public AnalogSensor {
+class AnalogSensor {
  public:
-  TeledyneR24(const char* name, const char* help_supplement, const GPIO::AdcChannel& channel,
-              ADC* adc);
+  AnalogSensor(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
+               ADC *adc);
 
-  float read(Pressure p_ambient) const override;
+  void set_zero();
+
+  float read_diff_volts() const;
+
+ private:
+  GPIO::AnalogInputPin pin_;
+  Voltage zero_;
+
+  mutable Debug::Variable::Float dbg_zero_;
+  mutable Debug::Variable::Float dbg_voltage_;
 };

--- a/software/controller/lib/sensors/oxygen.cpp
+++ b/software/controller/lib/sensors/oxygen.cpp
@@ -15,10 +15,9 @@ limitations under the License.
 
 #include "oxygen.h"
 
-TeledyneR24::TeledyneR24(const char *name, const char *help_supplement, GPIO::Port port,
-                         uint8_t pin, ADC *adc, AdcChannel adc_channel)
-    : OxygenSensor(name, help_supplement),
-      AnalogSensor(name, help_supplement, port, pin, adc, adc_channel) {}
+TeledyneR24::TeledyneR24(const char *name, const char *help_supplement,
+                         const GPIO::AdcChannel &channel, ADC *adc)
+    : OxygenSensor(name, help_supplement), AnalogSensor(name, help_supplement, channel, adc) {}
 
 // Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
 //

--- a/software/controller/lib/sensors/oxygen.cpp
+++ b/software/controller/lib/sensors/oxygen.cpp
@@ -15,14 +15,16 @@ limitations under the License.
 
 #include "oxygen.h"
 
-TeledyneR24::TeledyneR24(const char *name, const char *help_supplement, AnalogPin pin)
-    : OxygenSensor(name, help_supplement), AnalogSensor(name, help_supplement, pin) {}
+TeledyneR24::TeledyneR24(const char *name, const char *help_supplement, GPIO::Port port,
+                         uint8_t pin, ADC *adc, AdcChannel adc_channel)
+    : OxygenSensor(name, help_supplement),
+      AnalogSensor(name, help_supplement, port, pin, adc, adc_channel) {}
 
 // Reads an oxygen sensor, returning the concentration of oxygen [0 ; 1.0]
 //
 // Output scales with partial pressure of O2, so ambient pressure must be
 // compensated to get an accurate FIO2.
-float TeledyneR24::read(const HalApi &hal_api, Pressure p_ambient) const {
+float TeledyneR24::read(Pressure p_ambient) const {
   // Teledyne R24-compatible Electrochemical Cell Oxygen Sensor
   // http://www.medicalsolutiontechnology.com/wp-content/uploads/2012/09/GO-04-DATA-SHEET.pdf
   // Sensitivity of 0.060V/fio2, where fio2 is 0.0 to 1.0, at pressure = 1atm
@@ -38,9 +40,9 @@ float TeledyneR24::read(const HalApi &hal_api, Pressure p_ambient) const {
   static const float OxygenSensorGain{0.060f};
 
   // TODO: raise alarm if fio2 is out of expected (0,1) range
-  auto ret = AnalogSensor::read_diff_volts(hal_api) / (AmplifierGain * OxygenSensorGain) /
-                 p_ambient.atm() +
-             O2ConcentrationInAir;
+  auto ret =
+      AnalogSensor::read_diff_volts() / (AmplifierGain * OxygenSensorGain) / p_ambient.atm() +
+      O2ConcentrationInAir;
 
   dbg_fio2_.set(ret);
 

--- a/software/controller/lib/sensors/oxygen.h
+++ b/software/controller/lib/sensors/oxygen.h
@@ -19,8 +19,8 @@ limitations under the License.
 
 class TeledyneR24 : public OxygenSensor, public AnalogSensor {
  public:
-  TeledyneR24(const char* name, const char* help_supplement, GPIO::Port port, uint8_t pin, ADC* adc,
-              AdcChannel adc_channel);
+  TeledyneR24(const char* name, const char* help_supplement, const GPIO::AdcChannel& channel,
+              ADC* adc);
 
   float read(Pressure p_ambient) const override;
 };

--- a/software/controller/lib/sensors/oxygen.h
+++ b/software/controller/lib/sensors/oxygen.h
@@ -19,7 +19,8 @@ limitations under the License.
 
 class TeledyneR24 : public OxygenSensor, public AnalogSensor {
  public:
-  TeledyneR24(const char* name, const char* help_supplement, AnalogPin pin);
+  TeledyneR24(const char* name, const char* help_supplement, GPIO::Port port, uint8_t pin, ADC* adc,
+              AdcChannel adc_channel);
 
-  float read(const HalApi& hal_api, Pressure p_ambient) const override;
+  float read(Pressure p_ambient) const override;
 };

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -16,13 +16,14 @@ limitations under the License.
 #include "pressure_sensors.h"
 
 AnalogPressureSensor::AnalogPressureSensor(const char *name, const char *help_supplement,
-                                           AnalogPin pin, float voltage_to_kPa)
+                                           GPIO::Port port, uint8_t pin, ADC *adc,
+                                           AdcChannel adc_channel, float voltage_to_kPa)
     : PressureSensor(name, help_supplement),
-      AnalogSensor(name, help_supplement, pin),
+      AnalogSensor(name, help_supplement, port, pin, adc, adc_channel),
       voltage_to_kPa_(voltage_to_kPa) {}
 
-Pressure AnalogPressureSensor::read(const HalApi &hal_api) const {
-  auto ret = kPa(AnalogSensor::read_diff_volts(hal_api) * voltage_to_kPa_);
+Pressure AnalogPressureSensor::read() const {
+  auto ret = kPa(AnalogSensor::read_diff_volts() * voltage_to_kPa_);
   dbg_pressure_.set(ret.cmH2O());
   return ret;
 }
@@ -33,9 +34,10 @@ Pressure AnalogPressureSensor::read(const HalApi &hal_api) const {
 //
 // voltage_range is whatever the voltage is scaled to as captured by your ADC.
 // Therefore, if we multiply the received voltage by 5/voltage_range, we get a pressure in kPa.
-MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, AnalogPin pin,
-                       float voltage_range)
-    : AnalogPressureSensor(name, help_supplement, pin, 5.f / voltage_range) {}
+MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
+                       ADC *adc, AdcChannel adc_channel, float voltage_range)
+    : AnalogPressureSensor(name, help_supplement, port, pin, adc, adc_channel,
+                           5.f / voltage_range) {}
 
 // Vout = Vss * (0.09 * P + 0.04) between 0 and 5 V :
 // https://www.nxp.com/docs/en/data-sheet/MPX5010.pdf
@@ -44,6 +46,7 @@ MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, AnalogPin 
 // voltage_range is whatever the voltage is scaled to as captured by your ADC.
 // Therefore, if we multiply the received voltage by 5/voltage_range and divide it by 0.45, we get a
 // pressure in kPa.
-MPXV5010DP::MPXV5010DP(const char *name, const char *help_supplement, AnalogPin pin,
-                       float voltage_range)
-    : AnalogPressureSensor(name, help_supplement, pin, 5.f / voltage_range / 0.45f) {}
+MPXV5010DP::MPXV5010DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
+                       ADC *adc, AdcChannel adc_channel, float voltage_range)
+    : AnalogPressureSensor(name, help_supplement, port, pin, adc, adc_channel,
+                           5.f / voltage_range / 0.45f) {}

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -35,8 +35,8 @@ Pressure AnalogPressureSensor::read() const {
 // voltage_range is whatever the voltage is scaled to as captured by your ADC.
 // Therefore, if we multiply the received voltage by 5/voltage_range, we get a pressure in kPa.
 MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement,
-                       const GPIO::AdcChannel &channel, ADC *adc, float voltage_range)
-    : AnalogPressureSensor(name, help_supplement, channel, adc, 5.f / voltage_range) {}
+                       const GPIO::AdcChannel &channel, ADC *adc, Voltage voltage_range)
+    : AnalogPressureSensor(name, help_supplement, channel, adc, 5.f / voltage_range.volts()) {}
 
 // Vout = Vss * (0.09 * P + 0.04) between 0 and 5 V :
 // https://www.nxp.com/docs/en/data-sheet/MPX5010.pdf
@@ -46,5 +46,6 @@ MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement,
 // Therefore, if we multiply the received voltage by 5/voltage_range and divide it by 0.45, we get a
 // pressure in kPa.
 MPXV5010DP::MPXV5010DP(const char *name, const char *help_supplement,
-                       const GPIO::AdcChannel &channel, ADC *adc, float voltage_range)
-    : AnalogPressureSensor(name, help_supplement, channel, adc, 5.f / voltage_range / 0.45f) {}
+                       const GPIO::AdcChannel &channel, ADC *adc, Voltage voltage_range)
+    : AnalogPressureSensor(name, help_supplement, channel, adc,
+                           5.f / voltage_range.volts() / 0.45f) {}

--- a/software/controller/lib/sensors/pressure_sensors.cpp
+++ b/software/controller/lib/sensors/pressure_sensors.cpp
@@ -16,10 +16,10 @@ limitations under the License.
 #include "pressure_sensors.h"
 
 AnalogPressureSensor::AnalogPressureSensor(const char *name, const char *help_supplement,
-                                           GPIO::Port port, uint8_t pin, ADC *adc,
-                                           AdcChannel adc_channel, float voltage_to_kPa)
+                                           const GPIO::AdcChannel &channel, ADC *adc,
+                                           float voltage_to_kPa)
     : PressureSensor(name, help_supplement),
-      AnalogSensor(name, help_supplement, port, pin, adc, adc_channel),
+      AnalogSensor(name, help_supplement, channel, adc),
       voltage_to_kPa_(voltage_to_kPa) {}
 
 Pressure AnalogPressureSensor::read() const {
@@ -34,10 +34,9 @@ Pressure AnalogPressureSensor::read() const {
 //
 // voltage_range is whatever the voltage is scaled to as captured by your ADC.
 // Therefore, if we multiply the received voltage by 5/voltage_range, we get a pressure in kPa.
-MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
-                       ADC *adc, AdcChannel adc_channel, float voltage_range)
-    : AnalogPressureSensor(name, help_supplement, port, pin, adc, adc_channel,
-                           5.f / voltage_range) {}
+MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement,
+                       const GPIO::AdcChannel &channel, ADC *adc, float voltage_range)
+    : AnalogPressureSensor(name, help_supplement, channel, adc, 5.f / voltage_range) {}
 
 // Vout = Vss * (0.09 * P + 0.04) between 0 and 5 V :
 // https://www.nxp.com/docs/en/data-sheet/MPX5010.pdf
@@ -46,7 +45,6 @@ MPXV5004DP::MPXV5004DP(const char *name, const char *help_supplement, GPIO::Port
 // voltage_range is whatever the voltage is scaled to as captured by your ADC.
 // Therefore, if we multiply the received voltage by 5/voltage_range and divide it by 0.45, we get a
 // pressure in kPa.
-MPXV5010DP::MPXV5010DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
-                       ADC *adc, AdcChannel adc_channel, float voltage_range)
-    : AnalogPressureSensor(name, help_supplement, port, pin, adc, adc_channel,
-                           5.f / voltage_range / 0.45f) {}
+MPXV5010DP::MPXV5010DP(const char *name, const char *help_supplement,
+                       const GPIO::AdcChannel &channel, ADC *adc, float voltage_range)
+    : AnalogPressureSensor(name, help_supplement, channel, adc, 5.f / voltage_range / 0.45f) {}

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include "analog_sensor.h"
 #include "sensor_base.h"
 
 class AnalogPressureSensor : public PressureSensor, public AnalogSensor {

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -19,10 +19,10 @@ limitations under the License.
 
 class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
  public:
-  AnalogPressureSensor(const char *name, const char *help_supplement, AnalogPin pin,
-                       float voltage_to_kPa);
+  AnalogPressureSensor(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
+                       ADC *adc, AdcChannel adc_channel, float voltage_to_kPa);
 
-  Pressure read(const HalApi &hal_api) const override;
+  Pressure read() const override;
 
  private:
   // Assume linear relationship, pending further research
@@ -31,7 +31,8 @@ class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
 
 class MPXV5004DP : public AnalogPressureSensor {
  public:
-  MPXV5004DP(const char *name, const char *help_supplement, AnalogPin pin, float voltage_range);
+  MPXV5004DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin, ADC *adc,
+             AdcChannel adc_channel, float voltage_range);
 
   // min/max possible reading from MPXV5004DP pressure sensors
   // \TODO: are we supposed to use these somehow?
@@ -41,7 +42,8 @@ class MPXV5004DP : public AnalogPressureSensor {
 
 class MPXV5010DP : public AnalogPressureSensor {
  public:
-  MPXV5010DP(const char *name, const char *help_supplement, AnalogPin pin, float voltage_range);
+  MPXV5010DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin, ADC *adc,
+             AdcChannel adc_channel, float voltage_range);
   // min/max possible reading from MPXV5010DP pressure sensors
   constexpr static Pressure MinPressure{kPa(0.0f)};
   constexpr static Pressure MaxPressure{kPa(10.0f)};

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -19,8 +19,8 @@ limitations under the License.
 
 class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
  public:
-  AnalogPressureSensor(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
-                       ADC *adc, AdcChannel adc_channel, float voltage_to_kPa);
+  AnalogPressureSensor(const char *name, const char *help_supplement,
+                       const GPIO::AdcChannel &channel, ADC *adc, float voltage_to_kPa);
 
   Pressure read() const override;
 
@@ -31,8 +31,8 @@ class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
 
 class MPXV5004DP : public AnalogPressureSensor {
  public:
-  MPXV5004DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin, ADC *adc,
-             AdcChannel adc_channel, float voltage_range);
+  MPXV5004DP(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
+             ADC *adc, float voltage_range);
 
   // min/max possible reading from MPXV5004DP pressure sensors
   // \TODO: are we supposed to use these somehow?
@@ -42,8 +42,8 @@ class MPXV5004DP : public AnalogPressureSensor {
 
 class MPXV5010DP : public AnalogPressureSensor {
  public:
-  MPXV5010DP(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin, ADC *adc,
-             AdcChannel adc_channel, float voltage_range);
+  MPXV5010DP(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
+             ADC *adc, float voltage_range);
   // min/max possible reading from MPXV5010DP pressure sensors
   constexpr static Pressure MinPressure{kPa(0.0f)};
   constexpr static Pressure MaxPressure{kPa(10.0f)};

--- a/software/controller/lib/sensors/pressure_sensors.h
+++ b/software/controller/lib/sensors/pressure_sensors.h
@@ -32,7 +32,7 @@ class AnalogPressureSensor : public PressureSensor, public AnalogSensor {
 class MPXV5004DP : public AnalogPressureSensor {
  public:
   MPXV5004DP(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
-             ADC *adc, float voltage_range);
+             ADC *adc, Voltage voltage_range);
 
   // min/max possible reading from MPXV5004DP pressure sensors
   // \TODO: are we supposed to use these somehow?
@@ -43,7 +43,7 @@ class MPXV5004DP : public AnalogPressureSensor {
 class MPXV5010DP : public AnalogPressureSensor {
  public:
   MPXV5010DP(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
-             ADC *adc, float voltage_range);
+             ADC *adc, Voltage voltage_range);
   // min/max possible reading from MPXV5010DP pressure sensors
   constexpr static Pressure MinPressure{kPa(0.0f)};
   constexpr static Pressure MaxPressure{kPa(10.0f)};

--- a/software/controller/lib/sensors/sensor_base.cpp
+++ b/software/controller/lib/sensors/sensor_base.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,31 +14,6 @@ limitations under the License.
 */
 
 #include "sensor_base.h"
-
-/// \TODO: generalize these classes to not require reference to entire HAL
-
-AnalogSensor::AnalogSensor(const char *name, const char *help_supplement,
-                           const GPIO::AdcChannel &channel, ADC *adc)
-    : pin_(channel, adc),
-      dbg_zero_("zero", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage offset "),
-      dbg_voltage_("voltage", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage reading ") {
-  dbg_zero_.prepend_name(name);
-  dbg_zero_.append_help(help_supplement);
-
-  dbg_voltage_.prepend_name(name);
-  dbg_voltage_.append_help(help_supplement);
-}
-
-void AnalogSensor::set_zero() {
-  zero_ = pin_.read();
-  dbg_zero_.set(zero_.volts());
-}
-
-float AnalogSensor::read_diff_volts() const {
-  auto ret = (pin_.read() - zero_).volts();
-  dbg_voltage_.set(ret);
-  return ret;
-}
 
 PressureSensor::PressureSensor(const char *name, const char *help_supplement)
     : dbg_pressure_("dp", Debug::Variable::Access::ReadOnly, 0.f, "cmH2O",

--- a/software/controller/lib/sensors/sensor_base.cpp
+++ b/software/controller/lib/sensors/sensor_base.cpp
@@ -17,9 +17,9 @@ limitations under the License.
 
 /// \TODO: generalize these classes to not require reference to entire HAL
 
-AnalogSensor::AnalogSensor(const char *name, const char *help_supplement, GPIO::Port port,
-                           uint8_t pin, ADC *adc, AdcChannel adc_channel)
-    : pin_(port, pin, adc, adc_channel),
+AnalogSensor::AnalogSensor(const char *name, const char *help_supplement,
+                           const GPIO::AdcChannel &channel, ADC *adc)
+    : pin_(channel, adc),
       dbg_zero_("zero", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage offset "),
       dbg_voltage_("voltage", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage reading ") {
   dbg_zero_.prepend_name(name);

--- a/software/controller/lib/sensors/sensor_base.cpp
+++ b/software/controller/lib/sensors/sensor_base.cpp
@@ -17,8 +17,9 @@ limitations under the License.
 
 /// \TODO: generalize these classes to not require reference to entire HAL
 
-AnalogSensor::AnalogSensor(const char *name, const char *help_supplement, AnalogPin pin)
-    : pin_(pin),
+AnalogSensor::AnalogSensor(const char *name, const char *help_supplement, GPIO::Port port,
+                           uint8_t pin, ADC *adc, AdcChannel adc_channel)
+    : pin_(port, pin, adc, adc_channel),
       dbg_zero_("zero", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage offset "),
       dbg_voltage_("voltage", Debug::Variable::Access::ReadOnly, 0.f, "V", "Voltage reading ") {
   dbg_zero_.prepend_name(name);
@@ -28,13 +29,13 @@ AnalogSensor::AnalogSensor(const char *name, const char *help_supplement, Analog
   dbg_voltage_.append_help(help_supplement);
 }
 
-void AnalogSensor::set_zero(const HalApi &hal_api) {
-  zero_ = hal_api.adc.read(pin_);
+void AnalogSensor::set_zero() {
+  zero_ = pin_.read();
   dbg_zero_.set(zero_.volts());
 }
 
-float AnalogSensor::read_diff_volts(const HalApi &hal_api) const {
-  auto ret = (hal_api.adc.read(pin_) - zero_).volts();
+float AnalogSensor::read_diff_volts() const {
+  auto ret = (pin_.read() - zero_).volts();
   dbg_voltage_.set(ret);
   return ret;
 }

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -15,20 +15,21 @@ limitations under the License.
 
 #pragma once
 
-#include "hal.h"
+#include "gpio.h"
 #include "units.h"
 #include "vars.h"
 
 class AnalogSensor {
  public:
-  AnalogSensor(const char *name, const char *help_supplement, AnalogPin pin);
+  AnalogSensor(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
+               ADC *adc, AdcChannel adc_channel);
 
-  void set_zero(const HalApi &hal_api);
+  void set_zero();
 
-  float read_diff_volts(const HalApi &hal_api) const;
+  float read_diff_volts() const;
 
  private:
-  AnalogPin pin_;
+  GPIO::AnalogInputPin pin_;
   Voltage zero_;
 
   mutable Debug::Variable::Float dbg_zero_;
@@ -37,7 +38,7 @@ class AnalogSensor {
 
 class PressureSensor {
  public:
-  virtual Pressure read(const HalApi &hal_api) const = 0;
+  virtual Pressure read() const = 0;
 
  protected:
   PressureSensor(const char *name, const char *help_supplement);
@@ -46,7 +47,7 @@ class PressureSensor {
 
 class FlowSensor {
  public:
-  virtual VolumetricFlow read(const HalApi &hal_api, float air_density) const = 0;
+  virtual VolumetricFlow read(float air_density) const = 0;
 
  protected:
   FlowSensor(const char *name, const char *help_supplement);
@@ -55,7 +56,7 @@ class FlowSensor {
 
 class OxygenSensor {
  public:
-  virtual float read(const HalApi &hal_api, Pressure p_ambient) const = 0;
+  virtual float read(Pressure p_ambient) const = 0;
 
  protected:
   OxygenSensor(const char *name, const char *help_supplement);

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -15,7 +15,7 @@ limitations under the License.
 
 #pragma once
 
-#include "gpio.h"
+#include "adc.h"
 #include "units.h"
 #include "vars.h"
 

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -21,8 +21,8 @@ limitations under the License.
 
 class AnalogSensor {
  public:
-  AnalogSensor(const char *name, const char *help_supplement, GPIO::Port port, uint8_t pin,
-               ADC *adc, AdcChannel adc_channel);
+  AnalogSensor(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
+               ADC *adc);
 
   void set_zero();
 

--- a/software/controller/lib/sensors/sensor_base.h
+++ b/software/controller/lib/sensors/sensor_base.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,26 +15,8 @@ limitations under the License.
 
 #pragma once
 
-#include "adc.h"
 #include "units.h"
 #include "vars.h"
-
-class AnalogSensor {
- public:
-  AnalogSensor(const char *name, const char *help_supplement, const GPIO::AdcChannel &channel,
-               ADC *adc);
-
-  void set_zero();
-
-  float read_diff_volts() const;
-
- private:
-  GPIO::AnalogInputPin pin_;
-  Voltage zero_;
-
-  mutable Debug::Variable::Float dbg_zero_;
-  mutable Debug::Variable::Float dbg_voltage_;
-};
 
 class PressureSensor {
  public:

--- a/software/controller/lib/sensors/venturi.cpp
+++ b/software/controller/lib/sensors/venturi.cpp
@@ -47,8 +47,8 @@ VenturiFlowSensor::VenturiFlowSensor(const char* name, const char* help_suppleme
  * direction of flow, depending on how the differential sensor is attached to
  * the venturi.
  */
-VolumetricFlow VenturiFlowSensor::read(const HalApi& hal_api, float air_density) const {
-  auto ret = pressure_delta_to_flow(pressure_sensor_->read(hal_api), air_density);
+VolumetricFlow VenturiFlowSensor::read(float air_density) const {
+  auto ret = pressure_delta_to_flow(pressure_sensor_->read(), air_density);
   dbg_flow_.set(ret.ml_per_sec());
   return ret;
 }

--- a/software/controller/lib/sensors/venturi.h
+++ b/software/controller/lib/sensors/venturi.h
@@ -25,7 +25,7 @@ class VenturiFlowSensor : public FlowSensor {
                     float venturi_correction);
 
   /// \param air_density in units of kg/m^3, will depend on temperature and pressure
-  VolumetricFlow read(const HalApi& hal_api, float air_density) const override;
+  VolumetricFlow read(float air_density) const override;
 
   /// This is exposed as static so the math can be tested without HAL
   VolumetricFlow pressure_delta_to_flow(Pressure delta, float air_density) const;

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -215,12 +215,10 @@ int main() {
   // Initialize hal first because it initializes the watchdog. See comment on HalApi::Init().
   hal.Init();
 
-  // Init the pwm pins for actuators
-  actuators.Init(HalApi::GetCpuFreq());
-
   // Locate our non-volatile parameter block in flash
   nv_params.Init(&eeprom);
-  actuators.link(&nv_params, offsetof(NVParams::Structure, blower_pinch_cal),
+  // Init the pwm pins for actuators and link calibration tables
+  actuators.Init(HalApi::GetCpuFreq(), &nv_params, offsetof(NVParams::Structure, blower_pinch_cal),
                  offsetof(NVParams::Structure, exhale_pinch_cal),
                  offsetof(NVParams::Structure, blower_cal),
                  offsetof(NVParams::Structure, psol_cal));

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -157,10 +157,6 @@ static void HighPriorityTask(void *arg) {
     debug.Poll();
   }
 
-  // Calibrate the sensors.
-  // This needs to be done before the sensors are used.
-  sensors.calibrate();
-
   // Current controller status.
   // Updated when we receive data from the GUI, when sensors read data, etc.
   controller_status = ControllerStatus_init_zero;
@@ -226,6 +222,10 @@ int main() {
                  offsetof(NVParams::Structure, psol_cal));
 
   CommsInit();
+
+  // Initialize and calibrate the sensors.
+  // This needs to be done before the sensors are used.
+  sensors.init(&hal.adc, HalApi::GetCpuFreq());
 
   BackgroundLoop();
 }

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -218,7 +218,7 @@ int main() {
   // Locate our non-volatile parameter block in flash
   nv_params.Init(&eeprom);
   // Init the pwm pins for actuators and link calibration tables
-  actuators.Init(HalApi::GetCpuFreq(), &nv_params, offsetof(NVParams::Structure, blower_pinch_cal),
+  actuators.init(HalApi::GetCpuFreq(), &nv_params, offsetof(NVParams::Structure, blower_pinch_cal),
                  offsetof(NVParams::Structure, exhale_pinch_cal),
                  offsetof(NVParams::Structure, blower_cal),
                  offsetof(NVParams::Structure, psol_cal));

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -225,7 +225,7 @@ int main() {
 
   // Initialize and calibrate the sensors.
   // This needs to be done before the sensors are used.
-  sensors.init(&hal.adc, HalApi::GetCpuFreq());
+  sensors.init(HalApi::GetCpuFreq());
 
   BackgroundLoop();
 }

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -157,9 +157,9 @@ static void HighPriorityTask(void *arg) {
     debug.Poll();
   }
 
-  // Initialize and calibrate the sensors after the pinch valves are properly homed to avoid the
+  // Calibrate the sensors after the pinch valves are properly homed to avoid the
   // effects of the blower (and to a lesser degree the pinch valves) moving during startup.
-  sensors.init(HalApi::GetCpuFreq());
+  sensors.calibrate();
 
   // Current controller status.
   // Updated when we receive data from the GUI, when sensors read data, etc.
@@ -222,6 +222,8 @@ int main() {
                  offsetof(NVParams::Structure, exhale_pinch_cal),
                  offsetof(NVParams::Structure, blower_cal),
                  offsetof(NVParams::Structure, psol_cal));
+
+  sensors.init(HalApi::GetCpuFreq());
 
   CommsInit();
 

--- a/software/controller/src/main.cpp
+++ b/software/controller/src/main.cpp
@@ -157,6 +157,10 @@ static void HighPriorityTask(void *arg) {
     debug.Poll();
   }
 
+  // Initialize and calibrate the sensors after the pinch valves are properly homed to avoid the
+  // effects of the blower (and to a lesser degree the pinch valves) moving during startup.
+  sensors.init(HalApi::GetCpuFreq());
+
   // Current controller status.
   // Updated when we receive data from the GUI, when sensors read data, etc.
   controller_status = ControllerStatus_init_zero;
@@ -222,10 +226,6 @@ int main() {
                  offsetof(NVParams::Structure, psol_cal));
 
   CommsInit();
-
-  // Initialize and calibrate the sensors.
-  // This needs to be done before the sensors are used.
-  sensors.init(HalApi::GetCpuFreq());
 
   BackgroundLoop();
 }

--- a/software/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/software/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 #include "hal.h"
+#include "system_constants.h"
 #include "system_timer.h"
 
 namespace {

--- a/software/controller/test/sensor_tests/sensors_test.cpp
+++ b/software/controller/test/sensor_tests/sensors_test.cpp
@@ -63,7 +63,7 @@ static VenturiFlowSensor typical_venturi{
  * range (0-4kPa) is in the voltage range 0-3.3V.
  */
 static Voltage MPXV5004_PressureToVoltage(Pressure pressure) {
-  return volts(3.3f * (0.2f * pressure.kPa() + 0.2f));
+  return volts(ADC::VoltageRange.volts() * (0.2f * pressure.kPa() + 0.2f));
 }
 
 // @brief This method models the pressure to voltage transfer function of the
@@ -72,7 +72,7 @@ static Voltage MPXV5004_PressureToVoltage(Pressure pressure) {
 // pressure range (0-10kPa) is in the voltage range 0-3.3V.
 
 static Voltage MPXV5010_PressureToVoltage(Pressure pressure) {
-  return volts(3.3f * (0.09f * pressure.kPa() + 0.04f));
+  return volts(ADC::VoltageRange.volts() * (0.09f * pressure.kPa() + 0.04f));
 }
 // This method models the oxygen sensor. Voltage reads partial pressure of O2
 // and needs ambient pressure to modulate output voltage.


### PR DESCRIPTION
# Description

This addresses some todos as well a the remaining review comment from #1190, but given the refactoring involved in GPIO and ADC, I wanted this to be a separate PR.
Updates #1190

Tested on my pizza build by setting blower to different values, reading resulting flows and patient pressure, running buzzer integration test, and general sanity checks of the running vent.
As for #1190, I could test neither the psol nor the oxygen sensor.

Some work is still necessary if we want to remove direct pin definitions from UART, SPI (stepper motors) and I2C, but this seems big enough already.

Also, with this, I was able to finally add a constants header for all systems constants: 
- venturi geometry,
- pinch valves constants,
- pin to function mappings,
- table sizes?
- ...

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
