### PR TITLE
Routine deployment and CI script maintenance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           && ./docs.sh build
           && touch _build/html/.nojekyll
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.1
+        uses: lycheeverse/lychee-action@v1.6.1
         with:
           fail: true
           # Check all markdown and html files
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Deploy to Github Pages
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: JamesIves/github-pages-deploy-action@4.0.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages # The branch the action should deploy to.

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -82,6 +82,7 @@ exclude = [
     '.*\.st.com\.*',
     '.*\.uflowvalve.com\.*',
     '.*\.valispace.com\.*',
+    '.*\wonsmart-motor.en.made-in-china.com\.*',
 ]
 
 # Exclude these filesystem paths from getting checked.

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -1,8 +1,5 @@
 #############################  Display  #############################
 
-# Verbose program output
-verbose = false
-
 # Don't show interactive progress bar while checking links.
 no_progress = true
 

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -131,7 +131,7 @@ install_linux() {
 
 configure_platformio() {
   echo 'ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="666"' | sudo tee /etc/udev/rules.d/99-openocd.rules > /dev/null
-  curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
+  curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
   sudo service udev restart
   sudo usermod -a -G dialout "$USER"
   sudo usermod -a -G plugdev "$USER"

--- a/software/gui/gui.sh
+++ b/software/gui/gui.sh
@@ -126,7 +126,7 @@ configure_conan() {
   pip3 install gitpython
   pip3 install conan==$CONAN_VERSION
   conan --version
-  #source ${HOME}/.profile
+  . "${HOME}/.profile"
   conan profile new --detect default
   conan profile update settings.compiler.libcxx=libstdc++11 default
 }

--- a/software/gui/gui.sh
+++ b/software/gui/gui.sh
@@ -126,7 +126,7 @@ configure_conan() {
   pip3 install gitpython
   pip3 install conan==$CONAN_VERSION
   conan --version
-  . "${HOME}/.profile"
+  source "${HOME}/.profile"
   conan profile new --detect default
   conan profile update settings.compiler.libcxx=libstdc++11 default
 }


### PR DESCRIPTION
# Description

Recent attempt to do a fresh deploy to the v0.3 enclosed in Maryland resulted in some issues:
* bootstrap script failed out because looks like a line was commented out that sources .profile to make conan executable visible
* the URL changed for downloading the platformio udev rules

CMake scripts for conan v.2.0 are still not on the main channel, so the ticket must remain open as we periodically check for updates.

Updates #1324

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them
