### PR TITLE
Fixes to build and test with gcc11

### DIFF
--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -143,9 +143,7 @@ run_checks() {
     set +e
     set +o pipefail
 
-    # STM32 - clangtidy [TODO(a-vinod) cppcheck]
     # Native - cppcheck & clangtidy
-
     pio check -e native --fail-on-defect=high
 }
 

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -161,10 +161,10 @@ run_checks() {
     set +e
     set +o pipefail
 
-    # STM32 - clangtidy [TODO(a-vinod) cppcheck]
-    # Native - cppcheck & clangtidy
-
+    # STM32 - cppcheck & clangtidy
     pio check -e stm32 --fail-on-defect=high --skip-packages
+
+    # Native - cppcheck & clangtidy
     pio check -e native --fail-on-defect=high
 }
 

--- a/software/controller/lib/debug/trace.cpp
+++ b/software/controller/lib/debug/trace.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ uint16_t Trace::traced_variable(uint8_t index) {
   // We want to make sure we read a full sample without being interrupted.
   *count = 0;
   BlockInterrupts block;
-  for (auto *var : traced_vars_) {
+  for (const auto *var : traced_vars_) {
     if (!var) {
       continue;
     }

--- a/software/controller/lib/framing/uart_stream.h
+++ b/software/controller/lib/framing/uart_stream.h
@@ -1,9 +1,11 @@
-
 /* Copyright 2020-2022, RespiraWorks
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,21 +39,21 @@ class UartStream : public OutputStream, public TxListener {
   StreamResponse put(int32_t b) override {
     if (tx_error_) {
       tx_error_ = false;
-      return {.count_written = 0, .flags = ResponseFlags::ErrorStreamBroken};
+      return {/*count_written=*/0, ResponseFlags::ErrorStreamBroken};
     }
     // TODO thread safety
     if (EndOfStream == b) {
-      return {.count_written = 0, .flags = transmit()};
+      return {/*count_written=*/0, transmit()};
     }
 
     if (buffer_full()) {
-      return {.count_written = 0, .flags = ResponseFlags::ErrorBufferFull};
+      return {/*count_written=*/0, ResponseFlags::ErrorBufferFull};
     } else {
       buffer_[index_++] = static_cast<uint8_t>(b);
       if (buffer_full()) {
-        return {.count_written = 1, .flags = transmit()};
+        return {/*count_written=*/1, transmit()};
       }
-      return {.count_written = 1, .flags = ResponseFlags::StreamSuccess};
+      return {/*count_written=*/1, ResponseFlags::StreamSuccess};
     }
   }
 

--- a/software/controller/test/test_debug/eeprom_cmd_test.cpp
+++ b/software/controller/test/test_debug/eeprom_cmd_test.cpp
@@ -1,8 +1,11 @@
 /* Copyright 2020-2022, RespiraWorks
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -112,13 +115,13 @@ TEST(EepromHandler, Errors) {
   long_write[0] = 1;
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::MissingData},                    // Missing subcommand
-      {{0, 0, 0, 4, 0}, ErrorCode::NoMemory},          // length > max response length
-      {{0, 0, 0, 0}, ErrorCode::MissingData},          // Read missing length
-      {{1, 0, 0}, ErrorCode::MissingData},             // Write missing data
-      {{1, 0xFF, 0xFF, 0}, ErrorCode::InternalError},  // Write outside eeprom
-      {long_write, ErrorCode::NoMemory},               // Write more than 1024 bytes
-      {{2, 0, 0}, ErrorCode::InvalidData},             // Invalid subcommand
+      {std::vector<uint8_t>{}, ErrorCode::MissingData},  // Missing subcommand
+      {{0, 0, 0, 4, 0}, ErrorCode::NoMemory},            // length > max response length
+      {{0, 0, 0, 0}, ErrorCode::MissingData},            // Read missing length
+      {{1, 0, 0}, ErrorCode::MissingData},               // Write missing data
+      {{1, 0xFF, 0xFF, 0}, ErrorCode::InternalError},    // Write outside eeprom
+      {long_write, ErrorCode::NoMemory},                 // Write more than 1024 bytes
+      {{2, 0, 0}, ErrorCode::InvalidData},               // Invalid subcommand
   };
 
   for (auto &[request, error] : requests) {

--- a/software/controller/test/test_debug/trace_cmd_test.cpp
+++ b/software/controller/test/test_debug/trace_cmd_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -317,8 +317,8 @@ TEST(TraceHandler, Errors) {
   trace.start();
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::MissingData},   // Missing subcommand
-      {{9}, ErrorCode::InvalidData},  // Invalid subcommand
+      {std::vector<uint8_t>{}, ErrorCode::MissingData},  // Missing subcommand
+      {{9}, ErrorCode::InvalidData},                     // Invalid subcommand
       {{static_cast<uint8_t>(TraceHandler::Subcommand::Download)}, ErrorCode::NoMemory},
       {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), 1, 1}, ErrorCode::MissingData},
       //      {{static_cast<uint8_t>(TraceHandler::Subcommand::SetVarId), Trace::MaxVars, 1, 0},

--- a/software/controller/test/test_debug/var_cmd_test.cpp
+++ b/software/controller/test/test_debug/var_cmd_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021, RespiraWorks
+/* Copyright 2020-2022, RespiraWorks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -181,8 +181,8 @@ TEST(VarHandler, Errors) {
   u16_to_u8(var_readonly.id(), id_readonly);
 
   std::vector<std::tuple<std::vector<uint8_t>, ErrorCode>> requests = {
-      {{}, ErrorCode::MissingData},   // Missing subcommand
-      {{4}, ErrorCode::InvalidData},  // Invalid subcommand
+      {std::vector<uint8_t>{}, ErrorCode::MissingData},  // Missing subcommand
+      {{4}, ErrorCode::InvalidData},                     // Invalid subcommand
       {{0, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
       {{1, 0xFF, 0xFF}, ErrorCode::UnknownVariable},
       {{2, 0xFF, 0xFF}, ErrorCode::UnknownVariable},

--- a/software/gui/src/qserial_output_stream.h
+++ b/software/gui/src/qserial_output_stream.h
@@ -1,8 +1,11 @@
 /* Copyright 2020-2022, RespiraWorks
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,11 +28,11 @@ class QSerialOutputStream : public OutputStream {
 
   StreamResponse put(int32_t b) override {
     if (EndOfStream == b) {
-      return {.count_written_ = 0, .flags = ResponseFlags::StreamSuccess};
+      return {/*count_written=*/0, ResponseFlags::StreamSuccess};
     }
     char byte = static_cast<char>(b);
     port_->write(&byte, 1);
-    return {.count_written_ = 1, .flags = ResponseFlags::StreamSuccess};
+    return {/*count_written=*/1, ResponseFlags::StreamSuccess};
   }
 
  private:


### PR DESCRIPTION
# Description

gcc v11 is now standard on some operating systems. Both controller and GUI have been failing to build and test because of some stricter rules for class initialization. This PR fixes the errors.

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them