### PR TITLE
Fix code coverage issue

### DIFF
--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -112,7 +112,7 @@ install_linux() {
   pip3 install platformio==${PIO_VERSION}
 
   # upgrading platformio to development version to get proper code coverage reports
-  # remove this when platformio 6.1.0 goes live.
+  # TODO: remove this when platformio 6.1.0 goes live.
   pio upgrade --dev
 
   source ${HOME}/.profile
@@ -122,7 +122,7 @@ update_platformio() {
   pip3 install platformio==${PIO_VERSION}
 
   # upgrading platformio to development version to get proper code coverage reports
-  # remove this when platformio 6.1.0 goes live.
+  # TODO: remove this when platformio 6.1.0 goes live.
   pio upgrade --dev
 
   pio pkg uninstall -d .

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -110,11 +110,21 @@ install_linux() {
   pip3 install -U pip
   pip3 install codecov
   pip3 install platformio==${PIO_VERSION}
+
+  # upgrading platformio to development version to get proper code coverage reports
+  # remove this when platformio 6.1.0 goes live.
+  pio upgrade --dev
+
   source ${HOME}/.profile
 }
 
 update_platformio() {
   pip3 install platformio==${PIO_VERSION}
+
+  # upgrading platformio to development version to get proper code coverage reports
+  # remove this when platformio 6.1.0 goes live.
+  pio upgrade --dev
+
   pio pkg uninstall -d .
   pio pkg install -d .
   exit $EXIT_SUCCESS
@@ -201,20 +211,12 @@ generate_coverage_reports() {
   rm "${COVERAGE_OUTPUT_DIR}/coverage.info"
   mv "${COVERAGE_OUTPUT_DIR}/coverage_trimmed.info" "${COVERAGE_OUTPUT_DIR}/coverage.info"
 
-  # Capture the case where coverage report is empty in order not to block in case of empty coverage report
-  # This is a temporary solution to an issue with platformio 6.0 (https://community.platformio.org/t/code-coverage-issue-on-native/28126)
-  # \\\TODO: remove this when platformio gets fixed
-  if [ -s "${COVERAGE_OUTPUT_DIR}/coverage.info" ]; then
-    genhtml ${QUIET} "${COVERAGE_OUTPUT_DIR}/coverage.info" \
-        --output-directory "${COVERAGE_OUTPUT_DIR}"
+  genhtml ${QUIET} "${COVERAGE_OUTPUT_DIR}/coverage.info" \
+      --output-directory "${COVERAGE_OUTPUT_DIR}"
 
-    echo "Coverage reports generated at '${COVERAGE_OUTPUT_DIR}/index.html'"
-    echo "   You may open it in browser with 'python -m webbrowser ${COVERAGE_OUTPUT_DIR}/index.html'"
-  else
-    echo "Error while generating coverage reports: reporting zero coverage. Non-blocking for now."
-  fi
+  echo "Coverage reports generated at '${COVERAGE_OUTPUT_DIR}/index.html'"
+  echo "   You may open it in browser with 'python -m webbrowser ${COVERAGE_OUTPUT_DIR}/index.html'"
 
-  #launch_browser
 }
 
 launch_browser() {

--- a/software/common/test_libs/custom_google/gtest_main.h
+++ b/software/common/test_libs/custom_google/gtest_main.h
@@ -17,5 +17,10 @@ limitations under the License.
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
-  return RUN_ALL_TESTS();
+  if (RUN_ALL_TESTS())
+    ;
+
+  // Always returning 0, per platformio documentation:
+  // https://docs.platformio.org/en/latest/advanced/unit-testing/frameworks/googletest.html
+  return 0;
 }

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -118,6 +118,11 @@ install_linux() {
   pip3 install -U pip
   pip3 install codecov pyserial matplotlib pandas gitpython
   pip3 install platformio==${PIO_VERSION}
+
+  # upgrading platformio to development version to get proper code coverage reports
+  # remove this when platformio 6.1.0 goes live.
+  pio upgrade --dev
+
   source ${HOME}/.profile
 }
 
@@ -133,6 +138,11 @@ configure_platformio() {
 
 update_platformio() {
   pip3 install platformio==${PIO_VERSION}
+
+  # upgrading platformio to development version to get proper code coverage reports
+  # remove this when platformio 6.1.0 goes live.
+  pio upgrade --dev
+
   pio pkg uninstall -d .
   pio pkg install -d .
   exit $EXIT_SUCCESS
@@ -234,18 +244,11 @@ generate_coverage_reports() {
   rm "${COVERAGE_OUTPUT_DIR}/coverage.info"
   mv "${COVERAGE_OUTPUT_DIR}/coverage_trimmed.info" "${COVERAGE_OUTPUT_DIR}/coverage.info"
 
-  # Capture the case where coverage report is empty in order not to block in case of empty coverage report
-  # This is a temporary solution to an issue with platformio 6.0 (https://community.platformio.org/t/code-coverage-issue-on-native/28126)
-  # \\\TODO: remove this when platformio gets fixed
-  if [ -s "${COVERAGE_OUTPUT_DIR}/coverage.info" ]; then
-    genhtml ${QUIET} "${COVERAGE_OUTPUT_DIR}/coverage.info" \
-        --output-directory "${COVERAGE_OUTPUT_DIR}"
+  genhtml ${QUIET} "${COVERAGE_OUTPUT_DIR}/coverage.info" \
+      --output-directory "${COVERAGE_OUTPUT_DIR}"
 
-    echo "Coverage reports generated at '$COVERAGE_OUTPUT_DIR/index.html'"
-    echo "   You may open it in browser with 'python -m webbrowser ${COVERAGE_OUTPUT_DIR}/index.html'"
-  else
-    echo "Error while generating coverage reports: reporting zero coverage. Non-blocking for now."
-  fi
+  echo "Coverage reports generated at '$COVERAGE_OUTPUT_DIR/index.html'"
+  echo "   You may open it in browser with 'python -m webbrowser ${COVERAGE_OUTPUT_DIR}/index.html'"
 
 }
 

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -120,7 +120,7 @@ install_linux() {
   pip3 install platformio==${PIO_VERSION}
 
   # upgrading platformio to development version to get proper code coverage reports
-  # remove this when platformio 6.1.0 goes live.
+  # TODO: remove this when platformio 6.1.0 goes live.
   pio upgrade --dev
 
   source ${HOME}/.profile
@@ -140,7 +140,7 @@ update_platformio() {
   pip3 install platformio==${PIO_VERSION}
 
   # upgrading platformio to development version to get proper code coverage reports
-  # remove this when platformio 6.1.0 goes live.
+  # TODO: remove this when platformio 6.1.0 goes live.
   pio upgrade --dev
 
   pio pkg uninstall -d .

--- a/software/controller/integration_tests/main.cpp
+++ b/software/controller/integration_tests/main.cpp
@@ -1,5 +1,6 @@
-// Including some headers here in order for ldf to find them:
+// Manually including some headers here in order for ldf to find them:
 // see https://community.platformio.org/t/ldf-not-following-environment-variables-in-6-1-0rc1/28616
+/// \TODO: remove when (if) the above issue ever gets fixed
 #include "actuator_base.h"
 #include "hal.h"
 #include "interface.h"

--- a/software/controller/integration_tests/main.cpp
+++ b/software/controller/integration_tests/main.cpp
@@ -1,3 +1,10 @@
+// Including some headers here in order for ldf to find them:
+// see https://community.platformio.org/t/ldf-not-following-environment-variables-in-6-1-0rc1/28616
+#include "actuator_base.h"
+#include "hal.h"
+#include "interface.h"
+#include "sensors.h"
+
 // Using these compile-time defines to avoid multiple directories and mains
 
 #include INTEGRATION_TEST_H

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -130,4 +130,4 @@ build_flags =
   ${env.build_flags} -g --coverage -lgcov
 extra_scripts =
   platformio/build_config/platformio_sanitizers.py
-build_src_filter = +<release/>
+build_src_filter = +<src/>

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -79,7 +79,6 @@ check_flags =
 check_patterns =
   ../controller/lib
   ../controller/src
-  ../controller/src_test
   ../controller/integration_tests
   ; ../common/libs checked as part of common
   ; Do not include ../common/test_libs
@@ -131,4 +130,4 @@ build_flags =
   ${env.build_flags} -g --coverage -lgcov
 extra_scripts =
   platformio/build_config/platformio_sanitizers.py
-build_src_filter = +<src/>
+build_src_filter = +<release/>


### PR DESCRIPTION
# Description

Upgrade to development version of `platformio` (version `6.1.0rc1`) in order to fix coverage reports.
With that fix, coverage reports are properly generated locally and should work on CI as well.

Closes #1249

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [ ] Manual tests are explained, with instructions for reproducing them
