### PR TITLE
Refactor i2c

### DIFF
--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -359,7 +359,7 @@ bool ADC::initialize(const Frequency cpu_frequency) {
   DMA::ChannelControl dma{DMA::Base::DMA1, DMA::Channel::Chan1};
 
   dma.Initialize(/*selection=*/0, &adc->adc[0].data, DMA::ChannelDir::PeripheralToMemory,
-                 /*tx_interrupt=*/false, DMA::ChannelPriority::Low, IntPriority::Standard,
+                 /*tx_interrupt=*/false, DMA::ChannelPriority::Low, InterruptPriority::Standard,
                  /*circular=*/true, DMA::TransferSize::HalfWord);
   dma.SetupTransfer(oversample_buffer_, adc_sample_history_ * MaxAdcChannels);
   dma.Enable();

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -356,7 +356,6 @@ bool ADC::initialize(const Frequency cpu_frequency) {
   }
 
   // I use DMA1 channel 1 to copy A/D readings into the buffer ([RM] 11.4.4)
-  enable_peripheral_clock(PeripheralID::DMA1);
   DMA::ChannelControl dma{DMA::Base::DMA1, DMA::Channel::Chan1};
 
   dma.Initialize(/*selection=*/0, &adc->adc[0].data, DMA::ChannelDir::PeripheralToMemory,

--- a/software/controller/lib/hal/adc.cpp
+++ b/software/controller/lib/hal/adc.cpp
@@ -359,8 +359,8 @@ bool ADC::initialize(const Frequency cpu_frequency) {
   DMA::ChannelControl dma{DMA::Base::DMA1, DMA::Channel::Chan1};
 
   dma.Initialize(/*selection=*/0, &adc->adc[0].data, DMA::ChannelDir::PeripheralToMemory,
-                 /*tx_interrupt=*/false, DMA::ChannelPriority::Low, /*circular=*/true,
-                 DMA::TransferSize::HalfWord);
+                 /*tx_interrupt=*/false, DMA::ChannelPriority::Low, IntPriority::Standard,
+                 /*circular=*/true, DMA::TransferSize::HalfWord);
   dma.SetupTransfer(oversample_buffer_, adc_sample_history_ * MaxAdcChannels);
   dma.Enable();
 

--- a/software/controller/lib/hal/dma.cpp
+++ b/software/controller/lib/hal/dma.cpp
@@ -148,7 +148,8 @@ ChannelControl::ChannelControl(Base base, Channel channel) : base_(base), channe
 
 void ChannelControl::Initialize(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
                                 bool tx_interrupt, ChannelPriority channel_priority,
-                                IntPriority interrupt_priority, bool circular, TransferSize size) {
+                                InterruptPriority interrupt_priority, bool circular,
+                                TransferSize size) {
   switch (base_) {
     case Base::DMA1:
       enable_peripheral_clock(PeripheralID::DMA1);

--- a/software/controller/lib/hal/dma.cpp
+++ b/software/controller/lib/hal/dma.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 #include "dma.h"
 
 #include "clocks.h"
-#include "interrupts.h"
 
 namespace DMA {
 struct DmaRegisters {
@@ -148,18 +147,20 @@ volatile DmaReg::ChannelRegs *get_channel_reg(const Base id, const Channel chann
 ChannelControl::ChannelControl(Base base, Channel channel) : base_(base), channel_(channel){};
 
 void ChannelControl::Initialize(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
-                                bool tx_interrupt, ChannelPriority prio, bool circular,
-                                TransferSize size) {
+                                bool tx_interrupt, ChannelPriority channel_priority,
+                                IntPriority interrupt_priority, bool circular, TransferSize size) {
   switch (base_) {
     case Base::DMA1:
       enable_peripheral_clock(PeripheralID::DMA1);
       // TODO: add all channel interrupts to interrupt vectors and here
       switch (channel_) {
         case DMA::Channel::Chan2:
-          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma1Channel2, IntPriority::Low);
+          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma1Channel2,
+                                                  interrupt_priority);
           break;
         case DMA::Channel::Chan3:
-          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma1Channel3, IntPriority::Low);
+          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma1Channel3,
+                                                  interrupt_priority);
           break;
         default:
           break;
@@ -168,13 +169,16 @@ void ChannelControl::Initialize(uint8_t selection, volatile uint32_t *peripheral
     case Base::DMA2:
       enable_peripheral_clock(PeripheralID::DMA2);
       switch (channel_) {
-        case DMA::Channel::Chan2:
-          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel3, IntPriority::Low);
+        case DMA::Channel::Chan3:
+          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel3,
+                                                  interrupt_priority);
           break;
         case DMA::Channel::Chan6:
-          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel6, IntPriority::Low);
+          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel6,
+                                                  interrupt_priority);
         case DMA::Channel::Chan7:
-          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel7, IntPriority::Low);
+          Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel7,
+                                                  interrupt_priority);
           break;
         default:
           break;
@@ -187,7 +191,7 @@ void ChannelControl::Initialize(uint8_t selection, volatile uint32_t *peripheral
 
   Disable();
   SelectChannel(selection);
-  SetupChannel(prio, size, dir, tx_interrupt, circular);
+  SetupChannel(channel_priority, size, dir, tx_interrupt, circular);
 
   auto *channel_reg = get_channel_reg(base_, channel_);
   channel_reg->peripheral_address = peripheral;

--- a/software/controller/lib/hal/dma.h
+++ b/software/controller/lib/hal/dma.h
@@ -18,6 +18,8 @@ limitations under the License.
 #include <cstddef>  // used for size_t definition
 #include <cstdint>
 
+#include "interrupts.h"
+
 namespace DMA {
 
 enum class Base {
@@ -45,8 +47,10 @@ class ChannelControl {
  public:
   ChannelControl(Base base, Channel channel);
   void Initialize(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
-                  bool tx_interrupt = false, ChannelPriority prio = ChannelPriority::Medium,
-                  bool circular = false, TransferSize size = TransferSize::Byte);
+                  bool tx_interrupt = false,
+                  ChannelPriority channel_priority = ChannelPriority::Medium,
+                  IntPriority interrupt_priority = IntPriority::Standard, bool circular = false,
+                  TransferSize size = TransferSize::Byte);
   bool InterruptStatus(Interrupt interrupt);
   void ClearInterrupt(Interrupt interrupt);
   void SetupTransfer(volatile void *data, uint32_t length);

--- a/software/controller/lib/hal/dma.h
+++ b/software/controller/lib/hal/dma.h
@@ -49,8 +49,8 @@ class ChannelControl {
   void Initialize(uint8_t selection, volatile uint32_t *peripheral, ChannelDir dir,
                   bool tx_interrupt = false,
                   ChannelPriority channel_priority = ChannelPriority::Medium,
-                  IntPriority interrupt_priority = IntPriority::Standard, bool circular = false,
-                  TransferSize size = TransferSize::Byte);
+                  InterruptPriority interrupt_priority = InterruptPriority::Standard,
+                  bool circular = false, TransferSize size = TransferSize::Byte);
   bool InterruptStatus(Interrupt interrupt);
   void ClearInterrupt(Interrupt interrupt);
   void SetupTransfer(volatile void *data, uint32_t length);

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -287,8 +287,6 @@ void HalApi::InitUARTs() {
 #endif
   debug_uart.Init(CPUFrequency, UARTBaudRate);
 
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Dma1Channel2, IntPriority::Standard);
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Dma1Channel3, IntPriority::Standard);
   Interrupts::singleton().EnableInterrupt(InterruptVector::Uart2, IntPriority::Standard);
   Interrupts::singleton().EnableInterrupt(InterruptVector::Uart3, IntPriority::Standard);
 }

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -125,7 +125,9 @@ void HalApi::Init() {
   /// \TODO: ensure CPUFrequency is a multiple of 10 MHz
   SystemTimer::singleton().initialize(CPUFrequency);
   InitUARTs();
-  i2c1.Initialize(I2C::Speed::Fast, GPIO::Port::B, 8, 9, GPIO::AlternativeFunction::AF4);
+  // [PCBsp] lists I2C1 pins : SCL=PB8 and SDA=PB9
+  i2c1.Initialize(I2C::Speed::Fast, GPIO::Port::B, /*scl_pin=*/8, /*sda_pin=*/9,
+                  GPIO::AlternativeFunction::AF4);
   Interrupts::singleton().EnableInterrupts();
   StepMotor::OneTimeInit();
 }
@@ -204,7 +206,7 @@ void HalApi::StartLoopTimer(const Duration &period, void (*callback)(void *), vo
   // for normal hardware interrupts.  This means that other
   // interrupts can be serviced while controller functions
   // are running.
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Timer15, IntPriority::Low);
+  Interrupts::singleton().EnableInterrupt(InterruptVector::Timer15, InterruptPriority::Low);
 }
 
 static float latency, max_latency, loop_time;
@@ -287,8 +289,8 @@ void HalApi::InitUARTs() {
 #endif
   debug_uart.Init(CPUFrequency, UARTBaudRate);
 
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Uart2, IntPriority::Standard);
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Uart3, IntPriority::Standard);
+  Interrupts::singleton().EnableInterrupt(InterruptVector::Uart2, InterruptPriority::Standard);
+  Interrupts::singleton().EnableInterrupt(InterruptVector::Uart3, InterruptPriority::Standard);
 }
 
 void Uart2ISR() { debug_uart.ISR(); }
