### PR TITLE
Instructions to run unit tests for debug interface locally

### DIFF
--- a/software/utils/debug/README.md
+++ b/software/utils/debug/README.md
@@ -124,3 +124,10 @@ Test scenarios are defined in `json` files in the [test_scenarios](test_scenario
 
 ### run
 This command takes the name of a python script and executes it in the same environment that the debug program runs in.  This allows the script to use functions defined in the debug tool to do things like get or set variables. The debug tool will search for scripts in the [scripts](scripts) subdirectory. These scripts may take additional parameters.
+
+## Unit Tests
+The unit tests for the debug interface were created using pytest. To run them manually, run the following command in Bash (not in the debug interface) within this working directory (`Ventilator/software/utils/debug`):
+```bash
+pytest --verbose unit_test.py
+```
+Omit the verbose flag if you only need to see failed tests.

--- a/software/utils/debug/README.md
+++ b/software/utils/debug/README.md
@@ -126,8 +126,15 @@ Test scenarios are defined in `json` files in the [test_scenarios](test_scenario
 This command takes the name of a python script and executes it in the same environment that the debug program runs in.  This allows the script to use functions defined in the debug tool to do things like get or set variables. The debug tool will search for scripts in the [scripts](scripts) subdirectory. These scripts may take additional parameters.
 
 ## Unit Tests
-The unit tests for the debug interface were created using pytest. To run them manually, run the following command in Bash (not in the debug interface) within this working directory (`Ventilator/software/utils/debug`):
+### Local Setup
+The unit tests for the debug interface were created using pytest. The pytest package is installed automatically by the `install` step of the common controller utilities script (`controller.sh install`). To install the standalone package, install it via pip:
 ```bash
-pytest --verbose unit_test.py
+pip3 install pytest
+```
+
+### Running Unit Tests Locally
+To run the unit tests, run the following command in Bash (not in the debug interface) within this working directory (`Ventilator/software/utils/debug`):
+```bash
+python3 -m pytest --verbose unit_test.py
 ```
 Omit the verbose flag if you only need to see failed tests.

--- a/software/utils/debug/README.md
+++ b/software/utils/debug/README.md
@@ -127,10 +127,7 @@ This command takes the name of a python script and executes it in the same envir
 
 ## Unit Tests
 ### Local Setup
-The unit tests for the debug interface were created using pytest. The pytest package is installed automatically by the `install` step of the common controller utilities script (`controller.sh install`). To install the standalone package, install it via pip:
-```bash
-pip3 install pytest
-```
+The unit tests for the debug interface were created using pytest. Necessary dependencies will be installed by the [controller.sh](../../controller/controller.sh) script.
 
 ### Running Unit Tests Locally
 To run the unit tests, run the following command in Bash (not in the debug interface) within this working directory (`Ventilator/software/utils/debug`):


### PR DESCRIPTION
# Description

Summary of changes
Added instructions to run unit tests locally for the debug interface.

Relevant motivation and context
Developing the interface and adding new unit tests require running unit tests locally.

Dependencies that are required for this change
None

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them
