### PR TITLE
Fixed CircleCI Ubuntu image bug and updated VM images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
           command: |
             sudo rm -rf /var/lib/apt/lists/*
             export FORCED_ROOT=1
-            export VERBOSE=1
             ./software/common/common.sh install
       - run:
           name: Run tests & publish coverage
@@ -52,8 +51,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo rm -rf /var/lib/apt/lists/*
             export FORCED_ROOT=1
-            export VERBOSE=1
             ./software/controller/controller.sh install
       - run:
           name: Run tests & publish coverage
@@ -72,8 +71,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo rm -rf /var/lib/apt/lists/*
             export FORCED_ROOT=1
-            export VERBOSE=1
             ./software/gui/gui.sh install
       - run:
           name: Build and run app
@@ -98,6 +97,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo rm -rf /var/lib/apt/lists/*
             export FORCED_ROOT=1
             ./software/controller/controller.sh install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo rm -rf /var/lib/apt/lists/*
             export FORCED_ROOT=1
             export VERBOSE=1
             ./software/common/common.sh install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           name: Install dependencies
           command: |
             export FORCED_ROOT=1
+            export VERBOSE=1
             ./software/common/common.sh install
       - run:
           name: Run tests & publish coverage
@@ -51,6 +52,7 @@ jobs:
           name: Install dependencies
           command: |
             export FORCED_ROOT=1
+            export VERBOSE=1
             ./software/controller/controller.sh install
       - run:
           name: Run tests & publish coverage
@@ -70,6 +72,7 @@ jobs:
           name: Install dependencies
           command: |
             export FORCED_ROOT=1
+            export VERBOSE=1
             ./software/gui/gui.sh install
       - run:
           name: Build and run app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
   common-tests:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     environment:
       GIT_LFS_SKIP_SMUDGE: 1
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   controller-tests:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     environment:
       GIT_LFS_SKIP_SMUDGE: 1
     resource_class: large
@@ -60,7 +60,7 @@ jobs:
 
   gui-tests:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     environment:
       GIT_LFS_SKIP_SMUDGE: 1
@@ -85,7 +85,7 @@ jobs:
 
   debug-tests:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     environment:
       GIT_LFS_SKIP_SMUDGE: 1
     resource_class: medium


### PR DESCRIPTION
# Description

`apt update` was failing on all jobs because of some packages that we don't even use.

Applied solution described here: https://support.circleci.com/hc/en-us/articles/360051749992-Build-Fails-Using-apt-get-update-Command

Also used the opportunity to update our packages to the currently supported LTS images of Ubuntu 2022-04.

Closes #1319
