### PR TITLE
Fix googletest version to v1.10 to allow unit testing again

### DIFF
--- a/software/common/platformio.ini
+++ b/software/common/platformio.ini
@@ -81,7 +81,7 @@ build_flags =
   --coverage
   -lgcov
 lib_deps =
-  googletest
+  googletest@1.10
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off

--- a/software/common/platformio.ini
+++ b/software/common/platformio.ini
@@ -81,6 +81,8 @@ build_flags =
   --coverage
   -lgcov
 lib_deps =
+; using v1.10 because v1.11 broke our unit tests:
+; https://community.platformio.org/t/googletest-v1-11-build-fail-on-native/27662
   googletest@1.10
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -141,7 +141,7 @@ lib_extra_dirs =
 build_flags =
   ${env.build_flags} -pthread -g --coverage -lgcov
 lib_deps =
-  googletest
+  googletest@1.10
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -141,6 +141,8 @@ lib_extra_dirs =
 build_flags =
   ${env.build_flags} -pthread -g --coverage -lgcov
 lib_deps =
+; using v1.10 because v1.11 broke our unit tests:
+; https://community.platformio.org/t/googletest-v1-11-build-fail-on-native/27662
   googletest@1.10
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7


### PR DESCRIPTION
# Description

Issue appeared since yesterday on my computer and on CI, unit tests fail to build.
Seems related to the googletest library version being updated from 1.10 to 1.11, this fixes the problem (including on CI).

# General checklist:

- [x] I have performed a self-review, including - looked through the `Files changed` tab, browsed repository in my branch
- [x] I have made corresponding changes to the documentation - to reflect changes in code, electrical or mechanical design
- [x] All new documentation or graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] All new content is linked, easily discoverable, does not require too many clicks
- [x] I have reviewed any other relevant parts of our [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki) to ensure that this PR conforms to the standards
- [x] I have given the PR a descriptive name (prefixed with **WIP** if it is not yet ready for review)
- [x] I have tagged relevant reviewers

## Code checklist:

- [ ] All new code follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have described tests I used to verify my changes, instructions for reproducing them and any relevant configuration details.
- [ ] I ran the unit test suite and verified that all tests pass - new and old, locally and on CI
- [ ] I performed a clean build and verified that there were no warnings
- [ ] I ran our static analysis tools and verified there were no warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All source files have license headers