@@ -343,8 +345,8 @@ void BadISR() {}
 // the I2C::Channel::*ISR() which are generic ISR associated with an I²C channel
 void I2c1EventISR() { i2c1.I2CEventHandler(); };
 void I2c1ErrorISR() { i2c1.I2CErrorHandler(); };
-void DMA2Channel6ISR() { i2c1.DMAIntHandler(I2C::ExchangeDirection::Read); };
-void DMA2Channel7ISR() { i2c1.DMAIntHandler(I2C::ExchangeDirection::Write); };
+void DMA2Channel6ISR() { i2c1.DMAInterruptHandler(I2C::ExchangeDirection::Read); };
+void DMA2Channel7ISR() { i2c1.DMAInterruptHandler(I2C::ExchangeDirection::Write); };
 #if defined(UART_VIA_DMA)
 void DMA1Channel2ISR() { dma_uart.DMA_tx_interrupt_handler(); }
 void DMA1Channel3ISR() { dma_uart.DMA_rx_interrupt_handler(); }

--- a/software/controller/lib/hal/hal_stm32.cpp
+++ b/software/controller/lib/hal/hal_stm32.cpp
@@ -125,7 +125,7 @@ void HalApi::Init() {
   /// \TODO: ensure CPUFrequency is a multiple of 10 MHz
   SystemTimer::singleton().initialize(CPUFrequency);
   InitUARTs();
-  I2C::initialize();
+  i2c1.Initialize(I2C::Speed::Fast, GPIO::Port::B, 8, 9, GPIO::AlternativeFunction::AF4);
   Interrupts::singleton().EnableInterrupts();
   StepMotor::OneTimeInit();
 }
