### PR TITLE
Make "forced_[actuator]_setting" debugvar names less generic

### DIFF
--- a/software/controller/integration_tests/buzzer_test.h
+++ b/software/controller/integration_tests/buzzer_test.h
@@ -27,8 +27,8 @@ void RunTest() {
 
   bool buzzer_on{false};
 
-  PwmActuator buzzer{BuzzerChannel,    BuzzerFreq, HalApi::GetCpuFreq(), "buzzer_",
-                     " of the buzzer", BuzzerOff,  MaxBuzzerVolume};
+  PwmActuator buzzer{BuzzerChannel, BuzzerFreq, HalApi::GetCpuFreq(), "buzzer_", " of the buzzer",
+                     "volume",      BuzzerOff,  MaxBuzzerVolume};
 
   while (true) {
     if (buzzer_on) {

--- a/software/controller/integration_tests/eeprom_test.h
+++ b/software/controller/integration_tests/eeprom_test.h
@@ -99,8 +99,8 @@ void RunTest() {
     write_data[i] = Data;
   }
 
-  PwmActuator buzzer{BuzzerChannel,    BuzzerFreq, HalApi::GetCpuFreq(), "buzzer_",
-                     " of the buzzer", BuzzerOff,  MaxBuzzerVolume};
+  PwmActuator buzzer{BuzzerChannel, BuzzerFreq, HalApi::GetCpuFreq(), "buzzer_", " of the buzzer",
+                     "volume",      BuzzerOff,  MaxBuzzerVolume};
 
   buzzer.set(0.1f);
   eeprom.ReadBytes(Address, Length, &eeprom_before, nullptr);

--- a/software/controller/integration_tests/psol_test.h
+++ b/software/controller/integration_tests/psol_test.h
@@ -22,9 +22,14 @@ static constexpr float InitialStep{TEST_PARAM_3};
 
 void RunTest() {
   hal.Init();
-  PwmActuator psol{
-      PSolChannel, PSolFreq, HalApi::GetCpuFreq(), "psol_", " of the proportional solenoid",
-      PSolClosed,  PSolOpen};
+  PwmActuator psol{PSolChannel,
+                   PSolFreq,
+                   HalApi::GetCpuFreq(),
+                   "psol_",
+                   " of the proportional solenoid",
+                   "position",
+                   PSolClosed,
+                   PSolOpen};
 
   float psol_position = PSolMin;
   float step = InitialStep;

--- a/software/controller/lib/actuators/actuator_base.cpp
+++ b/software/controller/lib/actuators/actuator_base.cpp
@@ -15,27 +15,26 @@ limitations under the License.
 
 #include "actuator_base.h"
 
-Actuator::Actuator(const char *name, const char *help, float cal_0, float cal_1)
+Actuator::Actuator(const char *name, const char *help, const char *setting_name, float cal_0,
+                   float cal_1)
     : calibration_("cal", cal_0, cal_1, "", "Calibration table") {
-  calibration_.cal_table_.prepend_name(name);
-  calibration_.cal_table_.append_help(help);
-  forced_value_.prepend_name(name);
-  forced_value_.prepend_name("forced_");
-  forced_value_.append_help("Force the setting");
-  forced_value_.append_help(help);
-  forced_value_.append_help(
-      " to a certain value in [0,1].  Specify a value outside"
-      " this range to let the controller control it.");
+  InitDebugVars(name, help, setting_name);
 };
 
 Actuator::Actuator(const char *name, const char *help,
-                   std::array<float, ActuatorsCalSize> calibration)
+                   std::array<float, ActuatorsCalSize> calibration, const char *setting_name)
     : calibration_("cal", calibration, "", "Calibration table") {
+  InitDebugVars(name, help, setting_name);
+};
+
+void Actuator::InitDebugVars(const char *name, const char *help, const char *setting_name) {
   calibration_.cal_table_.prepend_name(name);
   calibration_.cal_table_.append_help(help);
+  forced_value_.prepend_name(setting_name);
   forced_value_.prepend_name(name);
   forced_value_.prepend_name("forced_");
-  forced_value_.append_help("Force the setting");
+  forced_value_.append_help("Force the ");
+  forced_value_.append_help(setting_name);
   forced_value_.append_help(help);
   forced_value_.append_help(
       " to a certain value in [0,1].  Specify a value outside"

--- a/software/controller/lib/actuators/actuator_base.h
+++ b/software/controller/lib/actuators/actuator_base.h
@@ -21,8 +21,10 @@ limitations under the License.
 
 class Actuator {
  public:
-  Actuator(const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f);
-  Actuator(const char *name, const char *help, std::array<float, ActuatorsCalSize> calibration);
+  Actuator(const char *name, const char *help, const char *setting_name = "setting",
+           float cal_0 = 0.0f, float cal_1 = 1.0f);
+  Actuator(const char *name, const char *help, std::array<float, ActuatorsCalSize> calibration,
+           const char *setting_name = "setting");
 
   // Link calibration table to nv params (if deemed necessary).
   // This function overwrites the existing (init?) calibration values with contents of nv_params
@@ -40,9 +42,8 @@ class Actuator {
 
  private:
   // Debug var that can be used from debug interface to force the actuator's setting
-  // TODO: make the "setting" debugvar name less generic, for example "position" for pinch valves,
-  // "power" for pwm, ...)
-  // Reminder: also update debug scripts (hardcoded debugvar names) when implementing this TODO.
-  Debug::Variable::Float forced_value_{"setting", Debug::Variable::Access::ReadWrite, -1.f,
-                                       "ratio"};
+  Debug::Variable::Float forced_value_{"", Debug::Variable::Access::ReadWrite, -1.f, "ratio"};
+
+  // Helper function to handle calibration and forced value debugvars during init
+  void InitDebugVars(const char *name, const char *help, const char *setting_name);
 };

--- a/software/controller/lib/actuators/pinch_valve.h
+++ b/software/controller/lib/actuators/pinch_valve.h
@@ -51,7 +51,7 @@ class PinchValve : public Actuator {
  public:
   // Create a new pinch valve using the specified stepper motor.
   PinchValve(const char *name, const char *help_supplement, int motor_index)
-      : Actuator(name, help_supplement), motor_index_(motor_index) {}
+      : Actuator(name, help_supplement, "position"), motor_index_(motor_index) {}
 
   // Initialize the pinch value absolute position.
   // This should be called at startup from the

--- a/software/controller/lib/actuators/pwm_actuator.h
+++ b/software/controller/lib/actuators/pwm_actuator.h
@@ -23,8 +23,10 @@ limitations under the License.
 class PwmActuator : public Actuator {
  public:
   PwmActuator(GPIO::PwmChannel channel, Frequency pwm_freq, Frequency cpu_frequency,
-              const char *name, const char *help, float cal_0 = 0.0f, float cal_1 = 1.0f)
-      : Actuator(name, help, cal_0, cal_1), pwm_pin_(channel, pwm_freq, cpu_frequency){};
+              const char *name, const char *help, const char *setting_name = "power",
+              float cal_0 = 0.0f, float cal_1 = 1.0f)
+      : Actuator(name, help, setting_name, cal_0, cal_1),
+        pwm_pin_(channel, pwm_freq, cpu_frequency){};
 
   void set(const float value) { pwm_pin_.set(Actuator::get_value(value)); }
 

--- a/software/controller/lib/core/actuators.cpp
+++ b/software/controller/lib/core/actuators.cpp
@@ -43,10 +43,10 @@ void Actuators::init(Frequency cpu_frequency, NVParams::Handler *nv_params,
   blower_.emplace(BlowerChannel, BlowerFreq, cpu_frequency, "blower_", " of the blower");
 
   psol_.emplace(PSolChannel, PSolFreq, cpu_frequency, "psol_", " of the proportional solenoid",
-                PSolClosed, PSolOpen);
+                "position", PSolClosed, PSolOpen);
 
-  buzzer.emplace(BuzzerChannel, BuzzerFreq, cpu_frequency, "buzzer_", "of the buzzer", BuzzerOff,
-                 MaxBuzzerVolume);
+  buzzer.emplace(BuzzerChannel, BuzzerFreq, cpu_frequency, "buzzer_", "of the buzzer", "volume",
+                 BuzzerOff, MaxBuzzerVolume);
 
   // In case init was called with nullptr, these fail silently
   blower_pinch_.LinkCalibration(nv_params, blower_pinch_cal_offset);

--- a/software/controller/lib/core/actuators.h
+++ b/software/controller/lib/core/actuators.h
@@ -42,8 +42,8 @@ struct ActuatorsState {
 class Actuators {
  public:
   Actuators(int blower_motor_index, int exhale_motor_index)
-      : blower_pinch_("blower_pinch_", " of the blower pinch valve", blower_motor_index),
-        exhale_pinch_("exhale_pinch_", " of the exhale pinch valve", exhale_motor_index){};
+      : blower_pinch_("blower_valve_", " of the blower pinch valve", blower_motor_index),
+        exhale_pinch_("exhale_valve_", " of the exhale pinch valve", exhale_motor_index){};
 
   // Returns true if the actuators are ready for action or false
   // if they aren't (for example pinch valves are homing).

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -225,9 +225,9 @@ class ControllerDebugInterface:
         # Ensure the ventilator fan is on, and disconnect the fan from the system
         # so it's not inflating the test lung.  Edwin's request is that the fan
         # doesn't have to spin up during these tests.
-        self.variable_set("forced_exhale_pinch_setting", 1)
-        self.variable_set("forced_blower_pinch_setting", 1)
-        self.variable_set("forced_blower_setting", 1)
+        self.variable_set("forced_exhale_valve_position", 1)
+        self.variable_set("forced_blower_valve_position", 1)
+        self.variable_set("forced_blower_power", 1)
         # todo force o2 psol open or closed?
 
     def variables_force_off(self):
@@ -235,9 +235,9 @@ class ControllerDebugInterface:
         # controller.  Note that you should unforce the blower power *after* setting the
         # forced_mode because if we unforced it while we were still in mode 0
         # (i.e. "ventilator off"), the fan would momentarily spin down.
-        self.variable_set("forced_exhale_pinch_setting", -1)
-        self.variable_set("forced_blower_pinch_setting", -1)
-        self.variable_set("forced_blower_setting", -1)
+        self.variable_set("forced_exhale_valve_position", -1)
+        self.variable_set("forced_blower_valve_position", -1)
+        self.variable_set("forced_blower_power", -1)
         # todo unforce o2 psol?
 
     def variables_set(self, pairs):

--- a/software/utils/debug/scripts/valve_calibration.py
+++ b/software/utils/debug/scripts/valve_calibration.py
@@ -26,9 +26,9 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
         print("Syntax:")
         print("  run valve_calibration <forced_valve_variable> <flow_variable>")
         print("    forced_valve_variable - one of these:")
-        print("         forced_exhale_pinch_setting")
-        print("         forced_blower_pinch_setting")
-        print("         forced_psol_setting")
+        print("         forced_exhale_valve_position")
+        print("         forced_blower_valve_position")
+        print("         forced_psol_position")
         print("    flow_variable - one of these:")
         print("         air_influx_flow")
         print("         oxygen_influx_flow")
@@ -37,8 +37,8 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
 
     # todo - for forced_psol_setting, we need blower off, and possibly other assumptions are not valid
 
-    valve_variable = cl[0]  # "forced_blower_pinch_setting"
-    flow_variable = cl[1]  # "flow_inhale"
+    valve_variable = cl[0]
+    flow_variable = cl[1]
 
     if valve_variable not in interface.variable_metadata.keys():
         print(f"Error: `{valve_variable}` is not a valid variable")
@@ -60,7 +60,7 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
     print("Shutting off fan and homing pinch valve")
     interface.variables_force_open()
     # todo why 0.75? not 1? what about the PSOL case?
-    interface.variable_set("forced_blower_setting", 0.75)
+    interface.variable_set("forced_blower_power", 0.75)
 
     input("Hit enter when ready to continue")
     print()
@@ -121,7 +121,7 @@ def valve_calibration(interface: ControllerDebugInterface, cmdline: str = ""):
                 break
             previous_flow = mean_flow
     results.insert(0, 0)
-    interface.variable_set("forced_blower_setting", 0)
+    interface.variable_set("forced_blower_power", 0)
 
     formatted_list = [f"{elem:.2f}" for elem in results]
     print(f"Results: {formatted_list}")


### PR DESCRIPTION
# Description

Addresses a TODO from #1210

# General checklist:

- [ ] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [ ] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [ ] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [ ] All new content is linked, easily discoverable, does not require too many clicks
- [ ] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [ ] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [ ] I have tagged relevant reviewers

## Code checklist:

- [ ] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [ ] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [ ] I performed a clean build and verified that there were no warnings
- [ ] I ran our static analysis tools and verified there were no warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All source files have license headers
