### PR TITLE
anti-lfs measures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
   dead-link-test:
     docker:
       - image: cimg/go:1.17
+    environment:
+      GIT_LFS_SKIP_SMUDGE: 1
     steps:
       - checkout
       - run:
@@ -17,6 +19,8 @@ jobs:
   common-precommit-checks:
     docker:
       - image: cimg/python:3.10.4
+    environment:
+      GIT_LFS_SKIP_SMUDGE: 1
     steps:
       - checkout
       - run:
@@ -35,6 +39,8 @@ jobs:
   controller-tests:
     machine:
       image: ubuntu-2004:current
+    environment:
+      GIT_LFS_SKIP_SMUDGE: 1
     resource_class: large
     steps:
       - checkout
@@ -52,6 +58,8 @@ jobs:
   common-tests:
     machine:
       image: ubuntu-2004:current
+    environment:
+      GIT_LFS_SKIP_SMUDGE: 1
     steps:
       - checkout
       - run:
@@ -69,6 +77,8 @@ jobs:
     machine:
       image: ubuntu-2004:current
     resource_class: large
+    environment:
+      GIT_LFS_SKIP_SMUDGE: 1
     steps:
       - checkout
       - run:

--- a/software/utils/rpi_config/bootstrap.sh
+++ b/software/utils/rpi_config/bootstrap.sh
@@ -61,7 +61,8 @@ fi
 
 ### Install git-lfs and update the system
 sudo apt-get update
-sudo apt-get --yes install git-lfs matchbox-keyboard
+sudo apt-get --yes install git matchbox-keyboard
+#sudo apt-get --yes install git-lfs matchbox-keyboard  TODO: bring this back when LFS problems are solved?
 sudo apt-get --yes upgrade
 sudo apt-get --yes autoremove
 sudo apt-get autoclean


### PR DESCRIPTION
This will likely break deployment scripts to some extent. Doing this as contingency because of extreme and rapid drain on LFS quota lately. Pending other solutions, this is an easy and quick insurance measure to take against some obvious pitfalls that may be happening.