### PR TITLE
Ventilator serial number saved as string

### DIFF
--- a/manufacturing/peripherals.md
+++ b/manufacturing/peripherals.md
@@ -11,13 +11,13 @@ BEFORE purchasing any parts.**
 
 [ppg]: purchasing_guidelines.md
 
-| Item | Quantity | Manufacturer  | Part Number        | Price (USD) | Sources[*][ppg]         | Notes |
-| ---- |---------:| --------------| ------------------ | -----------:|:-----------------------:| ----- |
-|**A1**| 1        | Mean Well     | GSM160A12-R7B      | 63.99       | [K][a1key]              | 12v Power supply adapter, medical grade, 11.5A |
-|**A2**| 1        | Cablelera     | ZWACPCAY-10        | 8.99        | [Z][a2amzn]             | Hospital grade power cord |
-|**A3**| (1)      | Anker         | 68ANREADER-B2A     | 12.99       | [Z][a3amzn]             | microSD-USB adapter, for flashing RasPi images |
-|**A4**| (1)      | Monoprice     | 3896               | 0.83        | [Z][a4amzn] [O][a4mono] | USB-A to miniUSB-B cable, for programming the nucleo |
-|**A5**| (1)      | VicTsing      | IC192305US         | 23.99       | [Z][a5amzn]             | Wireless keyboard and mouse, for setting up Rpi, **OPTIONAL** |
+| Item | Quantity | Manufacturer  | Part Number        | Price (USD) | Sources[*][ppg] | Notes |
+| ---- |---------:| --------------| ------------------ | -----------:|:---------------:| ----- |
+|**A1**| 1        | Mean Well     | GSM160A12-R7B      | 63.99       |   [K][a1key]    | 12v Power supply adapter, medical grade, 11.5A |
+|**A2**| 1        | Cablelera     | ZWACPCAY-10        | 8.99        |   [Z][a2amzn]   | Hospital grade power cord |
+|**A3**| (1)      | Anker         | 68ANREADER-B2A     | 12.99       |   [Z][a3amzn]   | microSD-USB adapter, for flashing RasPi images |
+|**A4**| (1)      | Monoprice     | 3896               | 0.83        |  [Z][a4amzn]    | USB-A to miniUSB-B cable, for programming the nucleo |
+|**A5**| (1)      | VicTsing      | IC192305US         | 23.99       |   [Z][a5amzn]   | Wireless keyboard and mouse, for setting up Rpi, **OPTIONAL** |
 
 **Essentials (A1+A2):** USD 72.98
 
@@ -25,7 +25,6 @@ BEFORE purchasing any parts.**
 [a2amzn]: https://www.amazon.com/Cablelera-North-American-Hospital-ZWACPCAY-10/dp/B00GP6CB5A
 [a3amzn]: https://www.amazon.com/Anker-Portable-Reader-RS-MMC-Micro/dp/B006T9B6R2
 [a4amzn]: https://www.amazon.com/AmazonBasics-USB-2-0-Cable-Male/dp/B00NH13S44/
-[a4mono]: https://www.monoprice.com/product?p_id=3896
 [a5amzn]: https://www.amazon.com/VicTsing-Keyboard-Adjustable-Independent-Indicator/dp/B07TT3VN4X
 
 

--- a/software/controller/lib/non_volatile/nvparams.h
+++ b/software/controller/lib/non_volatile/nvparams.h
@@ -23,11 +23,14 @@ limitations under the License.
 #include "network_protocol.pb.h"
 #include "units.h"
 
