### PR TITLE
Fix coverage reports

### DIFF
--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -146,6 +146,5 @@ lib_deps =
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
 extra_scripts =
-  pre:platformio/build_config/auto_firmware_version.py
   platformio/build_config/platformio_sanitizers.py
 src_filter = +<src/>


### PR DESCRIPTION
# Description

For some reason, pre:script in platformio.ini native environment seems to prevent the coverage reports from having correct numbers.
This means building on native `pio run -e native` will no longer work due to several undefined environment variables, e.g:
```
In file included from src/main.cpp:28:
lib/core/version.h:20:34: error: ‘GIT_VERSION’ was not declared in this scope; did you mean ‘PSTL_VERSION’?
```

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [x] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [x] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [x] I performed a clean build and verified that there were no warnings
- [x] I ran our static analysis tools and verified there were no warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All source files have license headers
