### PR TITLE
Fix debugvar names in debug scripts

### DIFF
--- a/software/controller/lib/actuators/actuator_base.h
+++ b/software/controller/lib/actuators/actuator_base.h
@@ -40,6 +40,9 @@ class Actuator {
 
  private:
   // Debug var that can be used from debug interface to force the actuator's setting
+  // TODO: make the "setting" debugvar name less generic, for example "position" for pinch valves,
+  // "power" for pwm, ...)
+  // Reminder: also update debug scripts (hardcoded debugvar names) when implementing this TODO.
   Debug::Variable::Float forced_value_{"setting", Debug::Variable::Access::ReadWrite, -1.f,
                                        "ratio"};
 };

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -225,9 +225,9 @@ class ControllerDebugInterface:
         # Ensure the ventilator fan is on, and disconnect the fan from the system
         # so it's not inflating the test lung.  Edwin's request is that the fan
         # doesn't have to spin up during these tests.
-        self.variable_set("forced_exhale_valve_pos", 1)
-        self.variable_set("forced_blower_valve_pos", 1)
-        self.variable_set("forced_blower_power", 1)
+        self.variable_set("forced_exhale_pinch_setting", 1)
+        self.variable_set("forced_blower_pinch_setting", 1)
+        self.variable_set("forced_blower_setting", 1)
         # todo force o2 psol open or closed?
 
     def variables_force_off(self):
@@ -235,9 +235,9 @@ class ControllerDebugInterface:
         # controller.  Note that you should unforce the blower power *after* setting the
         # forced_mode because if we unforced it while we were still in mode 0
         # (i.e. "ventilator off"), the fan would momentarily spin down.
-        self.variable_set("forced_exhale_valve_pos", -1)
-        self.variable_set("forced_blower_valve_pos", -1)
-        self.variable_set("forced_blower_power", -1)
+        self.variable_set("forced_exhale_pinch_setting", -1)
+        self.variable_set("forced_blower_pinch_setting", -1)
+        self.variable_set("forced_blower_setting", -1)
         # todo unforce o2 psol?
 
     def variables_set(self, pairs):

--- a/software/utils/debug/scripts/valve_calibration.py
+++ b/software/utils/debug/scripts/valve_calibration.py
@@ -26,16 +26,18 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
         print("Syntax:")
         print("  run valve_calibration <forced_valve_variable> <flow_variable>")
         print("    forced_valve_variable - one of these:")
-        print("         forced_exhale_valve_pos")
-        print("         forced_blower_valve_pos")
+        print("         forced_exhale_pinch_setting")
+        print("         forced_blower_pinch_setting")
+        print("         forced_psol_setting")
         print("    flow_variable - one of these:")
-        print("         flow_inhale")
-        print("         flow_exhale")
+        print("         air_influx_flow")
+        print("         oxygen_influx_flow")
+        print("         outflow_flow")
         return
 
-    # todo - for forced_psol_pos, we need blower off, and possibly other assumptions are not valid
+    # todo - for forced_psol_setting, we need blower off, and possibly other assumptions are not valid
 
-    valve_variable = cl[0]  # "forced_blower_valve_pos"
+    valve_variable = cl[0]  # "forced_blower_pinch_setting"
     flow_variable = cl[1]  # "flow_inhale"
 
     if valve_variable not in interface.variable_metadata.keys():
@@ -58,7 +60,7 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
     print("Shutting off fan and homing pinch valve")
     interface.variables_force_open()
     # todo why 0.75? not 1? what about the PSOL case?
-    interface.variable_set("forced_blower_power", 0.75)
+    interface.variable_set("forced_blower_setting", 0.75)
 
     input("Hit enter when ready to continue")
     print()
@@ -119,7 +121,7 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
                 break
             previous_flow = mean_flow
     results.insert(0, 0)
-    interface.variable_set("forced_blower_power", 0)
+    interface.variable_set("forced_blower_setting", 0)
 
     formatted_list = [f"{elem:.2f}" for elem in results]
     print(f"Results: {formatted_list}")


### PR DESCRIPTION
# Description

Issue: Running preset tests with the debug interface yields `Cannot set unknown variable forced_exhale_valve_pos` error message.
Recent refactoring changed some debugvar names, which are hardcoded in debug scripts. This simply changes the name of the variables to the new ones.

# General checklist:

- [ ] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [ ] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [ ] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [ ] All new content is linked, easily discoverable, does not require too many clicks
- [ ] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [ ] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [ ] I have tagged relevant reviewers

## Code checklist:

- [ ] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [ ] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [ ] I performed a clean build and verified that there were no warnings
- [ ] I ran our static analysis tools and verified there were no warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All source files have license headers
