### PR TITLE
Abstract DMA channels and stop client module from manipulating DMA registers directly

### DIFF
--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -359,10 +359,10 @@ bool ADC::initialize(const Frequency cpu_frequency) {
   enable_peripheral_clock(PeripheralID::DMA1);
   DMA::ChannelControl dma{DMA::Base::DMA1, DMA::Channel::Chan1};
 
-  dma.Init(/*selection=*/0, &adc->adc[0].data, DMA::ChannelDir::PeripheralToMemory,
-           /*tx_interrupt=*/false, DMA::ChannelPriority::Low, /*circular=*/true,
-           DMA::TransferSize::HalfWord);
-  dma.SetupTx(oversample_buffer_, adc_sample_history_ * MaxAdcChannels);
+  dma.Initialize(/*selection=*/0, &adc->adc[0].data, DMA::ChannelDir::PeripheralToMemory,
+                 /*tx_interrupt=*/false, DMA::ChannelPriority::Low, /*circular=*/true,
+                 DMA::TransferSize::HalfWord);
+  dma.SetupTransfer(oversample_buffer_, adc_sample_history_ * MaxAdcChannels);
   dma.Enable();
 
   // Start the A/D converter (by setting bit 2 of the control register - per [RM] p457)

--- a/software/controller/lib/hal/dma.cpp
+++ b/software/controller/lib/hal/dma.cpp
@@ -211,8 +211,8 @@ void ChannelControl::SetupChannel(ChannelPriority prio, TransferSize size, Chann
   channel_reg->config.tx_complete_interrupt = tx_interrupt;
   channel_reg->config.memory_size = static_cast<uint32_t>(size) & 0b11;
   channel_reg->config.peripheral_size = static_cast<uint32_t>(size) & 0b11;
-  channel_reg->config.direction = static_cast<bool>(dir);
-  channel_reg->config.circular = static_cast<bool>(circular);
+  channel_reg->config.direction = static_cast<uint32_t>(dir) & 0b1;
+  channel_reg->config.circular = circular;
 
   // those settings are the same for all DMA channels we use.
   channel_reg->config.half_tx_interrupt = 0;

--- a/software/controller/lib/hal/dma.cpp
+++ b/software/controller/lib/hal/dma.cpp
@@ -185,7 +185,7 @@ void ChannelControl::Disable() {
   channel_reg->config.enable = 0;
 }
 
-uint32_t ChannelControl::Remaining() {
+size_t ChannelControl::Remaining() {
   auto *channel_reg = get_channel_reg(base_, channel_);
   return channel_reg->count;
 }

--- a/software/controller/lib/hal/dma.cpp
+++ b/software/controller/lib/hal/dma.cpp
@@ -16,45 +16,209 @@ limitations under the License.
 #include "dma.h"
 
 namespace DMA {
+struct DmaStruct {
+  union {
+    struct {
+      uint32_t gif1 : 1;   // global interrupt flag
+      uint32_t tcif1 : 1;  // transfer complete (TC) flag
+      uint32_t htif1 : 1;  // half transfer (HT) flag
+      uint32_t teif1 : 1;  // transfer error (TE) flag
+      uint32_t gif2 : 1;   // global interrupt flag
+      uint32_t tcif2 : 1;  // transfer complete (TC) flag
+      uint32_t htif2 : 1;  // half transfer (HT) flag
+      uint32_t teif2 : 1;  // transfer error (TE) flag
+      uint32_t gif3 : 1;   // global interrupt flag
+      uint32_t tcif3 : 1;  // transfer complete (TC) flag
+      uint32_t htif3 : 1;  // half transfer (HT) flag
+      uint32_t teif3 : 1;  // transfer error (TE) flag
+      uint32_t gif4 : 1;   // global interrupt flag
+      uint32_t tcif4 : 1;  // transfer complete (TC) flag
+      uint32_t htif4 : 1;  // half transfer (HT) flag
+      uint32_t teif4 : 1;  // transfer error (TE) flag
+      uint32_t gif5 : 1;   // global interrupt flag
+      uint32_t tcif5 : 1;  // transfer complete (TC) flag
+      uint32_t htif5 : 1;  // half transfer (HT) flag
+      uint32_t teif5 : 1;  // transfer error (TE) flag
+      uint32_t gif6 : 1;   // global interrupt flag
+      uint32_t tcif6 : 1;  // transfer complete (TC) flag
+      uint32_t htif6 : 1;  // half transfer (HT) flag
+      uint32_t teif6 : 1;  // transfer error (TE) flag
+      uint32_t gif7 : 1;   // global interrupt flag
+      uint32_t tcif7 : 1;  // transfer complete (TC) flag
+      uint32_t htif7 : 1;  // half transfer (HT) flag
+      uint32_t teif7 : 1;  // transfer error (TE) flag
+      uint32_t reserved : 4;
+    };
+    uint32_t full_reg;
+  } interrupt_status;  // Interrupt Status Register (DMA_ISR) [RM] 11.6.1 (pg
+  // 308)
 
-DmaReg* const get_register(const Base id) {
+  union {
+    struct {
+      uint32_t gif1 : 1;   // global interrupt flag
+      uint32_t tcif1 : 1;  // transfer complete (TC) flag
+      uint32_t htif1 : 1;  // half transfer (HT) flag
+      uint32_t teif1 : 1;  // transfer error (TE) flag
+      uint32_t gif2 : 1;   // global interrupt flag
+      uint32_t tcif2 : 1;  // transfer complete (TC) flag
+      uint32_t htif2 : 1;  // half transfer (HT) flag
+      uint32_t teif2 : 1;  // transfer error (TE) flag
+      uint32_t gif3 : 1;   // global interrupt flag
+      uint32_t tcif3 : 1;  // transfer complete (TC) flag
+      uint32_t htif3 : 1;  // half transfer (HT) flag
+      uint32_t teif3 : 1;  // transfer error (TE) flag
+      uint32_t gif4 : 1;   // global interrupt flag
+      uint32_t tcif4 : 1;  // transfer complete (TC) flag
+      uint32_t htif4 : 1;  // half transfer (HT) flag
+      uint32_t teif4 : 1;  // transfer error (TE) flag
+      uint32_t gif5 : 1;   // global interrupt flag
+      uint32_t tcif5 : 1;  // transfer complete (TC) flag
+      uint32_t htif5 : 1;  // half transfer (HT) flag
+      uint32_t teif5 : 1;  // transfer error (TE) flag
+      uint32_t gif6 : 1;   // global interrupt flag
+      uint32_t tcif6 : 1;  // transfer complete (TC) flag
+      uint32_t htif6 : 1;  // half transfer (HT) flag
+      uint32_t teif6 : 1;  // transfer error (TE) flag
+      uint32_t gif7 : 1;   // global interrupt flag
+      uint32_t tcif7 : 1;  // transfer complete (TC) flag
+      uint32_t htif7 : 1;  // half transfer (HT) flag
+      uint32_t teif7 : 1;  // transfer error (TE) flag
+      uint32_t reserved : 4;
+    };
+    uint32_t full_reg;
+  } interrupt_clear;  // Interrupt Flag Clear Register [RM] 11.6.2 (pg 311)
+  struct ChannelRegs {
+    struct {
+      uint32_t enable : 1;
+      uint32_t tx_complete_interrupt : 1;
+      uint32_t half_tx_interrupt : 1;
+      uint32_t tx_error_interrupt : 1;
+      uint32_t direction : 1;
+      uint32_t circular : 1;
+      uint32_t peripheral_increment : 1;
+      uint32_t memory_increment : 1;
+      uint32_t peripheral_size : 2;
+      uint32_t memory_size : 2;
+      uint32_t priority : 2;
+      uint32_t mem2mem : 1;
+      uint32_t reserved : 17;
+    } config;
+    uint32_t count;
+    volatile void *peripheral_address;
+    volatile void *memory_address;
+    uint32_t reserved;
+  } channel[7];
+  uint32_t reserved[5];
+  union {
+    struct {
+      uint32_t c1s : 4;
+      uint32_t c2s : 4;
+      uint32_t c3s : 4;
+      uint32_t c4s : 4;
+      uint32_t c5s : 4;
+      uint32_t c6s : 4;
+      uint32_t c7s : 4;
+      uint32_t reserved : 4;
+    };
+    uint32_t full_reg;
+  } channel_select;  // Channel Selection Register [RM] 11.6.7 (pg 317)
+};
+typedef volatile DmaStruct DmaReg;
+
+DmaReg *get_register(const Base id) {
   switch (id) {
     case Base::DMA1:
-      return reinterpret_cast<DmaReg*>(0x40020000);
+      return reinterpret_cast<DmaReg *>(0x40020000);
     case Base::DMA2:
-      return reinterpret_cast<DmaReg*>(0x40020400);
+      return reinterpret_cast<DmaReg *>(0x40020400);
   }
   // All cases covered above (and GCC checks this).
   __builtin_unreachable();
 }
 
-void SelectChannel(Base dma_id, Channel chan, int selection) {
-  DmaReg* dma = get_register(dma_id);
+volatile DmaReg::ChannelRegs *get_channel_reg(const Base id, const Channel channel) {
+  auto *base_reg = get_register(id);
+  return &base_reg->channel[static_cast<uint8_t>(channel)];
+}
 
+ChannelControl::ChannelControl(Base base, Channel channel) : base_(base), channel_(channel){};
+
+void ChannelControl::Init(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
+                          bool tx_interrupt, ChannelPriority prio, bool circular,
+                          TransferSize size) {
+  Disable();
+  SelectChannel(selection);
+  SetupChannel(prio, size, dir, tx_interrupt, circular);
+
+  auto *channel_reg = get_channel_reg(base_, channel_);
+  channel_reg->peripheral_address = peripheral;
+}
+
+bool ChannelControl::IntStatus(Interrupt interrupt) {
+  uint32_t x = static_cast<uint32_t>(interrupt);
+  x <<= 4 * static_cast<uint8_t>(channel_);  // 4 events per channel ([RM] 11.6.2)
+  auto *dma_reg = get_register(base_);
+  return (x & dma_reg->interrupt_status.full_reg) > 0;
+};
+
+void ChannelControl::ClearInt(Interrupt interrupt) {
+  uint32_t x = static_cast<uint32_t>(interrupt);
+  x <<= 4 * static_cast<uint8_t>(channel_);  // 4 events per channel ([RM] 11.6.2)
+  auto *dma_reg = get_register(base_);
+  dma_reg->interrupt_clear.full_reg = x;
+};
+
+void ChannelControl::SetupTx(volatile void *data, uint32_t length) {
+  auto *channel_reg = get_channel_reg(base_, channel_);
+  channel_reg->memory_address = data;
+  channel_reg->count = length;
+}
+
+void ChannelControl::Enable() {
+  auto *channel_reg = get_channel_reg(base_, channel_);
+  channel_reg->config.enable = 1;
+}
+
+void ChannelControl::Disable() {
+  auto *channel_reg = get_channel_reg(base_, channel_);
+  channel_reg->config.enable = 0;
+}
+
+uint32_t ChannelControl::Remaining() {
+  auto *channel_reg = get_channel_reg(base_, channel_);
+  return channel_reg->count;
+}
+
+void ChannelControl::SelectChannel(uint8_t selection) {
   selection &= 0x0F;
 
-  int x = 4 * static_cast<int>(chan);  // 4 bits per channel ([RM] 11.3.2)
+  int x = 4 * static_cast<int>(channel_);  // 4 bits per channel ([RM] 11.3.2)
 
-  uint32_t val = dma->channel_select.full_reg;
+  auto *dma_reg = get_register(base_);
+  uint32_t val = dma_reg->channel_select.full_reg;
+
   val &= ~(0xF << x);
   val |= selection << x;
-  dma->channel_select.full_reg = val;
+
+  dma_reg->channel_select.full_reg = val;
 }
 
-bool IntStatus(Base dma_id, Channel chan, Interrupt interrupt) {
-  DmaReg* dma = get_register(dma_id);
+void ChannelControl::SetupChannel(ChannelPriority prio, TransferSize size, ChannelDir dir,
+                                  bool tx_interrupt, bool circular) {
+  auto *channel_reg = get_channel_reg(base_, channel_);
+  channel_reg->config.priority = static_cast<uint32_t>(prio) & 0b11;
+  channel_reg->config.tx_complete_interrupt = tx_interrupt;
+  channel_reg->config.memory_size = static_cast<uint32_t>(size) & 0b11;
+  channel_reg->config.peripheral_size = static_cast<uint32_t>(size) & 0b11;
+  channel_reg->config.direction = static_cast<bool>(dir);
+  channel_reg->config.circular = static_cast<bool>(circular);
 
-  uint32_t x = static_cast<uint32_t>(interrupt);
-  x <<= 4 * static_cast<uint8_t>(chan);  // 4 events per channel ([RM] 11.6.2)
-  return (x & dma->interrupt_status.full_reg) > 0;
-}
-
-void ClearInt(Base dma_id, Channel chan, Interrupt interrupt) {
-  DmaReg* dma = get_register(dma_id);
-
-  uint32_t x = static_cast<uint32_t>(interrupt);
-  x <<= 4 * static_cast<uint8_t>(chan);  // 4 events per channel ([RM] 11.6.2)
-  dma->interrupt_clear.full_reg = x;
+  // those settings are the same for all DMA channels we use.
+  channel_reg->config.half_tx_interrupt = 0;
+  channel_reg->config.tx_error_interrupt = 1;
+  channel_reg->config.mem2mem = 0;
+  channel_reg->config.memory_increment = 1;
+  channel_reg->config.peripheral_increment = 0;
 }
 
 }  // namespace DMA

--- a/software/controller/lib/hal/dma.h
+++ b/software/controller/lib/hal/dma.h
@@ -17,116 +17,6 @@ limitations under the License.
 
 #include <cstdint>
 
-/// \TODO: move this to cpp
-struct DmaStruct {
-  union {
-    struct {
-      uint32_t gif1 : 1;   // global interrupt flag
-      uint32_t tcif1 : 1;  // transfer complete (TC) flag
-      uint32_t htif1 : 1;  // half transfer (HT) flag
-      uint32_t teif1 : 1;  // transfer error (TE) flag
-      uint32_t gif2 : 1;   // global interrupt flag
-      uint32_t tcif2 : 1;  // transfer complete (TC) flag
-      uint32_t htif2 : 1;  // half transfer (HT) flag
-      uint32_t teif2 : 1;  // transfer error (TE) flag
-      uint32_t gif3 : 1;   // global interrupt flag
-      uint32_t tcif3 : 1;  // transfer complete (TC) flag
-      uint32_t htif3 : 1;  // half transfer (HT) flag
-      uint32_t teif3 : 1;  // transfer error (TE) flag
-      uint32_t gif4 : 1;   // global interrupt flag
-      uint32_t tcif4 : 1;  // transfer complete (TC) flag
-      uint32_t htif4 : 1;  // half transfer (HT) flag
-      uint32_t teif4 : 1;  // transfer error (TE) flag
-      uint32_t gif5 : 1;   // global interrupt flag
-      uint32_t tcif5 : 1;  // transfer complete (TC) flag
-      uint32_t htif5 : 1;  // half transfer (HT) flag
-      uint32_t teif5 : 1;  // transfer error (TE) flag
-      uint32_t gif6 : 1;   // global interrupt flag
-      uint32_t tcif6 : 1;  // transfer complete (TC) flag
-      uint32_t htif6 : 1;  // half transfer (HT) flag
-      uint32_t teif6 : 1;  // transfer error (TE) flag
-      uint32_t gif7 : 1;   // global interrupt flag
-      uint32_t tcif7 : 1;  // transfer complete (TC) flag
-      uint32_t htif7 : 1;  // half transfer (HT) flag
-      uint32_t teif7 : 1;  // transfer error (TE) flag
-      uint32_t reserved : 4;
-    };
-    uint32_t full_reg;
-  } interrupt_status;  // Interrupt Status Register (DMA_ISR) [RM] 11.6.1 (pg
-  // 308)
-
-  union {
-    struct {
-      uint32_t gif1 : 1;   // global interrupt flag
-      uint32_t tcif1 : 1;  // transfer complete (TC) flag
-      uint32_t htif1 : 1;  // half transfer (HT) flag
-      uint32_t teif1 : 1;  // transfer error (TE) flag
-      uint32_t gif2 : 1;   // global interrupt flag
-      uint32_t tcif2 : 1;  // transfer complete (TC) flag
-      uint32_t htif2 : 1;  // half transfer (HT) flag
-      uint32_t teif2 : 1;  // transfer error (TE) flag
-      uint32_t gif3 : 1;   // global interrupt flag
-      uint32_t tcif3 : 1;  // transfer complete (TC) flag
-      uint32_t htif3 : 1;  // half transfer (HT) flag
-      uint32_t teif3 : 1;  // transfer error (TE) flag
-      uint32_t gif4 : 1;   // global interrupt flag
-      uint32_t tcif4 : 1;  // transfer complete (TC) flag
-      uint32_t htif4 : 1;  // half transfer (HT) flag
-      uint32_t teif4 : 1;  // transfer error (TE) flag
-      uint32_t gif5 : 1;   // global interrupt flag
-      uint32_t tcif5 : 1;  // transfer complete (TC) flag
-      uint32_t htif5 : 1;  // half transfer (HT) flag
-      uint32_t teif5 : 1;  // transfer error (TE) flag
-      uint32_t gif6 : 1;   // global interrupt flag
-      uint32_t tcif6 : 1;  // transfer complete (TC) flag
-      uint32_t htif6 : 1;  // half transfer (HT) flag
-      uint32_t teif6 : 1;  // transfer error (TE) flag
-      uint32_t gif7 : 1;   // global interrupt flag
-      uint32_t tcif7 : 1;  // transfer complete (TC) flag
-      uint32_t htif7 : 1;  // half transfer (HT) flag
-      uint32_t teif7 : 1;  // transfer error (TE) flag
-      uint32_t reserved : 4;
-    };
-    uint32_t full_reg;
-  } interrupt_clear;  // Interrupt Flag Clear Register [RM] 11.6.2 (pg 311)
-  struct ChannelRegs {
-    struct {
-      uint32_t enable : 1;
-      uint32_t tx_complete_interrupt : 1;
-      uint32_t half_tx_interrupt : 1;
-      uint32_t tx_error_interrupt : 1;
-      uint32_t direction : 1;
-      uint32_t circular : 1;
-      uint32_t peripheral_increment : 1;
-      uint32_t memory_increment : 1;
-      uint32_t peripheral_size : 2;
-      uint32_t memory_size : 2;
-      uint32_t priority : 2;
-      uint32_t mem2mem : 1;
-      uint32_t reserved : 17;
-    } config;
-    uint32_t count;
-    volatile void *peripheral_address;
-    volatile void *memory_address;
-    uint32_t reserved;
-  } channel[7];
-  uint32_t reserved[5];
-  union {
-    struct {
-      uint32_t c1s : 4;
-      uint32_t c2s : 4;
-      uint32_t c3s : 4;
-      uint32_t c4s : 4;
-      uint32_t c5s : 4;
-      uint32_t c6s : 4;
-      uint32_t c7s : 4;
-      uint32_t reserved : 4;
-    };
-    uint32_t full_reg;
-  } channel_select;  // Channel Selection Register [RM] 11.6.7 (pg 317)
-};
-typedef volatile DmaStruct DmaReg;
-
 namespace DMA {
 
 enum class Base {
@@ -148,15 +38,28 @@ enum class Channel : uint8_t {
 enum class ChannelDir { PeripheralToMemory = 0, MemoryToPeripheral = 1 };
 enum class TransferSize { Byte = 0, HalfWord = 1, Word = 2 };
 enum class Interrupt { Global = 1, TransferComplete = 2, HalfTransfer = 4, TransferError = 8 };
+enum class ChannelPriority { Low = 0, Medium = 1, High = 2, Highest = 3 };
 
-DmaReg *const get_register(Base id);
+class ChannelControl {
+ public:
+  ChannelControl(Base base, Channel channel);
+  void Init(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
+            bool tx_interrupt = false, ChannelPriority prio = ChannelPriority::Medium,
+            bool circular = false, TransferSize size = TransferSize::Byte);
+  bool IntStatus(Interrupt interrupt);
+  void ClearInt(Interrupt interrupt);
+  void SetupTx(volatile void *data, uint32_t length);
+  void Enable();
+  void Disable();
+  uint32_t Remaining();
 
-void SelectChannel(Base dma_id, Channel chan, int selection);
+ private:
+  void SelectChannel(uint8_t selection);
+  void SetupChannel(ChannelPriority prio, TransferSize size, ChannelDir dir, bool tx_interrupt,
+                    bool circular);
 
-// Detect a DMA Interrupt
-bool IntStatus(Base dma_id, Channel chan, Interrupt interrupt);
-
-// Clear a DMA Interrupt
-void ClearInt(Base dma_id, Channel chan, Interrupt interrupt);
+  Base base_;
+  Channel channel_;
+};
 
 }  // namespace DMA

--- a/software/controller/lib/hal/dma.h
+++ b/software/controller/lib/hal/dma.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include <cstddef>  // used for size_t definition
 #include <cstdint>
 
 namespace DMA {
@@ -51,7 +52,7 @@ class ChannelControl {
   void SetupTransfer(volatile void *data, uint32_t length);
   void Enable();
   void Disable();
-  uint32_t Remaining();
+  size_t Remaining();
 
  private:
   void SelectChannel(uint8_t selection);

--- a/software/controller/lib/hal/dma.h
+++ b/software/controller/lib/hal/dma.h
@@ -43,12 +43,12 @@ enum class ChannelPriority { Low = 0, Medium = 1, High = 2, Highest = 3 };
 class ChannelControl {
  public:
   ChannelControl(Base base, Channel channel);
-  void Init(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
-            bool tx_interrupt = false, ChannelPriority prio = ChannelPriority::Medium,
-            bool circular = false, TransferSize size = TransferSize::Byte);
-  bool IntStatus(Interrupt interrupt);
-  void ClearInt(Interrupt interrupt);
-  void SetupTx(volatile void *data, uint32_t length);
+  void Initialize(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
+                  bool tx_interrupt = false, ChannelPriority prio = ChannelPriority::Medium,
+                  bool circular = false, TransferSize size = TransferSize::Byte);
+  bool InterruptStatus(Interrupt interrupt);
+  void ClearInterrupt(Interrupt interrupt);
+  void SetupTransfer(volatile void *data, uint32_t length);
   void Enable();
   void Disable();
   uint32_t Remaining();

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -242,6 +242,8 @@ void Timer15ISR() {
 static UART rpi_uart(Uart3Base);
 static UART debug_uart(Uart2Base);
 #if defined(UART_VIA_DMA)
+// The character used for char_match is entirely arbitrary and will need to be a constant from
+// common, to allow using it in GUI as well for framing (once we get framing)
 static UartDma dma_uart(Uart3Base, 0xE2);
 #endif
 // The UART that talks to the rPi uses the following pins:

--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -253,7 +253,6 @@ void Channel::I2CErrorHandler() {
 
 void STM32Channel::Init(I2CReg *i2c, DMA::Base dma, Speed speed) {
   i2c_ = i2c;
-  dma_ = dma;
 
   // Disable I²C peripheral
   i2c_->control_reg1.enable = 0;
@@ -339,45 +338,18 @@ void STM32Channel::SetupDMAChannels(const DMA::Base dma) {
 
   for (auto &map : DmaMap) {
     if (dma == map.dma_base && i2c_ == map.i2c_base) {
-      auto *dma_register = DMA::get_register(dma);
-      dma_ = dma;
-      tx_channel_ = &dma_register->channel[static_cast<uint8_t>(map.tx_channel_id)];
-      rx_channel_ = &dma_register->channel[static_cast<uint8_t>(map.rx_channel_id)];
+      tx_channel_control_.emplace(dma, map.tx_channel_id);
+      rx_channel_control_.emplace(dma, map.rx_channel_id);
 
-      // Tell the STM32 that those two DMA channels are used for I2C
-      DMA::SelectChannel(dma, map.rx_channel_id, map.request_number);
-      DMA::SelectChannel(dma, map.tx_channel_id, map.request_number);
-
-      // configure both DMA channels to handle I²C transfers
-      ConfigureDMAChannel(rx_channel_, ExchangeDirection::Read);
-      ConfigureDMAChannel(tx_channel_, ExchangeDirection::Write);
-
+      tx_channel_control_->Init(map.request_number, &(i2c_->tx_data),
+                                DMA::ChannelDir::MemoryToPeripheral, 1);
+      rx_channel_control_->Init(map.request_number, &(i2c_->rx_data),
+                                DMA::ChannelDir::PeripheralToMemory, 1);
       dma_enable_ = true;
       i2c_->control_reg1.dma_rx = 1;
       i2c_->control_reg1.dma_tx = 1;
       break;
     }
-  }
-}
-
-void I2C::STM32Channel::ConfigureDMAChannel(volatile DmaReg::ChannelRegs *channel,
-                                            ExchangeDirection direction) {
-  channel->config.priority = 0b01;            // medium priority
-  channel->config.tx_error_interrupt = 1;     // interrupt on error
-  channel->config.half_tx_interrupt = 0;      // no half-transfer interrupt
-  channel->config.tx_complete_interrupt = 1;  // interrupt on DMA complete
-  channel->config.mem2mem = 0;                // memory-to-memory mode disabled
-  channel->config.memory_size = static_cast<uint8_t>(DMA::TransferSize::Byte);
-  channel->config.peripheral_size = static_cast<uint8_t>(DMA::TransferSize::Byte);
-  channel->config.memory_increment = 1;      // increment dest address
-  channel->config.peripheral_increment = 0;  // don't increment source address
-  channel->config.circular = 0;
-  if (direction == ExchangeDirection::Read) {
-    channel->config.direction = static_cast<uint8_t>(DMA::ChannelDir::PeripheralToMemory);
-    channel->peripheral_address = &(i2c_->rx_data);
-  } else {
-    channel->config.direction = static_cast<uint8_t>(DMA::ChannelDir::MemoryToPeripheral);
-    channel->peripheral_address = &(i2c_->tx_data);
   }
 }
 
@@ -387,23 +359,24 @@ void STM32Channel::SetupDMATransfer() {
   }
   // to be on the safe size, disable both channels in case they weren't
   // (likely when this is called as a "retry after error")
-  rx_channel_->config.enable = 0;
-  tx_channel_->config.enable = 0;
+  rx_channel_control_->Disable();
+  tx_channel_control_->Disable();
 
-  volatile DmaReg::ChannelRegs *channel{nullptr};
+  DMA::ChannelControl *channel{nullptr};
   if (last_request_.direction == ExchangeDirection::Read) {
-    channel = rx_channel_;
+    channel = &(rx_channel_control_.value());
   } else {
-    channel = tx_channel_;
+    channel = &(tx_channel_control_.value());
   }
 
-  channel->memory_address = next_data_;
-
+  uint16_t transfer_size{0};
   if (remaining_size_ <= 255) {
-    channel->count = remaining_size_;
+    transfer_size = remaining_size_;
   } else {
-    channel->count = 255;
+    transfer_size = 255;
   }
+
+  channel->SetupTx(next_data_, transfer_size);
 
   // when using DMA, we need to use autoend, otherwise the STOP condition
   // which we issue at the end of the DMA transfer (which means the last byte
@@ -412,14 +385,21 @@ void STM32Channel::SetupDMATransfer() {
   // enabled to send Stop at the end of the I2C transfer were inconclusive.
   i2c_->control2.autoend = 1;
 
-  channel->config.enable = 1;
+  channel->Enable();
 }
 
-void STM32Channel::DMAIntHandler(DMA::Channel chan) {
+void STM32Channel::DMAIntHandler(ExchangeDirection direction) {
   if (!dma_enable_ || !transfer_in_progress_) return;
-  auto *dma_register = DMA::get_register(dma_);
-  dma_register->channel[static_cast<uint8_t>(chan)].config.enable = 0;
-  if (DMA::IntStatus(dma_, chan, DMA::Interrupt::TransferComplete)) {
+
+  DMA::ChannelControl *channel{nullptr};
+  if (last_request_.direction == ExchangeDirection::Read) {
+    channel = &(rx_channel_control_.value());
+  } else {
+    channel = &(tx_channel_control_.value());
+  }
+
+  channel->Disable();
+  if (channel->IntStatus(DMA::Interrupt::TransferComplete)) {
     if (remaining_size_ > 255) {
       // decrement remaining size by 255 (the size of the DMA transfer)
       remaining_size_ = static_cast<uint16_t>(remaining_size_ - 255);
@@ -428,7 +408,7 @@ void STM32Channel::DMAIntHandler(DMA::Channel chan) {
       remaining_size_ = 0;
       EndTransfer();
     }
-  } else if (DMA::IntStatus(dma_, chan, DMA::Interrupt::TransferError)) {
+  } else if (channel->IntStatus(DMA::Interrupt::TransferError)) {
     // we are dealing with an error --> reset transfer (up to MaxRetries
     // times)
     if (--error_retry_ > 0) {
@@ -440,7 +420,7 @@ void STM32Channel::DMAIntHandler(DMA::Channel chan) {
     }
   }
   // clear all interrupts and (re-)start the current or next transfer
-  DMA::ClearInt(dma_, chan, DMA::Interrupt::Global);
+  channel->ClearInt(DMA::Interrupt::Global);
   StartTransfer();
 }
 

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -298,8 +298,8 @@ class STM32Channel : public Channel {
  private:
   I2CReg *i2c_{nullptr};
 
-  std::optional<DMA::ChannelControl> rx_channel_control_{std::nullopt};
-  std::optional<DMA::ChannelControl> tx_channel_control_{std::nullopt};
+  std::optional<DMA::ChannelControl> rx_dma_{std::nullopt};
+  std::optional<DMA::ChannelControl> tx_dma_{std::nullopt};
 
   void SetupI2CTransfer() override;  // configure a transfer
   void ReceiveByte() override { *next_data_ = static_cast<uint8_t>(i2c_->rx_data); };

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -293,14 +293,13 @@ class STM32Channel : public Channel {
   // handled in software.
   void Init(I2CReg *i2c, DMA::Base dma, Speed speed);
   // Interrupt handlers for DMA, which only makes sense on the STM32
-  void DMAIntHandler(DMA::Channel chan);
+  void DMAIntHandler(ExchangeDirection direction);
 
  private:
   I2CReg *i2c_{nullptr};
-  DMA::Base dma_;
-  /// \TODO: anyway to avoid keeping regiters here directly? Improve DMA abstraction?
-  volatile DmaReg::ChannelRegs *rx_channel_{nullptr};
-  volatile DmaReg::ChannelRegs *tx_channel_{nullptr};
+
+  std::optional<DMA::ChannelControl> rx_channel_control_{std::nullopt};
+  std::optional<DMA::ChannelControl> tx_channel_control_{std::nullopt};
 
   void SetupI2CTransfer() override;  // configure a transfer
   void ReceiveByte() override { *next_data_ = static_cast<uint8_t>(i2c_->rx_data); };
@@ -320,7 +319,6 @@ class STM32Channel : public Channel {
   void ClearErrors() override { i2c_->interrupt_clear = 0x720; }
 
   void SetupDMAChannels(DMA::Base dma);
-  void ConfigureDMAChannel(volatile DmaReg::ChannelRegs *channel, ExchangeDirection direction);
   void SetupDMATransfer();
 };
 

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -25,7 +25,6 @@ std::optional<GPIO::DigitalOutputPin> StepMotor::chip_select_{std::nullopt};
 #include <cstring>
 
 #include "clocks.h"
-#include "dma.h"
 #include "interrupts.h"
 #include "spi.h"
 #include "system_timer.h"
@@ -33,6 +32,8 @@ std::optional<GPIO::DigitalOutputPin> StepMotor::chip_select_{std::nullopt};
 // Static data members
 uint8_t StepMotor::dma_buff_[StepMotor::MaxMotors];
 StepCommState StepMotor::coms_state_ = StepCommState::Idle;
+std::optional<DMA::ChannelControl> StepMotor::rx_dma_{std::nullopt};
+std::optional<DMA::ChannelControl> StepMotor::tx_dma_{std::nullopt};
 
 // This array holds the length of each parameter in units of
 // bytes, rounded up to the nearest byte.  This info is based
@@ -218,43 +219,13 @@ void StepMotor::OneTimeInit() {
 
   // DMA2 channels 3 and 4 can be used to handle rx and tx interrupts from
   // SPI1 respectively.
-  DMA::SelectChannel(DMA::Base::DMA2, DMA::Channel::Chan3, 4);
-  DMA::SelectChannel(DMA::Base::DMA2, DMA::Channel::Chan4, 4);
+  rx_dma_.emplace(DMA::Base::DMA2, DMA::Channel::Chan3);
+  tx_dma_.emplace(DMA::Base::DMA2, DMA::Channel::Chan4);
 
-  // The two DMA channels move data to/from the SPI data register.
-  DmaReg *dma = DMA::get_register(DMA::Base::DMA2);
-
-  // Configure the DMA channels, but don't enable them yet
-  /// \TODO: (subtly) repetitive blocks for each channel - factor this out
-  int c3 = static_cast<int>(DMA::Channel::Chan3);
-  dma->channel[c3].peripheral_address = &spi->data;
-  dma->channel[c3].config.enable = 0;
-  dma->channel[c3].config.tx_complete_interrupt = 1;
-  dma->channel[c3].config.half_tx_interrupt = 0;
-  dma->channel[c3].config.tx_error_interrupt = 0;
-  dma->channel[c3].config.direction = static_cast<uint32_t>(DMA::ChannelDir::PeripheralToMemory);
-  dma->channel[c3].config.circular = 0;
-  dma->channel[c3].config.peripheral_increment = 0;
-  dma->channel[c3].config.memory_increment = 1;
-  dma->channel[c3].config.peripheral_size = 0;
-  dma->channel[c3].config.memory_size = 0;
-  dma->channel[c3].config.priority = 0;
-  dma->channel[c3].config.mem2mem = 0;
-
-  int c4 = static_cast<int>(DMA::Channel::Chan4);
-  dma->channel[c4].peripheral_address = &spi->data;
-  dma->channel[c4].config.enable = 0;
-  dma->channel[c4].config.tx_complete_interrupt = 0;
-  dma->channel[c4].config.half_tx_interrupt = 0;
-  dma->channel[c4].config.tx_error_interrupt = 0;
-  dma->channel[c4].config.direction = static_cast<uint32_t>(DMA::ChannelDir::MemoryToPeripheral);
-  dma->channel[c4].config.circular = 0;
-  dma->channel[c4].config.peripheral_increment = 0;
-  dma->channel[c4].config.memory_increment = 1;
-  dma->channel[c4].config.peripheral_size = 0;
-  dma->channel[c4].config.memory_size = 0;
-  dma->channel[c4].config.priority = 0;
-  dma->channel[c4].config.mem2mem = 0;
+  rx_dma_->Init(4, &spi->data, DMA::ChannelDir::PeripheralToMemory, /*tx_interrupt=*/true,
+                DMA::ChannelPriority::Low);
+  tx_dma_->Init(4, &spi->data, DMA::ChannelDir::MemoryToPeripheral, /*tx_interrupt=*/false,
+                DMA::ChannelPriority::Low);
 
   Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel3, IntPriority::Standard);
 
@@ -764,32 +735,26 @@ void StepMotor::UpdateComState() {
   // of motor driver chips.  Set up my DMA to
   // send it out.
   //////////////////////////////////////////////
-  int c3 = static_cast<int>(DMA::Channel::Chan3);
-  int c4 = static_cast<int>(DMA::Channel::Chan4);
+  rx_dma_->Disable();
+  tx_dma_->Disable();
 
-  DmaReg *dma = DMA::get_register(DMA::Base::DMA2);
-  dma->channel[c3].config.enable = 0;
-  dma->channel[c4].config.enable = 0;
-
-  dma->channel[c3].count = total_motors_;
-  dma->channel[c4].count = total_motors_;
-  dma->channel[c3].memory_address = dma_buff_;
-  dma->channel[c4].memory_address = dma_buff_;
+  rx_dma_->SetupTx(dma_buff_, total_motors_);
+  tx_dma_->SetupTx(dma_buff_, total_motors_);
 
   // NOTE - CS has to be high for at least 650ns between bytes.
   // I don't bother timing this because I've found that in
   // practice it takes longer than that to handle the interrupt
   chip_select_->clear();
 
-  dma->channel[c3].config.enable = 1;
-  dma->channel[c4].config.enable = 1;
+  rx_dma_->Enable();
+  tx_dma_->Enable();
 }
 
 void StepMotor::DmaISR() {
   chip_select_->set();
 
   // Clear the DMA interrupt
-  DMA::ClearInt(DMA::Base::DMA2, DMA::Channel::Chan3, DMA::Interrupt::Global);
+  rx_dma_->ClearInt(DMA::Interrupt::Global);
 
   UpdateComState();
 }
@@ -803,17 +768,11 @@ void StepMotor::StartQueuedCommands() {
 
 // This is used to send a command to the stepper chips during startup.
 void StepMotor::SendInitCmd(uint8_t *buff, int len) {
-  int c3 = static_cast<int>(DMA::Channel::Chan3);
-  int c4 = static_cast<int>(DMA::Channel::Chan4);
+  rx_dma_->Disable();
+  tx_dma_->Disable();
 
-  DmaReg *dma = DMA::get_register(DMA::Base::DMA2);
-  dma->channel[c3].config.enable = 0;
-  dma->channel[c4].config.enable = 0;
-
-  dma->channel[c3].count = len;
-  dma->channel[c4].count = len;
-  dma->channel[c3].memory_address = buff;
-  dma->channel[c4].memory_address = buff;
+  rx_dma_->SetupTx(buff, len);
+  tx_dma_->SetupTx(buff, len);
 
   chip_select_->clear();
 
@@ -824,14 +783,15 @@ void StepMotor::SendInitCmd(uint8_t *buff, int len) {
   // to add the additional logic to it to handle these
   // unusual startup commands.
   BlockInterrupts block;
-  dma->channel[c3].config.enable = 1;
-  dma->channel[c4].config.enable = 1;
-  while (!dma->interrupt_status.tcif3) {
+  rx_dma_->Enable();
+  tx_dma_->Enable();
+
+  while (!rx_dma_->IntStatus(DMA::Interrupt::TransferComplete)) {
   }
 
   // Clear the interrupt flag so I won't get an interrupt
   // as soon as I re-enable them
-  DMA::ClearInt(DMA::Base::DMA2, DMA::Channel::Chan3, DMA::Interrupt::Global);
+  rx_dma_->ClearInt(DMA::Interrupt::Global);
 
   // Raise the chip select line and wait 1 microsecond.
   // The minimum time the CS needs to be high is just under

--- a/software/controller/lib/hal/stepper.h
+++ b/software/controller/lib/hal/stepper.h
@@ -49,6 +49,7 @@ limitations under the License.
 #include <cstdint>
 #include <optional>
 
+#include "dma.h"
 #include "gpio.h"
 
 // These are the simple opcodes for the stepper driver.
@@ -296,6 +297,8 @@ class StepMotor {
  private:
   static StepMotor motor_[MaxMotors];
   static uint8_t dma_buff_[MaxMotors];
+  static std::optional<DMA::ChannelControl> rx_dma_;
+  static std::optional<DMA::ChannelControl> tx_dma_;
   static uint8_t param_len_[32];
   static StepCommState coms_state_;
 

--- a/software/controller/lib/hal/uart_dma.cpp
+++ b/software/controller/lib/hal/uart_dma.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,11 +30,9 @@ limitations under the License.
 
 // This driver also provides Character Match callback on match_char reception.
 
-extern UartDma uart_dma;
-
-// Performs UART3 initialization
-void UartDma::initialize(const Frequency cpu_frequency, const Frequency baud) {
-  baud_ = baud;
+// Performs UART initialization
+void UartDma::initialize(const Frequency cpu_frequency, const Frequency baud, DMA::Base dma,
+                         DMA::Channel tx_channel, DMA::Channel rx_channel) {
   // Set baud rate register
   uart_->baudrate = static_cast<uint32_t>(cpu_frequency / baud);
 
@@ -58,31 +56,12 @@ void UartDma::initialize(const Frequency cpu_frequency, const Frequency baud) {
 
   // TODO enable parity checking?
 
-  auto &rx_dma_config = dma_->channel[rx_channel_].config;
-  rx_dma_config.priority = 0b11;            // high priority
-  rx_dma_config.tx_error_interrupt = 1;     // interrupt on error
-  rx_dma_config.half_tx_interrupt = 0;      // no half-transfer interrupt
-  rx_dma_config.tx_complete_interrupt = 1;  // interrupt on DMA complete
-  rx_dma_config.mem2mem = 0;                // memory-to-memory mode disabled
-  rx_dma_config.memory_size = static_cast<uint32_t>(DMA::TransferSize::Byte);
-  rx_dma_config.peripheral_size = static_cast<uint32_t>(DMA::TransferSize::Byte);
-  rx_dma_config.memory_increment = 1;      // increment destination (memory)
-  rx_dma_config.peripheral_increment = 0;  // don't increment source (peripheral) address
-  rx_dma_config.circular = 0;              // not circular
-  rx_dma_config.direction = static_cast<uint32_t>(DMA::ChannelDir::PeripheralToMemory);
-
-  auto &tx_dma_config = dma_->channel[tx_channel_].config;
-  tx_dma_config.priority = 0b11;            // high priority
-  tx_dma_config.tx_error_interrupt = 1;     // interrupt on error
-  tx_dma_config.half_tx_interrupt = 0;      // no half-transfer interrupt
-  tx_dma_config.tx_complete_interrupt = 1;  // DMA complete interrupt enabled
-  tx_dma_config.mem2mem = 0;                // memory-to-memory mode disabled
-  tx_dma_config.memory_size = static_cast<uint32_t>(DMA::TransferSize::Byte);
-  tx_dma_config.peripheral_size = static_cast<uint32_t>(DMA::TransferSize::Byte);
-  tx_dma_config.memory_increment = 1;      // increment source (memory) address
-  tx_dma_config.peripheral_increment = 0;  // don't increment dest (peripheral) address
-  tx_dma_config.circular = 0;              // not circular
-  tx_dma_config.direction = static_cast<uint32_t>(DMA::ChannelDir::MemoryToPeripheral);
+  rx_dma_.emplace(dma, rx_channel);
+  tx_dma_.emplace(dma, tx_channel);
+  rx_dma_->Init(2, &(uart_->rx_data), DMA::ChannelDir::PeripheralToMemory, 1,
+                DMA::ChannelPriority::Highest);
+  tx_dma_->Init(2, &(uart_->tx_data), DMA::ChannelDir::MemoryToPeripheral, 1,
+                DMA::ChannelPriority::Highest);
 }
 
 // Sets up an interrupt on matching char incoming form UART3
@@ -107,21 +86,17 @@ bool UartDma::rx_in_progress() const {
 // Returns false if DMA transmission is in progress, does not
 // interrupt previous transmission.
 // Returns true if no transmission is in progress
-bool UartDma::start_tx(uint8_t *buf, uint32_t length, TxListener *txl) {
+bool UartDma::start_tx(uint8_t *buffer, uint32_t length, TxListener *txl) {
   if (tx_in_progress()) {
     return false;
   }
 
   tx_listener_ = txl;
 
-  auto &tx_dma = dma_->channel[tx_channel_];
-  tx_dma.config.enable = 0;                       // Disable channel before config
-  tx_dma.peripheral_address = &(uart_->tx_data);  // data sink
-  tx_dma.memory_address = const_cast<void *>(reinterpret_cast<const void *>(buf));  // data source
-  tx_dma.count = length & 0x0000FFFF;                                               // data length
-  tx_dma.config.enable = 1;                                                         // go!
-
+  tx_dma_->Disable();  // Disable channel before config
+  tx_dma_->SetupTx(buffer, length & 0x0000FFFF);
   tx_in_progress_ = true;
+  tx_dma_->Enable();
 
   return true;
 }
@@ -129,7 +104,7 @@ bool UartDma::start_tx(uint8_t *buf, uint32_t length, TxListener *txl) {
 void UartDma::stop_tx() {
   if (tx_in_progress()) {
     // Disable DMA channel
-    dma_->channel[tx_channel_].config.enable = 0;
+    tx_dma_->Disable();
     // TODO thread safety
     tx_in_progress_ = false;
   }
@@ -156,7 +131,7 @@ void UartDma::stop_tx() {
 // Returns false if reception is in progress, new reception is not setup.
 // Returns true if no reception is in progress and new reception was setup.
 
-bool UartDma::start_rx(uint8_t *buf, uint32_t length, RxListener *rxl) {
+bool UartDma::start_rx(uint8_t *buffer, uint32_t length, RxListener *rxl) {
   // UART3 reception happens on DMA1 channel 3
   if (rx_in_progress()) {
     return false;
@@ -164,30 +139,25 @@ bool UartDma::start_rx(uint8_t *buf, uint32_t length, RxListener *rxl) {
 
   rx_listener_ = rxl;
 
-  auto &rx_dma = dma_->channel[rx_channel_];
-
-  rx_dma.config.enable = 0;  // don't enable yet
-
-  rx_dma.peripheral_address = &(uart_->rx_data);                                    // data source
-  rx_dma.memory_address = const_cast<void *>(reinterpret_cast<const void *>(buf));  // data sink
-  rx_dma.count = length;                                                            // data length
+  rx_dma_->Disable();  // Disable channel before config
+  rx_dma_->SetupTx(buffer, length & 0x0000FFFF);
 
   uart_->interrupt_clear.bitfield.rx_timeout_clear = 1;  // Clear rx timeout flag
   uart_->request.bitfield.flush_rx = 1;                  // Clear RXNE flag
 
-  rx_dma.config.enable = 1;  // go!
-
   rx_in_progress_ = true;
+
+  rx_dma_->Enable();
 
   return true;
 }
 
-uint32_t UartDma::rx_bytes_left() { return dma_->channel[2].count; }
+uint32_t UartDma::rx_bytes_left() { return tx_dma_->Remaining(); }
 
 void UartDma::stop_rx() {
   if (rx_in_progress()) {
     uart_->control_reg1.bitfield.rx_timeout_interrupt = 0;  // Disable receive timeout interrupt
-    dma_->channel[rx_channel_].config.enable = 0;           // Disable DMA channel
+    rx_dma_->Disable();
     // TODO thread safety
     rx_in_progress_ = false;
   }
@@ -246,7 +216,7 @@ void UartDma::UART_interrupt_handler() {
 // Calls on_tx_error and on_tx_complete functions of the tx_listener_
 void UartDma::DMA_tx_interrupt_handler() {
   stop_tx();
-  if (dma_->interrupt_status.teif2) {
+  if (tx_dma_->IntStatus(DMA::Interrupt::TransferError)) {
     if (tx_listener_) {
       tx_listener_->on_tx_error();
     }
@@ -255,13 +225,14 @@ void UartDma::DMA_tx_interrupt_handler() {
       tx_listener_->on_tx_complete();
     }
   }
+  tx_dma_->ClearInt(DMA::Interrupt::Global);
 }
 
 // ISR handler for the DMA peripheral responsible for reception.
 // Calls on_rx_error and on_rx_complete functions of the rx_listener_
 void UartDma::DMA_rx_interrupt_handler() {
   stop_rx();
-  if (dma_->interrupt_status.teif3) {
+  if (rx_dma_->IntStatus(DMA::Interrupt::TransferError)) {
     if (rx_listener_) {
       rx_listener_->on_rx_error(RxError::DMA);
     }
@@ -270,21 +241,7 @@ void UartDma::DMA_rx_interrupt_handler() {
       rx_listener_->on_rx_complete();
     }
   }
+  rx_dma_->ClearInt(DMA::Interrupt::Global);
 }
-
-// TODO: These are declared in hal_stm32.cpp but implemented here, clean this up!
-
-void DMA1Channel2ISR() {
-  uart_dma.DMA_tx_interrupt_handler();
-  DMA::get_register(DMA::Base::DMA1)->interrupt_clear.gif2 = 1;  // clear all channel 3 flags
-}
-
-void DMA1Channel3ISR() {
-  uart_dma.DMA_rx_interrupt_handler();
-  DMA::get_register(DMA::Base::DMA1)->interrupt_clear.gif3 = 1;  // clear all channel 2 flags
-}
-
-// This is the interrupt handler for the UART.
-void Uart3ISR() { uart_dma.UART_interrupt_handler(); }
 
 #endif

--- a/software/controller/lib/hal/uart_dma.h
+++ b/software/controller/lib/hal/uart_dma.h
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,37 +20,18 @@ limitations under the License.
 #include "serial_listeners.h"
 #include "uart.h"
 
-class DmaCtrl {
- public:
-  explicit DmaCtrl(DmaReg *const dma) : dma_(dma) {}
-  void init() {
-    // UART3 reception happens on DMA1 channel 3
-    dma_->channel_select.c3s = 0b0010;
-    // UART3 transmission happens on DMA1 channel 2
-    dma_->channel_select.c2s = 0b0010;
-  }
-
- private:
-  DmaReg *const dma_{nullptr};
-};
-
 class UartDma {
  public:
 #if !defined(BARE_STM32)
   UartDma() = default;
 #endif
-  UartDma(UartReg *const uart, DmaReg *const dma, uint8_t tx_channel, uint8_t rx_channel,
-          char match_char)
-      : uart_(uart),
-        dma_(dma),
-        tx_channel_(tx_channel),
-        rx_channel_(rx_channel),
-        match_char_(match_char) {}
+  UartDma(UartReg *const uart, char match_char) : uart_(uart), match_char_(match_char){};
 
-  void initialize(Frequency cpu_frequency, Frequency baud);
+  void initialize(Frequency cpu_frequency, Frequency baud, DMA::Base dma, DMA::Channel tx_channel,
+                  DMA::Channel rx_channel);
 
-  [[nodiscard]] bool start_tx(uint8_t *buf, uint32_t length, TxListener *txl);
-  [[nodiscard]] bool start_rx(uint8_t *buf, uint32_t length, RxListener *rxl);
+  [[nodiscard]] bool start_tx(uint8_t *buffer, uint32_t length, TxListener *txl);
+  [[nodiscard]] bool start_rx(uint8_t *buffer, uint32_t length, RxListener *rxl);
 
   bool tx_in_progress() const;
   bool rx_in_progress() const;
@@ -68,12 +49,10 @@ class UartDma {
 
  private:
   UartReg *const uart_{nullptr};
-  DmaReg *const dma_{nullptr};
-  uint8_t tx_channel_;
-  uint8_t rx_channel_;
+  std::optional<DMA::ChannelControl> tx_dma_{std::nullopt};
+  std::optional<DMA::ChannelControl> rx_dma_{std::nullopt};
   RxListener *rx_listener_{nullptr};
   TxListener *tx_listener_{nullptr};
-  uint32_t baud_{0};
   uint8_t match_char_;
   bool tx_in_progress_{false};
   bool rx_in_progress_{false};


### PR DESCRIPTION
Addresses several todos regarding DMA abstraction: create a `DMA::ChannelControl` class which takes care of manipulating DMA registers.

Updates #1184

Tested by running the vent, changing eeprom parameters and checking those are properly taken into account after vent restart.
modules that use DMA are:
- stepper driver
- i2c
- adc
- uart with rpi (if UART_VIA_DMA, still not fully functional)

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