@@ -269,9 +269,6 @@ void HalApi::InitUARTs() {
   //        Need to do that as soon as the boards are available.
   enable_peripheral_clock(PeripheralID::USART2);
   enable_peripheral_clock(PeripheralID::USART3);
-#if defined(UART_VIA_DMA)
-  enable_peripheral_clock(PeripheralID::DMA1);
-#endif
   // [DS] Table 17 (pg 76)
   GPIO::AlternatePin(GPIO::Port::A, 2, GPIO::AlternativeFunction::AF7);  // USART2_TX
   GPIO::AlternatePin(GPIO::Port::A, 3, GPIO::AlternativeFunction::AF7);  // USART2_RX

--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -186,21 +186,21 @@ void Channel::Initialize(Speed speed, GPIO::Port port, uint8_t scl_pin, uint8_t 
   switch (i2c_) {
     case Base::I2C1:
       enable_peripheral_clock(PeripheralID::I2C1);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c1Event, IntPriority::Low);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c1Error, IntPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c1Event, InterruptPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c1Error, InterruptPriority::Low);
       break;
     case Base::I2C2:
       enable_peripheral_clock(PeripheralID::I2C2);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c2Event, IntPriority::Low);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c2Error, IntPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c2Event, InterruptPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c2Error, InterruptPriority::Low);
     case Base::I2C3:
       enable_peripheral_clock(PeripheralID::I2C3);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c3Event, IntPriority::Low);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c3Error, IntPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c3Event, InterruptPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c3Error, InterruptPriority::Low);
     case Base::I2C4:
       enable_peripheral_clock(PeripheralID::I2C4);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c4Event, IntPriority::Low);
-      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c4Error, IntPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c4Event, InterruptPriority::Low);
+      Interrupts::singleton().EnableInterrupt(InterruptVector::I2c4Error, InterruptPriority::Low);
       break;
     default:
       // All cases covered above (and GCC checks this).
