### PR TITLE
Documentation scripts improved, especially for wiring assemblies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: Check for broken links
           command: |
-            git ls-files -z '**/*.md' | xargs -0 liche -d . -x "amazon.com|mouser.com|cypress.com|digikey.com|st.com|rsdelivers.com|platformio.org|smcpneumatics.com|all3dp.com|uflowvalve.com" -t 30
+            git ls-files -z '**/*.md' | xargs -0 liche -d . -x "amazon.com|mouser.com|cypress.com|digikey.com|st.com|rsdelivers.com|platformio.org|smcpneumatics.com|all3dp.com|uflowvalve.com|aliexpress.us" -t 30
 
   common-precommit-checks:
     docker:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,8 @@ name: Docs
 
 on:
   push:
-#    branches:
-#    - master
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,8 @@ name: Docs
 
 on:
   push:
-    branches:
-    - master
+#    branches:
+#    - master
 
 jobs:
   build:
@@ -15,28 +15,19 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: Requirements
-        run: sudo apt-get install graphviz
-          && sudo apt-get install doxygen
-          && pip3 install sphinx-rtd-theme
-          && pip3 install breathe
-          && pip3 install sphinx-sitemap
-          && pip3 install mlx.traceability
-          && pip3 install wireviz
-          && pip3 install pandas
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Install requirements
+        run: cd docs
+          && ./docs.sh install
       - name: Pull in relevant images only
         run: git lfs pull -I "docs/wiring/images/*.png"
       - name: Build docs
         run: cd docs
-          && wiring/make_wiring.sh
-          && purchasing/make_parts.sh
-          && make html
-          && cd _build/html
-          && touch .nojekyll
+          && ./docs.sh build
+          && touch _build/html/.nojekyll
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@4.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ cscope.out
 *.lck
 OldVersions/
 