+/// \todo This parameter might be better kept in system_constants? And use template here?
 // Actuators calibration size, defined here because the tables are stored in NVParams.
 // Size 11 means the settings are given with a 10% output increment between two points.
 static constexpr size_t ActuatorsCalSize{11};
 
 namespace NVParams {
+
+static constexpr size_t SerialNumLength{20};
 
 // This structure defines the layout of the non-volatile
 // parameter info stored in the I²C EEPROM.
@@ -50,7 +53,7 @@ struct Structure {
 
   uint8_t reserved{0};  // Kept here for 32bits-alignment's sake
 
-  uint32_t vent_serial_number{0};
+  char vent_serial[SerialNumLength]{0};
   // Non-volatile parameters should be added here
   uint32_t power_cycles{0};       // Count of device ON/OFF cycles.
   uint32_t cumulated_service{0};  // Cumulated power-ON time, stored in seconds.

--- a/software/utils/debug/controller_debug.py
+++ b/software/utils/debug/controller_debug.py
@@ -135,7 +135,10 @@ class ControllerDebugInterface:
         # we do this just for the git info
         test = TestData(test_scenario.TestScenario())
 
-        # \TODO check that serial number is valid?
+        try:
+            sn = self.variable_get("0_ventilator_serial_number")
+        except Exception as e:
+            sn = "invalid"
 
         try:
             ctrl_version = self.variable_get("0_controller_version")
@@ -152,6 +155,7 @@ class ControllerDebugInterface:
         except Exception as e:
             ctrl_branch = "invalid"
 
+        bad_serial = (len(sn) == 0) or (sn == "invalid")
         bad_version = (
             (ctrl_version == "invalid")
             or (ctrl_dirty == "invalid")
@@ -160,7 +164,8 @@ class ControllerDebugInterface:
         version_mismatch = test.git_version != ctrl_version
         branch_mismatch = test.git_branch != ctrl_branch
         problem = (
-            bad_version
+            bad_serial
+            or bad_version
             or version_mismatch
             or branch_mismatch
             or test.git_dirty
@@ -182,6 +187,8 @@ class ControllerDebugInterface:
                 " Potential controller version incompatibility or uncertain provenance "
             )
         )
+        if bad_serial:
+            print(red("    * ventilator serial number invalid"))
         if ctrl_version == "invalid":
             print(red("    * controller version invalid"))
         if ctrl_dirty == "invalid":

--- a/software/utils/debug/debug_cli.py
+++ b/software/utils/debug/debug_cli.py
@@ -120,11 +120,8 @@ class CmdLine(cmd.Cmd):
         if mode == MODE_BOOT:
             self.prompt = orange(f"[{self.interface.serial_port.port}:boot] ")
         else:
-            sn = self.interface.variable_get("0_ventilator_serial_number", raw=True)
-            if sn > 0:
-                self.prompt = green(f"[sn:{sn}] ")
-            else:
-                self.prompt = green(f"[port:{self.interface.serial_port.port}] ")
+            sn = self.interface.variable_get("0_ventilator_serial_number")
+            self.prompt = green(f"[sn:{sn}] ")
 
     def cli_loop(self):
         self.autoload()

--- a/software/utils/debug/var_info.py
+++ b/software/utils/debug/var_info.py
@@ -193,5 +193,13 @@ class VarInfo:
                     f"FloatArray size mismatch. Should be {self.size()}, was {len(float_array)}"
                 )
             return debug_types.float32s_to_bytes(float_array)
+        elif self.type == VAR_STRING:
+            if not isinstance(value, str):
+                raise TypeError(f"Expected type STRING, got {val_type}")
+            if len(value) > self.size():
+                raise Error(
+                    f"String size exceeds limit. Should be {self.size()}, was {len(value)}"
+                )
+            return list(value.ljust(self.size(), "\0").encode("ascii", "replace"))
         else:
             raise Error(f"Sorry, I don't know how to handle variable type {self.type}")


### PR DESCRIPTION
This changes the `0_ventilator_serial_number` debug variable from integer to string, so we can have semantically interesting unit descriptors in it, such as `v03e2` for the 2nd enclosed prototype of the v0.3 line. Will be even more important if various spin-offs and startups start using our software.

A knock-on effect is that the non-volatile memory implementation and tests had to be updated.

To make it work, I have also updated the debug interface, which did not have facilities for serializing string debug vars. This is the first writable one.

Closes #376

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them