@@ -230,10 +230,10 @@ void Channel::Initialize(Speed speed, GPIO::Port port, uint8_t scl_pin, uint8_t 
 
   // Setup DMA channels
   if (dma_enable_) {
-    tx_dma_->Initialize(request_, &(i2c_reg->tx_data), DMA::ChannelDir::MemoryToPeripheral, true,
-                        DMA::ChannelPriority::Low, IntPriority::Low);
-    rx_dma_->Initialize(request_, &(i2c_reg->rx_data), DMA::ChannelDir::PeripheralToMemory, true,
-                        DMA::ChannelPriority::Low, IntPriority::Low);
+    tx_dma_->Initialize(request_, &(i2c_reg->tx_data), DMA::ChannelDir::MemoryToPeripheral,
+                        /*tx_interrupt=*/true, DMA::ChannelPriority::Low, InterruptPriority::Low);
+    rx_dma_->Initialize(request_, &(i2c_reg->rx_data), DMA::ChannelDir::PeripheralToMemory,
+                        /*tx_interrupt=*/true, DMA::ChannelPriority::Low, InterruptPriority::Low);
     i2c_reg->control_reg1.dma_rx = 1;
     i2c_reg->control_reg1.dma_tx = 1;
   }
@@ -539,7 +539,7 @@ void Channel::I2CErrorHandler() {
   StartTransfer();
 }
 
-void Channel::DMAIntHandler(ExchangeDirection direction) {
+void Channel::DMAInterruptHandler(ExchangeDirection direction) {
   if (!dma_enable_ || !transfer_in_progress_) return;
 
   DMA::ChannelControl *channel{nullptr};

--- a/software/controller/lib/hal/i2c.cpp
+++ b/software/controller/lib/hal/i2c.cpp
@@ -27,6 +27,8 @@ limitations under the License.
 #include "clocks.h"
 
 // Declaration of I2C channel, as global since hal requires it to exist for interrupt handlers
+// TODO: find a way to get rid of this as global variable (probably requires a more flexible
+// handling of InterruptVector in Reset_Handler() function from hal_stm32.cpp)
 I2C::Channel i2c1(I2C::Base::I2C1, DMA::Base::DMA2);
 
 namespace I2C {
@@ -228,8 +230,10 @@ void Channel::Initialize(Speed speed, GPIO::Port port, uint8_t scl_pin, uint8_t 
 
   // Setup DMA channels
   if (dma_enable_) {
-    tx_dma_->Initialize(request_, &(i2c_reg->tx_data), DMA::ChannelDir::MemoryToPeripheral, 1);
-    rx_dma_->Initialize(request_, &(i2c_reg->rx_data), DMA::ChannelDir::PeripheralToMemory, 1);
+    tx_dma_->Initialize(request_, &(i2c_reg->tx_data), DMA::ChannelDir::MemoryToPeripheral, true,
+                        DMA::ChannelPriority::Low, IntPriority::Low);
+    rx_dma_->Initialize(request_, &(i2c_reg->rx_data), DMA::ChannelDir::PeripheralToMemory, true,
+                        DMA::ChannelPriority::Low, IntPriority::Low);
     i2c_reg->control_reg1.dma_rx = 1;
     i2c_reg->control_reg1.dma_tx = 1;
   }

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -19,126 +19,20 @@ limitations under the License.
 
 #pragma once
 
-/// \TODO: refactor this -- too much stuff in one file, and get rid of static globals
-
 #include "circular_buffer.h"
 #include "dma.h"
-
-// [RM] 37.7 I2C Registers
-struct I2CStruct {
-  union {
-    struct {
-      uint32_t enable : 1;
-      uint32_t tx_interrupts : 1;
-      uint32_t rx_interrupts : 1;
-      uint32_t addr_interrupts : 1;
-      uint32_t nack_interrupts : 1;
-      uint32_t stop_interrupts : 1;
-      uint32_t tx_complete_interrupts : 1;
-      uint32_t error_interrupts : 1;
-      uint32_t digital_noise_filter_conntrol : 4;
-      uint32_t analog_noise_filternig_off : 1;
-      uint32_t reserved1 : 1;
-      uint32_t dma_tx : 1;
-      uint32_t dma_rx : 1;
-      uint32_t slave_byte : 1;
-      uint32_t no_clock_stretch : 1;
-      uint32_t wake_from_stop : 1;
-      uint32_t general_call : 1;
-      uint32_t smbus_default_host : 1;
-      uint32_t smbus_default_device : 1;
-      uint32_t smbus_alert : 1;
-      uint32_t smbus_packet_error_checking : 1;
-      uint32_t reserved2 : 8;
-    };
-    uint32_t full_reg;
-  } control_reg1;  // Control register 1 [RM] 37.7.1
-  union {
-    struct {
-      uint32_t slave_addr_lsb : 1;  // lsb of 10 bits slave address
-      // (master)
-      uint32_t slave_addr_7b : 7;  // middle 7b bits of slave address
-      // (master)
-      uint32_t slave_addr_msb : 2;  // msb of 10 bits slave address
-      // (master)
-      uint32_t transfer_direction : 1;  // 0 = write, 1 = read (master)
-      uint32_t address_10b : 1;         // Set to enable 10 bits address header
-      // (master)
-      uint32_t read_10b_header : 1;  // Clear to send complete read sequence
-      // (master)
-      uint32_t start : 1;  // Set to generate START condition
-      uint32_t stop : 1;   // Set to generate STOP after byte transfer
-      // (master)
-      uint32_t nack : 1;                     // Generate NACK after byte reception (slave)
-      uint32_t n_bytes : 8;                  // Set to the number of bytes to send
-      uint32_t reload : 1;                   // Set to allow several consecutive transfers
-      uint32_t autoend : 1;                  // Set to automatically send stop condition
-      uint32_t packet_error_check_byte : 1;  // Set to send SMBus packet error
-      // checking byte
-      uint32_t reserved : 5;
-    };
-    uint32_t full_reg;
-  } control2;        // Control register 2 [RM] 37.7.2
-  uint32_t addr[2];  // Own address (1-2) register [RM] 37.7.{3,4} (slave)
-  union {
-    struct {
-      uint32_t scl_low : 8;   // Duration of SCL Low state (cycles)
-      uint32_t scl_high : 8;  // Duration of SCL High state (cycles)
-      uint32_t sda_hold : 4;  // Delay between SCL falling edge and SDA
-      // edge (cycles)
-      uint32_t scl_delay : 4;  // Delay between SDA edge and SCL rising
-      // edge (cycles)
-      uint32_t reserved : 4;
-      uint32_t prescaler : 4;  // Prescaler
-    };
-    uint32_t full_reg;
-  } timing;          // Timing register [RM] 37.7.5
-  uint32_t timeout;  // Timout register [RM] 37.7.6
-  union {
-    struct {
-      uint32_t tx_empty : 1;
-      uint32_t tx_interrupt : 1;
-      uint32_t rx_not_empty : 1;
-      uint32_t address_match : 1;
-      uint32_t nack : 1;
-      uint32_t stop : 1;
-      uint32_t transfer_complete : 1;
-      uint32_t transfer_reload : 1;
-      uint32_t bus_error : 1;
-      uint32_t arbitration_loss : 1;
-      uint32_t overrun : 1;
-      uint32_t packet_check_error : 1;
-      uint32_t timeout : 1;
-      uint32_t alert : 1;
-      uint32_t reserved1 : 1;
-      uint32_t busy : 1;
-      uint32_t transfer_direction : 1;
-      uint32_t address_code : 7;
-      uint32_t reserved : 8;
-    };
-    uint32_t full_reg;
-  } status;                     // Interrupt & status register [RM] 37.7.7
-  uint32_t interrupt_clear;     // Interrupt clear register [RM] 37.7.8
-  uint32_t packet_error_check;  // PEC register [RM] 37.7.9
-  uint32_t rx_data;             // Receive data register [RM] 37.7.10
-  uint32_t tx_data;             // Transmit data register [RM] 37.7.11
-};
-typedef volatile I2CStruct I2CReg;
-inline I2CReg *const I2C1Base = reinterpret_cast<I2CReg *>(0x40005400);
-inline I2CReg *const I2C2Base = reinterpret_cast<I2CReg *>(0x40005800);
-inline I2CReg *const I2C3Base = reinterpret_cast<I2CReg *>(0x40005c00);
-inline I2CReg *const I2C4Base = reinterpret_cast<I2CReg *>(0x40008400);
+#include "gpio.h"
 
 namespace I2C {
 
-void initialize();
+enum class Base { I2C1, I2C2, I2C3, I2C4 };
 
 // Speed values correspond to the timing register value from [RM] table 182
 enum class Speed {
-  Slow = 0x3042C3C7,      // 10 kb/s
-  Standard = 0x30420F13,  // 100 kb/s
-  Fast = 0x10320309,      // 400 kb/s
-  FastPlus = 0x00200204,  // 1 Mb/s
+  Slow,      // 10 kb/s
+  Standard,  // 100 kb/s
+  Fast,      // 400 kb/s
+  FastPlus,  // 1 Mb/s
 };
 
 enum class ExchangeDirection {
@@ -186,7 +80,16 @@ struct Request {
 // monitor what is sent on the bus.
 class Channel {
  public:
-  Channel() = default;
+  explicit Channel(Base i2c) : i2c_(i2c){};
+  Channel(Base i2c, DMA::Base dma);
+
+  // Init I²C channel, setting up registers to enable the channel and use
+  // DMA if a valid dma channel was provided during constuction.
+  // If no DMA was given (or it cannot be linked to this I²C), DMA is disabled
+  // and all transfers are handled in software.
+  void Initialize(Speed speed, GPIO::Port port, uint8_t scl_pin, uint8_t sda_pin,
+                  GPIO::AlternativeFunction alt_function);
+
   // Method that ultimately sends a request over the I²C channel, note
   // that it may take some time to be processed: if the line is already
   // busy, the request ends up in a queue. Once the request has been
@@ -199,12 +102,14 @@ class Channel {
   // Interrupt handlers
   void I2CEventHandler();
   void I2CErrorHandler();
+  // Interrupt handler for DMA, which only makes sense on the STM32
+  void DMAIntHandler(ExchangeDirection direction);
 
- protected:
-  // We queue of a few requests. The number of requests is arbitrary but
+  // Queue of a few requests. The number of requests is arbitrary but
   // should be enough for all intents and purposes.
   static constexpr size_t QueueLength{80};
 
+ protected:
   // We copy the write data into a buffer to make sure nothing can be lost
   // due to the scope of the caller's variable. This is the buffer size.
   static constexpr size_t WriteBufferSize{4096};
@@ -216,45 +121,52 @@ class Channel {
   // If it hits zero, we abort the request.
   int8_t error_retry_{MaxRetries};
 
-  bool dma_enable_{false};
-
   bool transfer_in_progress_{false};
 
-  void StartTransfer();               // initiate a transfer
-  virtual void SetupI2CTransfer(){};  // configure a transfer
-  void TransferByte();                // transfer a single byte (for non-DMA transfer)
-  virtual void ReceiveByte(){};
-  virtual void SendByte(){};
-  virtual void WriteTransferSize(){};
-  void EndTransfer();             // Clear necessary states
-  virtual void StopTransfer(){};  // send stop condition
-
-  // I²C interrupt getters:
-  // Indicates that the hardware has processed the current byte and we can
-  // read (or write) the next one in the Tx (or Rx) register.
-  virtual bool NextByteNeeded() const { return false; };
-  // Indicates that a 255 bytes transfer that does not end the current
-  // request is completed.
-  virtual bool TransferReload() const { return false; };
-  // Indicates that a transfer is completed.
-  virtual bool TransferComplete() const { return false; };
-  // Indicates that the slave is busy, while this is not an error, per
-  // say, we need to retry when a NACK occurs.  Because this is not an
-  // error, this retry does not decrement the error_retry countdown.
-  virtual bool NackDetected() const { return false; };
-  // Interrupt clear
-  virtual void ClearNack(){};
-  virtual void ClearErrors(){};
-
-  // Store the last request in order to be able to resume in case of
-  // errors.
-  Request last_request_;
   // For non-DMA transfers, store pointer to the next data to be
   // sent/received
   uint8_t *next_data_{nullptr};
   // For transfers longer than 255 bytes and non-DMA transfers, store size
   // of data that is still expected to be received/sent
   uint16_t remaining_size_{0};
+
+ private:
+  Base i2c_;
+  std::optional<DMA::ChannelControl> rx_dma_{std::nullopt};
+  std::optional<DMA::ChannelControl> tx_dma_{std::nullopt};
+  bool dma_enable_{false};
+  uint8_t request_{0};  // request number for dma setup
+
+  void StartTransfer();             // initiate a transfer
+  virtual void SetupI2CTransfer();  // configure I2C to process a transfer
+  void SetupDMATransfer();          // configure DMA registers to process a transfer
+  void TransferByte();              // transfer a single byte (for non-DMA transfer)
+  virtual void ReceiveByte();
+  virtual void SendByte();
+  virtual void WriteTransferSize();
+  void EndTransfer();           // Clear necessary states
+  virtual void StopTransfer();  // send stop condition
+
+  // I²C interrupt getters:
+  // Indicates that the hardware has processed the current byte and we can
+  // read (or write) the next one in the Tx (or Rx) register.
+  virtual bool NextByteNeeded() const;
+  // Indicates that a 255 bytes transfer that does not end the current
+  // request is completed.
+  virtual bool TransferReload() const;
+  // Indicates that a transfer is completed.
+  virtual bool TransferComplete() const;
+  // Indicates that the slave is busy, while this is not an error, per
+  // say, we need to retry when a NACK occurs.  Because this is not an
+  // error, this retry does not decrement the error_retry countdown.
+  virtual bool NackDetected() const;
+  // Interrupt clear
+  virtual void ClearNack();
+  virtual void ClearErrors();
+
+  // Store the last request in order to be able to resume in case of
+  // errors.
+  Request last_request_;
 
   // Because Request cannot be std::move'd (and is therefore not
   // compatible with our circular buffer template), we use a circular
@@ -277,97 +189,13 @@ class Channel {
   // which
   //    means we lose the ability to retry a request after an I²C (or DMA)
   //    error.
-  uint8_t write_buffer_[WriteBufferSize];
+  uint8_t write_buffer_[WriteBufferSize] = {0};
   size_t write_buffer_index_{0};
   size_t write_buffer_start_{0};
   size_t wrapping_index_{WriteBufferSize};
   bool CopyDataToWriteBuffer(const void *data, uint16_t size);
 };
 
-class STM32Channel : public Channel {
- public:
-  STM32Channel() = default;
-  // Init I²C channel, setting up registers DMA_Reg and I²C_Reg to enable
-  // the channel using DMA if possible. If DMA_Reg is invalid (or that DMA
-  // cannot be linked to this I²C), dma is disabled and all transfers are
-  // handled in software.
-  void Init(I2CReg *i2c, DMA::Base dma, Speed speed);
-  // Interrupt handlers for DMA, which only makes sense on the STM32
-  void DMAIntHandler(ExchangeDirection direction);
-
- private:
-  I2CReg *i2c_{nullptr};
-
-  std::optional<DMA::ChannelControl> rx_dma_{std::nullopt};
-  std::optional<DMA::ChannelControl> tx_dma_{std::nullopt};
-
-  void SetupI2CTransfer() override;  // configure a transfer
-  void ReceiveByte() override { *next_data_ = static_cast<uint8_t>(i2c_->rx_data); };
-  void SendByte() override { i2c_->tx_data = *next_data_; };
-  void WriteTransferSize() override;
-  void StopTransfer() override { i2c_->control2.stop = 1; };
-
-  // Override interrupt getters:
-  bool NextByteNeeded() const override {
-    return i2c_->status.rx_not_empty || i2c_->status.tx_interrupt;
-  };
-  bool TransferReload() const override { return i2c_->status.transfer_reload; };
-  bool TransferComplete() const override { return i2c_->status.transfer_complete; };
-  bool NackDetected() const override { return i2c_->status.nack; };
-  // Override Interrupt clear
-  void ClearNack() override { i2c_->interrupt_clear = 0x10; }
-  void ClearErrors() override { i2c_->interrupt_clear = 0x720; }
-
-  void SetupDMAChannels(DMA::Base dma);
-  void SetupDMATransfer();
-};
-
-class TestChannel : public Channel {
- public:
-  TestChannel() = default;
-  // in test mode, setters and getters for faked sent/received data
-  std::optional<uint8_t> TESTGetSentData() { return sent_buffer_.Get(); };
-  bool TESTQueueReceiveData(uint8_t data) { return rx_buffer_.Put(data); };
-  // setter to simulate Nack received
-  void TESTSimulateNack() { nack_ = true; };
-
- private:
-  // in test mode, fake sending and receiving data through circular
-  // buffers.
-  CircularBuffer<uint8_t, WriteBufferSize> sent_buffer_;
-  // note it is up to the tester to put data in the rx_buffer before
-  // calling I2CEventHandler during a read request
-  CircularBuffer<uint8_t, WriteBufferSize> rx_buffer_;
-  // fake a NACK condition on next handler call
-  bool nack_{false};
-
-  // mock the sending and receiving of bytes from internal buffers
-  void SendByte() override {
-    bool ok = sent_buffer_.Put(*next_data_);
-    if (ok) return;
-  };
-  void ReceiveByte() override {
-    std::optional<uint8_t> data = rx_buffer_.Get();
-    if (data != std::nullopt) {
-      *next_data_ = *data;
-    }
-  };
-
-  // Override I²C interrupt getters for Mock
-  bool NextByteNeeded() const override { return remaining_size_ > 0; };
-  bool TransferReload() const override {
-    return remaining_size_ % 255 == 0 && remaining_size_ > 0;
-  };
-  bool TransferComplete() const override { return remaining_size_ == 0; };
-  bool NackDetected() const override { return nack_; };
-
-  void ClearNack() override { nack_ = false; };
-};
-
 }  // namespace I2C
 
-#if defined(BARE_STM32)
-extern I2C::STM32Channel i2c1;
-#else
 extern I2C::Channel i2c1;
-#endif

--- a/software/controller/lib/hal/i2c.h
+++ b/software/controller/lib/hal/i2c.h
@@ -103,7 +103,7 @@ class Channel {
   void I2CEventHandler();
   void I2CErrorHandler();
   // Interrupt handler for DMA, which only makes sense on the STM32
-  void DMAIntHandler(ExchangeDirection direction);
+  void DMAInterruptHandler(ExchangeDirection direction);
 
   // Queue of a few requests. The number of requests is arbitrary but
   // should be enough for all intents and purposes.

--- a/software/controller/lib/hal/interrupts.cpp
+++ b/software/controller/lib/hal/interrupts.cpp
@@ -31,7 +31,7 @@ inline InterruptControlReg *const NvicBase = reinterpret_cast<InterruptControlRe
 
 // Enable an interrupt with a specified priority (0 to 15)
 // See [RM] chapter 12 for more information on the NVIC.
-void Interrupts::EnableInterrupt(InterruptVector vec, IntPriority pri) {
+void Interrupts::EnableInterrupt(InterruptVector vec, InterruptPriority pri) {
   InterruptControlReg *nvic = NvicBase;
 
   int addr = static_cast<int>(vec);
@@ -61,7 +61,7 @@ bool Interrupts::InInterruptHandler() {
 
 #else
 
-void Interrupts::EnableInterrupt(InterruptVector vec, IntPriority pri) {}
+void Interrupts::EnableInterrupt(InterruptVector vec, InterruptPriority pri) {}
 void Interrupts::DisableInterrupts() { interrupts_enabled_ = false; }
 void Interrupts::EnableInterrupts() { interrupts_enabled_ = true; }
 bool Interrupts::InterruptsEnabled() const { return interrupts_enabled_; }

--- a/software/controller/lib/hal/interrupts.h
+++ b/software/controller/lib/hal/interrupts.h
@@ -51,7 +51,7 @@ enum class InterruptVector : uint32_t {
 // here.  Hard faults, NMI, resets, etc have a fixed
 // priority of -1, so they can always interrupt any other
 // priority level.
-enum class IntPriority {
+enum class InterruptPriority {
   Critical = 2,  // Very important interrupt
   Standard = 5,  // Normal hardware interrupts
   Low = 8,       // Less important.  Hardware interrupts can interrupt this
@@ -75,7 +75,7 @@ class Interrupts {
     return SingletonInstance;
   }
 
-  void EnableInterrupt(InterruptVector vec, IntPriority pri);
+  void EnableInterrupt(InterruptVector vec, InterruptPriority pri);
 
   // Interrupt enable/disable functions.
   void DisableInterrupts();

--- a/software/controller/lib/hal/interrupts.h
+++ b/software/controller/lib/hal/interrupts.h
@@ -27,6 +27,8 @@ enum class InterruptVector : uint32_t {
   Timer15 = 0xA0,
   I2c1Event = 0xBC,
   I2c1Error = 0xC0,
+  I2c2Event = 0xC4,
+  I2c2Error = 0xC8,
   Spi1 = 0xCC,
   Uart2 = 0x0D8,
   Uart3 = 0x0DC,
@@ -34,6 +36,10 @@ enum class InterruptVector : uint32_t {
   Dma2Channel3 = 0x128,
   Dma2Channel6 = 0x150,
   Dma2Channel7 = 0x157,
+  I2c3Event = 0x160,
+  I2c3Error = 0x164,
+  I2c4Event = 0x18C,
+  I2c4Error = 0x190,
 };
 
 // Interrupts on the STM32 are prioritized.  This allows

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -221,10 +221,13 @@ void StepMotor::OneTimeInit() {
   rx_dma_.emplace(DMA::Base::DMA2, DMA::Channel::Chan3);
   tx_dma_.emplace(DMA::Base::DMA2, DMA::Channel::Chan4);
 
-  rx_dma_->Initialize(4, &spi->data, DMA::ChannelDir::PeripheralToMemory, /*tx_interrupt=*/true,
-                      DMA::ChannelPriority::Low, IntPriority::Standard);
-  tx_dma_->Initialize(4, &spi->data, DMA::ChannelDir::MemoryToPeripheral, /*tx_interrupt=*/false,
-                      DMA::ChannelPriority::Low, IntPriority::Standard);
+  // SPI1 can be linked to DMA2 using selection number 4 [RM p299]
+  rx_dma_->Initialize(/*selection=*/4, &spi->data, DMA::ChannelDir::PeripheralToMemory,
+                      /*tx_interrupt=*/true, DMA::ChannelPriority::Low,
+                      InterruptPriority::Standard);
+  tx_dma_->Initialize(/*selection=*/4, &spi->data, DMA::ChannelDir::MemoryToPeripheral,
+                      /*tx_interrupt=*/false, DMA::ChannelPriority::Low,
+                      InterruptPriority::Standard);
 
   // Do some basic init of the stepper motor chips so we can
   // make them spin the motors

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -222,11 +222,9 @@ void StepMotor::OneTimeInit() {
   tx_dma_.emplace(DMA::Base::DMA2, DMA::Channel::Chan4);
 
   rx_dma_->Initialize(4, &spi->data, DMA::ChannelDir::PeripheralToMemory, /*tx_interrupt=*/true,
-                      DMA::ChannelPriority::Low);
+                      DMA::ChannelPriority::Low, IntPriority::Standard);
   tx_dma_->Initialize(4, &spi->data, DMA::ChannelDir::MemoryToPeripheral, /*tx_interrupt=*/false,
-                      DMA::ChannelPriority::Low);
-
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Dma2Channel3, IntPriority::Standard);
+                      DMA::ChannelPriority::Low, IntPriority::Standard);
 
   // Do some basic init of the stepper motor chips so we can
   // make them spin the motors

--- a/software/controller/lib/hal/stepper.cpp
+++ b/software/controller/lib/hal/stepper.cpp
@@ -163,7 +163,6 @@ StepMtrErr StepMotor::GetParam(StepMtrParam param, uint32_t *value) {
  *****************************************************************/
 void StepMotor::OneTimeInit() {
   enable_peripheral_clock(PeripheralID::SPI1);
-  enable_peripheral_clock(PeripheralID::DMA2);
 
   // The following pins are used to talk to the stepper
   // drivers:

--- a/software/controller/lib/hal/system_timer.cpp
+++ b/software/controller/lib/hal/system_timer.cpp
@@ -56,7 +56,7 @@ void SystemTimer::initialize(Frequency cpu_frequency) {
   tmr->control_reg1.bitfield.counter_enable = 1;
   tmr->interrupts_enable = 1;
 
-  Interrupts::singleton().EnableInterrupt(InterruptVector::Timer6, IntPriority::Standard);
+  Interrupts::singleton().EnableInterrupt(InterruptVector::Timer6, InterruptPriority::Standard);
 }
 
 void SystemTimer::interrupt_handler() {


### PR DESCRIPTION
# Description

- Address todo to refactor I2C.
- Move enabling of clocks and interrupts from HAL's one time init function to the corresponding peripheral's init function (I2C and DMA for now).
- Move I2C mock class to test library.

Todo: find a way to make `i2c1` a non-global instance.

Updates #1184

Chained with #1214

As with previous hal refactoring PRs,  I ran a sanity check of the vent (run it from gui, read/write to nvparams from debug interface) and noticed no regression.

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
