### PR TITLE
Remove some warnings (including some from new tools enabled with pio 5.2.3)

### DIFF
--- a/software/.clang-tidy
+++ b/software/.clang-tidy
@@ -31,7 +31,10 @@ Checks: >
   -readability-implicit-bool-conversion,
   -modernize-use-using,
   -modernize-use-nodiscard,
-  -readability-non-const-parameter
+  -readability-non-const-parameter,
+  -bugprone-reserved-identifier,
+  -altera-struct-pack-align,
+  -llvmlibc-*,
 
 # TODO: apply necessary code fixes so we can re-enable
 #WarningsAsErrors: '*'

--- a/software/controller/lib/core/interpolant.h
+++ b/software/controller/lib/core/interpolant.h
@@ -25,8 +25,8 @@ limitations under the License.
 template <size_t N>
 class Interpolant {
  public:
-  Interpolant(const char *name, float cal_0 = 0.0f, float cal_1 = 1.0f, const char *units = "",
-              const char *help = "", const char *fmt = "%.3f")
+  explicit Interpolant(const char *name, float cal_0 = 0.0f, float cal_1 = 1.0f,
+                       const char *units = "", const char *help = "", const char *fmt = "%.3f")
       : cal_table_(name, Debug::Variable::Access::ReadWrite, cal_0, units, help, fmt) {
     // starting the loop at index 1 in order to avoid division by 0: if N <= 1 (which
     // doesn't make sense anyway), we don't actually enter the loop, and the first element

--- a/software/controller/lib/core/pinch_valve.h
+++ b/software/controller/lib/core/pinch_valve.h
@@ -91,5 +91,5 @@ class PinchValve {
   PinchValveHomeState home_state_{PinchValveHomeState::Disabled};
 
   // pinch valve calibration table
-  Interpolant<pinch_valves_cal_size> calibration_{"pinch_cal", 0.0f, 1.0f, "", "calibration table"};
+  Interpolant<PinchValvesCalSize> calibration_{"pinch_cal", 0.0f, 1.0f, "", "calibration table"};
 };

--- a/software/controller/lib/debug/eeprom_cmd.cpp
+++ b/software/controller/lib/debug/eeprom_cmd.cpp
@@ -66,12 +66,10 @@ ErrorCode EepromHandler::Write(const uint16_t address, Context *context) {
   uint8_t request[MaxWriteLength] = {0};
   memcpy(&request[0], &(context->request[3]), length);
   context->response_length = 0;
-  if (eeprom_->WriteBytes(address, length, &request, context->processed)) {
-    return ErrorCode::None;
-  } else {
-    // could not send write request for some reason
-    return ErrorCode::InternalError;
-  }
+  if (eeprom_->WriteBytes(address, length, &request, context->processed)) return ErrorCode::None;
+
+  // could not send write request for some reason
+  return ErrorCode::InternalError;
 }
 
 }  // namespace Debug::Command

--- a/software/controller/lib/hal/hal.h
+++ b/software/controller/lib/hal/hal.h
@@ -77,7 +77,6 @@ class HalApi {
   LEDIndicators LEDs;
   PWM pwm;
 
- public:
   void Init();
 
   // Receives bytes from the GUI controller along the serial bus.

--- a/software/controller/lib/non_volatile/nvparams.h
+++ b/software/controller/lib/non_volatile/nvparams.h
@@ -25,7 +25,7 @@ limitations under the License.
 #include "units.h"
 
 // pinch_valve calibration size, defined here because the tables are stored in NVParams.
-static constexpr size_t pinch_valves_cal_size{11};
+static constexpr size_t PinchValvesCalSize{11};
 
 namespace NVParams {
 
@@ -62,12 +62,12 @@ struct Structure {
   // should give pinch valve settings for a list of equally spaced flow rates.  The first entry
   // should be the setting for 0 flow rate (normally 0) and the last entry should be the setting
   // for 100% flow rate. The minimum length of the table is 2 entries.
-  std::array<float, pinch_valves_cal_size> blower_pinch_cal{0.0000f, 0.0410f, 0.0689f, 0.0987f,
-                                                            0.1275f, 0.1590f, 0.1932f, 0.2359f,
-                                                            0.2940f, 0.3988f, 1.0000f};
-  std::array<float, pinch_valves_cal_size> exhale_pinch_cal{0.0000f, 0.0410f, 0.0689f, 0.0987f,
-                                                            0.1275f, 0.1590f, 0.1932f, 0.2359f,
-                                                            0.2940f, 0.3988f, 1.0000f};
+  std::array<float, PinchValvesCalSize> blower_pinch_cal{0.0000f, 0.0410f, 0.0689f, 0.0987f,
+                                                         0.1275f, 0.1590f, 0.1932f, 0.2359f,
+                                                         0.2940f, 0.3988f, 1.0000f};
+  std::array<float, PinchValvesCalSize> exhale_pinch_cal{0.0000f, 0.0410f, 0.0689f, 0.0987f,
+                                                         0.1275f, 0.1590f, 0.1932f, 0.2359f,
+                                                         0.2940f, 0.3988f, 1.0000f};
 };
 
 // We are reserving the first 8 kB out of our 32kB eeprom for nv params.

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -72,15 +72,15 @@ check_flags =
   ; quieting missingIncludeSystem (which is not an error in our code), unusedFunction (which is true of all interrupt-called functions)
   ; and unmatchedSuppression (which would otherwise trigger for every file where one of the suppressed messages isn't present)
   ; This helps with output readability.
-  cppcheck: --enable=all --std=c++17 --suppress=missingIncludeSystem --suppress=unmatchedSuppression --suppress=unusedFunction
+  cppcheck: --enable=all --std=c++17 --suppress=missingIncludeSystem --suppress=unmatchedSuppression --suppress=unusedFunction --suppress=unusedStructMember
   ; The actual checks are defined in .clang-tidy.
-  clangtidy: --checks='-*' --extra-arg-before=-xc++ --extra-arg-before=-std=c++17 --extra-arg-before=-Wno-pragma-once-outside-header
+  clangtidy: --checks='*' --extra-arg-before=-xc++ --extra-arg-before=-std=c++17 --extra-arg-before=-Wno-pragma-once-outside-header
 check_patterns =
   ../controller/lib
   ../controller/src
   ../controller/src_test
   ../controller/integration_tests
-  ../common/libs
+  ; ../common/libs checked as part of common
   ; Do not include ../common/test_libs
   ; Do not include ../common/generated_libs
   ; Do not include ../common/third_party


### PR DESCRIPTION
# Description
This fixes some of the `clang-tidy` and `cppcheck` warnings that were introduced earlier in the project, and silences some of the new checks from `platformio` 5.2

Closes #1189

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [ x I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [ x I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
