### PR TITLE
Upgrade to platformio 6.1.0

### DIFF
--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -26,7 +26,7 @@
 # CircleCI runs this script (via .circleci/config.yml), but might have some
 # environment differences, so the approximation is not perfect. For
 
-PIO_VERSION=6.0.2
+PIO_VERSION=6.1.0
 COVERAGE_ENVIRONMENT=native
 COVERAGE_OUTPUT_DIR=coverage_reports
 
@@ -110,21 +110,11 @@ install_linux() {
   pip3 install -U pip
   pip3 install codecov
   pip3 install platformio==${PIO_VERSION}
-
-  # upgrading platformio to development version to get proper code coverage reports
-  # TODO: remove this when platformio 6.1.0 goes live.
-  pio upgrade --dev
-
   source ${HOME}/.profile
 }
 
 update_platformio() {
   pip3 install platformio==${PIO_VERSION}
-
-  # upgrading platformio to development version to get proper code coverage reports
-  # TODO: remove this when platformio 6.1.0 goes live.
-  pio upgrade --dev
-
   pio pkg uninstall -d .
   pio pkg install -d .
   exit $EXIT_SUCCESS

--- a/software/controller/README.md
+++ b/software/controller/README.md
@@ -46,10 +46,10 @@ Instructions for installing:
  * [CLI](https://docs.platformio.org/en/latest/core/index.html)
  * [IDE](https://docs.platformio.org/en/latest/integration/ide/pioide.html)
 
-Some issues may prevent specific versions of platformio from building or running unit tests. It is currently recommended that you use `v6.0.1` (latest version at the time of this writing), which you may install with i.e.:
+Some issues may prevent specific versions of platformio from building or running unit tests. It is currently recommended that you use `v6.1.0` (latest version at the time of this writing), which you may install with i.e.:
 
 ```
-$ pip install platformio==6.0.1
+$ pip install platformio==6.1.0
 ```
 
 You may also need to install the package `libtinfo5` on Linux. Clang-tidy needs this package to run its checks, but platformio will just say all checks have passed without giving an error if it's missing.

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -32,7 +32,7 @@
 # - They have to have a very good chance of passing for other
 #   developers if they run via ./controller.sh test
 
-PIO_VERSION=6.0.2
+PIO_VERSION=6.1.0
 COVERAGE_ENVIRONMENT=native
 COVERAGE_OUTPUT_DIR=coverage_reports
 
@@ -118,11 +118,6 @@ install_linux() {
   pip3 install -U pip
   pip3 install codecov pyserial matplotlib pandas gitpython
   pip3 install platformio==${PIO_VERSION}
-
-  # upgrading platformio to development version to get proper code coverage reports
-  # TODO: remove this when platformio 6.1.0 goes live.
-  pio upgrade --dev
-
   source ${HOME}/.profile
 }
 
@@ -138,11 +133,6 @@ configure_platformio() {
 
 update_platformio() {
   pip3 install platformio==${PIO_VERSION}
-
-  # upgrading platformio to development version to get proper code coverage reports
-  # TODO: remove this when platformio 6.1.0 goes live.
-  pio upgrade --dev
-
   pio pkg uninstall -d .
   pio pkg install -d .
   exit $EXIT_SUCCESS

--- a/software/controller/integration_tests/main.cpp
+++ b/software/controller/integration_tests/main.cpp
@@ -1,11 +1,3 @@
-// Manually including some headers here in order for ldf to find them:
-// see https://community.platformio.org/t/ldf-not-following-environment-variables-in-6-1-0rc1/28616
-/// \TODO: remove when (if) the above issue ever gets fixed
-#include "actuator_base.h"
-#include "hal.h"
-#include "interface.h"
-#include "sensors.h"
-
 // Using these compile-time defines to avoid multiple directories and mains
 
 #include INTEGRATION_TEST_H

--- a/software/controller/platformio.ini
+++ b/software/controller/platformio.ini
@@ -86,7 +86,7 @@ check_patterns =
   ; Do not include ../common/third_party
 
 [env:stm32]
-platform = ststm32@15.4.0
+platform = ststm32@15.4.1
 board = custom_stm32
 build_flags =
   ${env.build_flags}
@@ -99,7 +99,7 @@ extra_scripts =
 build_src_filter = +<src/>
 
 [env:integration-test]
-platform = ststm32@15.4.0
+platform = ststm32@15.4.1
 board = custom_stm32
 build_flags =
   ${env.build_flags}


### PR DESCRIPTION
# Description
Platformio 6.1.0 is out, we can get rid of the development version which we used to get proper coverage reports, as well as the patch for the ldf bug when running integration tests, which was fixed as well.

Took advantage of this to upgrade to latest ststm32 package which released last week.
I built and loaded to my vent to test for regression, found none.

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers
