### PR TITLE
Platformio version bump

### DIFF
--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -27,7 +27,7 @@
 # environment differences, so the approximation is not perfect. For
 
 # \todo: keep PIO_VERSION updated, test thoroughly whenever you do, leave this "todo" here
-PIO_VERSION=6.1.0
+PIO_VERSION=6.1.6
 COVERAGE_ENVIRONMENT=native
 COVERAGE_OUTPUT_DIR=coverage_reports
 

--- a/software/controller/README.md
+++ b/software/controller/README.md
@@ -58,9 +58,9 @@ Instructions for installing:
  * [Platformio IDE](https://docs.platformio.org/en/latest/integration/ide/pioide.html)
  * [CLion](https://docs.platformio.org/en/latest/integration/ide/clion.html)
 
-Note: To use with CLion, it seems to work best if you run `pio init --ide clion` in this directory before loading the CMake files.
+Note: To use with CLion, it seems to work best if you run `pio project init --ide clion` in this directory before loading the CMake files.
 
-Some issues may prevent specific versions of platformio from building or running unit tests. It is currently recommended that you use `v6.1.0` (latest version at the time of this writing).
+Some issues may prevent specific versions of platformio from building or running unit tests. It is currently recommended that you use `v6.1.6` (latest version at the time of this writing).
 
 ## Building and testing
 

--- a/software/controller/README.md
+++ b/software/controller/README.md
@@ -68,11 +68,9 @@ After installing platformio, you should be able to build and run test as follows
 
 ```shell
 ./controller.sh test
-# This will run a few commands, such as "platformio run" and
-# "platformio test -e native".
 ```
 
-This is the same script that runs on our continuous integration server (Travis CI).
+This is the same script that runs on our continuous integration server (Travis CI) and will also perform static checks with `cppcheck` and `clang-tidy`.
 Run it frequently during development to catch errors/style violations early.
 
 Sometimes PlatformIO can get into a bad state - e.g. if things don't build for you in `master`, try:
@@ -155,57 +153,8 @@ If you have the environment variable `SN` set to a registered device alias, then
 
 For more info about the debug interface and other manual testing utilities, see the [../utils](../utils) directory.
 
-## Common problems
+## Further details
 
-These should mostly be addressed by the controller script. But just in case...
-
-### USB permission problems
-
-If `pio device list` did not show the Nucleo as, for example, when attempting to deploy directly from the Raspberry Pi, you may have to give yourself rw permission on the USB device.
-
-Find the device ID with `lsusb`. Let us assume in this case, that it shows `Bus 001 Device 004: ID 0483:374b STMicroelectronics ST-LINK/V2.1`.
-
-Add a udev rule for that device that mounts it with 666 permission. For example, create a file `/etc/udev/rules.d/99-openocd.rules` with the following line:
-
-```
-ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="666"
-```
-
-After that, either you unplug and re-plug the USB for STM32 or you restart the pi, you should see something like this:
-
-```
-pi@raspberrypi:~ $ pio device list
-/dev/ttyACM0
-------------
-Hardware ID: USB VID:PID=0483:374B SER=0663FF303435554157115746 LOCATION=1-1.4:1.2
-Description: STM32 STLink - ST-Link VCP Ctrl
-/dev/ttyAMA0
-------------
-Hardware ID: fe201000.serial
-Description: ttyAMA0
-```
-
-### Other udev problems
-
-If you get the following error, it means platformio was unable to find a connected device.
-
-```
-# This means pio couldn't find a device to upload to.  Check that it's connected?
-Error: Please specify `upload_port` for environment or use global `--upload-port` option.
-```
-
-You may have to modify your `udev` rule to enable flashing of the controller as follows:
-
-```
-curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
-sudo service udev restart
-sudo usermod -a -G dialout $USER
-sudo usermod -a -G plugdev $USER
-```
-and then either re-login or restart machine.
-
-For more details on this, see the following articles:
-[platformio FAQ](https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules)
-[community forums](https://community.platformio.org/t/stm32-vs-code-mbed-upload-issue-error-libusb-open-failed-with-libusb-error-access-error-open-failed/10650)
-
-Alternatively, you can upload the firmware.elf and firmware.bin files to the controller mounted as a USB storage device.
+Our automation scripts may not be up-to-date. If you encounter problems deploying to or connecting via debug interface, see the most up-to-date information here:
+* [platformio FAQ](https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules)
+* [platformio community forums](https://community.platformio.org/t/stm32-vs-code-mbed-upload-issue-error-libusb-open-failed-with-libusb-error-access-error-open-failed/10650)

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -33,7 +33,7 @@
 #   developers if they run via ./controller.sh test
 
 # \todo: keep PIO_VERSION updated, test thoroughly whenever you do, leave this "todo" here
-PIO_VERSION=6.1.0
+PIO_VERSION=6.1.6
 COVERAGE_ENVIRONMENT=native
 COVERAGE_OUTPUT_DIR=coverage_reports
 

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -334,19 +334,24 @@ run_all_integration_tests() {
   # Ends with putting controller in idle loop.
 
   eval "$(deploy_integration_test blower 0.0f 1.0f)"
-  sleep $wait_time
+  echo "<<<<< Verify that blower power is ramping up and down >>>>>"
+  sleep "$wait_time"
 
   eval "$(deploy_integration_test buzzer 0.0f 1.0f)"
-  sleep $wait_time
+  echo "<<<<< Verify that buzzer is cycling at a range of volumes >>>>>"
+  sleep "$wait_time"
 
   eval "$(deploy_integration_test pinch_valve 0)"
-  sleep $wait_time
+  echo "<<<<< Verify that pinch valve 0 is cycling >>>>>"
+  sleep "$wait_time"
 
   eval "$(deploy_integration_test pinch_valve 1)"
-  sleep $wait_time
+  echo "<<<<< Verify that pinch valve 1 is cycling >>>>>"
+  sleep "$wait_time"
 
   eval "$(deploy_integration_test eeprom 0 85 10)"
-  sleep $wait_time
+  echo "<<<<< Buzzer should have briefly gone on and off to indicate successful EEPROM test >>>>>"
+  sleep "$wait_time"
 
   eval "$(deploy_integration_test idle)"
 }

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -414,7 +414,7 @@ elif [ "$1" == "check" ]; then
 elif [ "$1" == "unit" ]; then
   clean_all
 
-  if [ -n "$2" ]; then
+f-z  if [ -n "$2" ]; then
     pio test -e native -f "$2"
   else
     pio test -e native
@@ -521,7 +521,11 @@ elif [ "$1" == "integrate" ]; then
   print_device_info
   if [ "$2" == "all" ]
   then
-    run_all_integration_tests "$3"
+   if [ -z "$3" ]; then
+     echo "No delay time provided"
+     exit $EXIT_FAILURE
+   fi
+   run_all_integration_tests "$3"
   else
     deploy_integration_test "${@:2}"
   fi

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -414,7 +414,7 @@ elif [ "$1" == "check" ]; then
 elif [ "$1" == "unit" ]; then
   clean_all
 
-f-z  if [ -n "$2" ]; then
+  if [ -n "$2" ]; then
     pio test -e native -f "$2"
   else
     pio test -e native

--- a/software/controller/lib/debug/interface.h
+++ b/software/controller/lib/debug/interface.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include <array>
 #include <optional>
 
 #include "debug_types.h"
@@ -74,9 +75,10 @@ class Interface {
   // Minimum debug message size is 3 bytes: 1 byte gives the command (respectively
   // the error code for responses), and 2 bytes are used for checksum.
   static constexpr size_t MinFrameSize{3};
+  static constexpr size_t BufferSize{500};
 
   // Buffer into which request data is written in AwaitingCommand state
-  uint8_t request_[500] = {0};
+  std::array<uint8_t, BufferSize> request_ = {0};
   size_t request_size_{0};
   // Remember when we receive an escape char (in case the call happens in
   // between the escape char and the special char)
@@ -84,7 +86,7 @@ class Interface {
 
   // Buffer into which the command handler writes its response and which is then
   // sent in Responding state.
-  uint8_t response_[500] = {0};
+  std::array<uint8_t, BufferSize> response_ = {0};
   size_t response_size_{0};
   size_t response_bytes_sent_{0};
 

--- a/software/controller/platformio/build_config/auto_firmware_version.py
+++ b/software/controller/platformio/build_config/auto_firmware_version.py
@@ -20,11 +20,16 @@ __license__ = """
 
 """
 
+Import("env")
+
+# List installed packages
+env.Execute("$PYTHONEXE -m pip list")
+
+# Install custom packages from the PyPi registry
+env.Execute("$PYTHONEXE -m pip install GitPython")
 
 import git
 from datetime import datetime
-
-Import("env")
 
 
 def get_firmware_specifier_build_flag():


### PR DESCRIPTION
# Description

* bumped to latest platformio version
* updated related installation/configuration/build scripts
* updated debug interface to use `<array>` as current implementation fails on newer compilers (GCC 12.2.0 in this case)
* few additional changes to address new clang-tidy warnings
* note, additional clang-tidy warnings abound throughout the rest of the code, but only fixing in files touched by the purpose of this PR
* regression validated with integration and lung-in-the-loop tests
* simplified controller README, because many of the manual config steps are now done by our script and we don't want to have double the maintenance burden.

## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them
