### PR TITLE
Add delimiter charaters when appending and prepending to debugvar strings

### DIFF
--- a/software/controller/lib/actuators/actuator_base.cpp
+++ b/software/controller/lib/actuators/actuator_base.cpp
@@ -33,7 +33,7 @@ void Actuator::InitDebugVars(const char *name, const char *help, const char *set
   forced_value_.prepend_name(setting_name, /*strict=*/true);
   forced_value_.prepend_name(name);
   forced_value_.prepend_name("forced_");
-  forced_value_.append_help("Force the ");
+  forced_value_.append_help("Force the", /*strict=*/true);
   forced_value_.append_help(setting_name);
   forced_value_.append_help(help);
   forced_value_.append_help(

--- a/software/controller/lib/actuators/actuator_base.cpp
+++ b/software/controller/lib/actuators/actuator_base.cpp
@@ -30,7 +30,7 @@ Actuator::Actuator(const char *name, const char *help,
 void Actuator::InitDebugVars(const char *name, const char *help, const char *setting_name) {
   calibration_.cal_table_.prepend_name(name);
   calibration_.cal_table_.append_help(help);
-  forced_value_.prepend_name(setting_name);
+  forced_value_.prepend_name(setting_name, /*strict=*/true);
   forced_value_.prepend_name(name);
   forced_value_.prepend_name("forced_");
   forced_value_.append_help("Force the ");

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -35,19 +35,19 @@ const char *Base::name() const { return name_; }
 void Base::prepend_name(const char *prefix, bool strict) {
   // Assumes name_ has enough space allocated for the combined string.
   size_t length = strlen(prefix);
-  constexpr char delimitor{'_'};
-  if (!strict && prefix[length - 1] != delimitor) {
+  constexpr char delimiter{'_'};
+  if (!strict && prefix[length - 1] != delimiter) {
     memmove(name_ + 1, name_, strlen(name_) + 1);
-    memcpy(name_, &delimitor, 1);
+    memcpy(name_, &delimiter, 1);
   }
   memmove(name_ + length, name_, strlen(name_) + 1);
   memcpy(name_, prefix, length);
 }
 
 void Base::append_help(const char *text, bool strict) {
-  constexpr char delimitor{' '};
+  constexpr char delimiter{' '};
   // \todo use stricat instead?
-  if (!strict && text[0] != delimitor) strncat(help_, &delimitor, 1);
+  if (!strict && text[0] != delimiter) strncat(help_, &delimiter, 1);
   strcat(help_, text);
 }
 

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -35,19 +35,19 @@ const char *Base::name() const { return name_; }
 void Base::prepend_name(const char *prefix, bool strict) {
   // Assumes name_ has enough space allocated for the combined string.
   size_t length = strlen(prefix);
-  constexpr char Delimitor{'_'};
-  if (!strict && prefix[length - 1] != Delimitor) {
+  constexpr char delimitor{'_'};
+  if (!strict && prefix[length - 1] != delimitor) {
     memmove(name_ + 1, name_, strlen(name_) + 1);
-    memcpy(name_, &Delimitor, 1);
+    memcpy(name_, &delimitor, 1);
   }
   memmove(name_ + length, name_, strlen(name_) + 1);
   memcpy(name_, prefix, length);
 }
 
 void Base::append_help(const char *text, bool strict) {
-  constexpr char Delimitor{' '};
+  constexpr char delimitor{' '};
   // \todo use stricat instead?
-  if (!strict && text[0] != Delimitor) strcat(help_, &Delimitor);
+  if (!strict && text[0] != delimitor) strncat(help_, &delimitor, 1);
   strcat(help_, text);
 }
 

--- a/software/controller/lib/debugvars/vars_base.cpp
+++ b/software/controller/lib/debugvars/vars_base.cpp
@@ -32,15 +32,22 @@ Base::Base(Type type, const char *name, Access access, const char *units, const 
 
 const char *Base::name() const { return name_; }
 
-void Base::prepend_name(const char *prefix) {
+void Base::prepend_name(const char *prefix, bool strict) {
   // Assumes name_ has enough space allocated for the combined string.
-  size_t len = strlen(prefix);
-  memmove(name_ + len, name_, strlen(name_) + 1);
-  memcpy(name_, prefix, len);
+  size_t length = strlen(prefix);
+  constexpr char Delimitor{'_'};
+  if (!strict && prefix[length - 1] != Delimitor) {
+    memmove(name_ + 1, name_, strlen(name_) + 1);
+    memcpy(name_, &Delimitor, 1);
+  }
+  memmove(name_ + length, name_, strlen(name_) + 1);
+  memcpy(name_, prefix, length);
 }
 
-void Base::append_help(const char *text) {
+void Base::append_help(const char *text, bool strict) {
+  constexpr char Delimitor{' '};
   // \todo use stricat instead?
+  if (!strict && text[0] != Delimitor) strcat(help_, &Delimitor);
   strcat(help_, text);
 }
 

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -76,8 +76,8 @@ class Base {
   virtual size_t byte_size() const = 0;
 
   const char *name() const;
-  void prepend_name(const char *prefix);
-  void append_help(const char *text);
+  void prepend_name(const char *prefix, bool strict = false);
+  void append_help(const char *text, bool strict = false);
 
   const char *format() const;
   const char *help() const;

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -81,7 +81,7 @@ class Base {
   //         is automatically added unless strict is set to true.
   /// \param strict can be set to true to prevent adding an '_' between prefix and var name
   void prepend_name(const char *prefix, bool strict = false);
-  /// \brief appends the help string with given text. If text does not start with a soace, one
+  /// \brief appends the help string with given text. If text does not start with a space, one
   //         is automatically added unless strict is set to true.
   /// \param strict can be set to true to prevent adding a space between help string and text
   void append_help(const char *text, bool strict = false);

--- a/software/controller/lib/debugvars/vars_base.h
+++ b/software/controller/lib/debugvars/vars_base.h
@@ -76,7 +76,14 @@ class Base {
   virtual size_t byte_size() const = 0;
 
   const char *name() const;
+
+  /// \brief prefixes the variable name with given prefix. If prefix does not end with an '_', one
+  //         is automatically added unless strict is set to true.
+  /// \param strict can be set to true to prevent adding an '_' between prefix and var name
   void prepend_name(const char *prefix, bool strict = false);
+  /// \brief appends the help string with given text. If text does not start with a soace, one
+  //         is automatically added unless strict is set to true.
+  /// \param strict can be set to true to prevent adding a space between help string and text
   void append_help(const char *text, bool strict = false);
 
   const char *format() const;

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -146,6 +146,5 @@ lib_deps =
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
 extra_scripts =
-  pre:platformio/build_config/auto_firmware_version.py
   platformio/build_config/platformio_sanitizers.py
 src_filter = +<src/>

--- a/software/controller/test/debug/vars_test.cpp
+++ b/software/controller/test/debug/vars_test.cpp
@@ -24,11 +24,26 @@ TEST(DebugVar, DebugVarInt32) {
   int32_t other_val{0};
   Primitive32 var("var", Access::ReadOnly, &value, "unit", "help", "fmt");
   EXPECT_STREQ("var", var.name());
-  var.prepend_name("pre_");
+  var.prepend_name("pre");
+  // check that an underscore was autmatically added to prefix
   EXPECT_STREQ("pre_var", var.name());
+  var.prepend_name("strict", true);
+  // check that no underscore was added
+  EXPECT_STREQ("strictpre_var", var.name());
+  var.prepend_name("pre_");
+  // check that underscore, already present, was not duplicated
+  EXPECT_STREQ("pre_strictpre_var", var.name());
   EXPECT_STREQ("help", var.help());
-  var.append_help(" so much help");
+  var.append_help("so much help");
+  // check that a space was automatically added
   EXPECT_STREQ("help so much help", var.help());
+  var.append_help("ing", true);
+  // check that no space was automatically added
+  EXPECT_STREQ("help so much helping", var.help());
+  var.append_help(" involved", true);
+  // check that no space was automatically added since it is already there
+  EXPECT_STREQ("help so much helping involved", var.help());
+
   EXPECT_EQ(Type::Int32, var.type());
   EXPECT_STREQ("fmt", var.format());
   EXPECT_STREQ("unit", var.units());


### PR DESCRIPTION
# Description
Adds feature to append/prepend functions in debug variables library to protect against simple mistakes when using those functions.
Closes #1216

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