-gui/build
 .DS_Store
 .clangd/
 .*.swp

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,26 +18,32 @@ C++ API documentation is generated using [Doxygen](https://github.com/doxygen/do
 
 Frequently used values that may change can be defined in the `conf.py` file in the `rst_prolog` section. The `rst_prolog` gets including in every `.rst` file and the variables can be referenced by using the format `|VARIABLE_NAME|` which will get expanded into the generated text.
 
-## Building the docs locally
+## Building the docs
 
-Install `Doxygen`, `Graphviz` and `Make` using your system package manager. For example, On Ubuntu, use:
+Use the [docs.sh](docs.sh) script in this directory to install required dependencies and build the documentation.
+
+To install all needed dependencies (do this once on your development machine):
+
 ```shell
-apt-get install make doxygen graphviz
+./docs.sh install
 ```
 
-Install Sphinx and the necessary extensions:
+To generate the documentation, run:
+
 ```shell
-pip install sphinx sphinx-rtd-theme breathe sphinx_sitemap mlx.traceability wireviz pandas
+./docs.sh build
 ```
 
-Then, to generate the docs, just run:
+If the directories are polluted and you want a clean slate:
 ```shell
-wiring/make_wiring.sh
-purchasing/make_parts.sh
-make html
+./docs.sh clean
 ```
 
-The generated output can be viewed by opening the file `docs/_build/html/index.html`
+The generated output can be viewed by opening the file `docs/_build/html/index.html`, or you can run this script to have it open it up for you in your browser:
+
+```shell
+./docs.sh view
+```
 
 ## Additional features and scripts
 

--- a/docs/docs.sh
+++ b/docs/docs.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Copyright 2020-2022, RespiraWorks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OUTPUT_DIR=_build
+
+# Fail if any command fails
+set -e
+set -o pipefail
+
+# Print each command as it executes
+if [ -n "$VERBOSE" ]; then
+  set -o xtrace
+fi
+
+# This script should work no matter where you call it from.
+cd "$(dirname "$0")"
+
+EXIT_FAILURE=1
+EXIT_SUCCESS=0
+
+# Check if Linux
+PLATFORM="$(uname -s)"
+if [ $PLATFORM != "Linux" ]; then
+  echo "Error: This script only supports 'Linux'. You have $PLATFORM."
+  exit $EXIT_FAILURE
+fi
+
+print_help() {
+    cat <<EOF
+Utility script for generating Ventilator documentation.
+
+The following options are available:
+  install     One-time installation of build toolchain and dependencies
+  clean       Clean build directories
+  build       Generate documentation
+  view        Open generated documentation in browser
+  help/-h     Display this help info
+EOF
+}
+
+clean_all() {
+  clean_dir ${OUTPUT_DIR}
+  # \todo clean intermediate files from wiring and parts
+}
+
+clean_dir() {
+  dir_name=$1
+  if [ -d "$dir_name" ]; then
+    echo "Removing $dir_name"
+    rm -rf "$dir_name"
+    return 0
+  elif [ -f "$dir_name" ]; then
+    echo "File with this name already exists, not a directory."
+    return 1
+  fi
+}
+
+install_linux() {
+  sudo apt-get update
+  sudo apt-get install -y \
+               make \
+               doxygen \
+               graphviz
+  pip3 install -U pip
+  pip3 install sphinx-rtd-theme breathe sphinx-sitemap mlx.traceability wireviz pandas
+  source ${HOME}/.profile
+}
+
+build_all() {
+  source ${HOME}/.profile
+  ./wiring/make_wiring.sh
+  ./purchasing/make_parts.sh
+  make html
+}
+
+launch_browser() {
+  python3 -m webbrowser "${OUTPUT_DIR}/html/index.html"
+}
+
+########
+# HELP #
+########
+
+if [ "$1" == "help" ] || [ "$1" == "-h" ]; then
+  print_help
+  exit $EXIT_SUCCESS
+
+###########
+# INSTALL #
+###########
+elif [ "$1" == "install" ]; then
+  if [ "$EUID" -eq 0 ] && [ -z "$FORCED_ROOT" ]; then
+    echo "Please do not run install with root privileges!"
+    exit $EXIT_FAILURE
+  fi
+  install_linux
+  exit $EXIT_SUCCESS
+
+#########
+# CLEAN #
+#########
+elif [ "$1" == "clean" ]; then
+  clean_all
+  exit $EXIT_SUCCESS
+
+########
+# MAKE #
+########
+elif [ "$1" == "build" ]; then
+  if [ "$EUID" -eq 0 ] && [ -z "$FORCED_ROOT" ]; then
+    echo "Please do not run build with root privileges!"
+    exit $EXIT_FAILURE
+  fi
+  build_all
+  exit $EXIT_SUCCESS
+
+########
+# VIEW #
+########
+elif [ "$1" == "view" ]; then
+  if [ "$EUID" -eq 0 ] && [ -z "$FORCED_ROOT" ]; then
+    echo "Please do not run view with root privileges!"
+    exit $EXIT_FAILURE
+  fi
+  launch_browser
+  exit $EXIT_SUCCESS
+
+################
+# ERROR & HELP #
+################
+else
+  echo "ERROR: Bad command or insufficient parameters!"
+  echo
+  print_help
+  exit $EXIT_FAILURE
+fi

--- a/docs/docs.sh
+++ b/docs/docs.sh
@@ -73,7 +73,8 @@ install_linux() {
   sudo apt-get install -y \
                make \
                doxygen \
-               graphviz
+               graphviz \
+               python3-pip
   pip3 install -U pip
   pip3 install sphinx-rtd-theme breathe sphinx-sitemap mlx.traceability wireviz pandas
   source ${HOME}/.profile

--- a/docs/docs.sh
+++ b/docs/docs.sh
@@ -64,7 +64,7 @@ clean_dir() {
     return $EXIT_SUCCESS
   elif [ -f "$dir_name" ]; then
     echo "File with this name already exists, not a directory."
-    return 1
+    return $EXIT_FAILURE
   fi
 }
 

--- a/docs/docs.sh
+++ b/docs/docs.sh
@@ -61,7 +61,7 @@ clean_dir() {
   if [ -d "$dir_name" ]; then
     echo "Removing $dir_name"
     rm -rf "$dir_name"
-    return 0
+    return $EXIT_SUCCESS
   elif [ -f "$dir_name" ]; then
     echo "File with this name already exists, not a directory."
     return 1

--- a/docs/purchasing/make_parts.sh
+++ b/docs/purchasing/make_parts.sh
@@ -37,3 +37,5 @@ if [ $PLATFORM != "Linux" ]; then
 fi
 
 ./make_parts.py
+
+exit $EXIT_SUCCESS

--- a/docs/wiring/make_wiring.sh
+++ b/docs/wiring/make_wiring.sh
@@ -36,5 +36,11 @@ if [ $PLATFORM != "Linux" ]; then
   exit $EXIT_FAILURE
 fi
 
-wireviz power_entry.yml
-./decorate_table.py power_entry.bom.tsv
+for filename in ./*.yml; do
+  stripped_name=$(basename "$filename" .yml)
+  echo "Processing wiring documentation for '${stripped_name}'"
+  wireviz ${filename}
+  ./decorate_table.py ${stripped_name}.bom.tsv
+done
+
+exit $EXIT_SUCCESS

--- a/manufacturing/internals/blower/README.md
+++ b/manufacturing/internals/blower/README.md
@@ -48,7 +48,7 @@ BEFORE purchasing any parts.**
 
 **Total assembly price:** USD 84.02
 
-[a1ali]:   https://www.aliexpress.com/item/32980201709.html
+[a1ali]:   https://www.aliexpress.us/item/2251832793886957.html
 [a2won]:   https://wonsmart-motor.en.made-in-china.com/product/hsjxFewOppVg/China-Air-Pump12V-Brushless-Motor-12V-Blower-Fan-Driver.html
 [a3rw]:    #tubing-adapter-c1
 [a4mcmc]:  https://www.mcmaster.com/8560K357/

--- a/manufacturing/internals/display_panel/README.md
+++ b/manufacturing/internals/display_panel/README.md
@@ -39,7 +39,7 @@ BEFORE purchasing any parts.**
 [a2mcmc]: https://www.mcmaster.com/96439A650/
 [a3mcmc]:  https://www.mcmaster.com/8560K357/
 [a4rw]:    #display-panel-acrylic-plate
-[a5ali]:   https://www.aliexpress.com/item/4000747984746.html
+[a5ali]:   https://www.aliexpress.us/item/2255800561669994.html
 [a5amzn]:  https://www.amazon.com/Eviciv-Portable-Monitor-Display-1024X600/dp/B07L6WT77H
 [a6mcmc]:  https://www.mcmaster.com/93625A102/
 [a7mcmc]:  https://www.mcmaster.com/98689A111/


### PR DESCRIPTION
This adds a `docs/docs.sh` script in the style of what we have for the software suites, that can:
* install dependencies
* build all documentation
* clean the build directory
* open up a browser to see a preview

Deployment scripts for github workflows and pertinent documentation have also been updated.
As a knock-on effect, wiki tutorial on how to do wiring documentation might have to be updated, @inceptionev 

Updates #1260

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them