### PR TITLE
Removes installation of deprecated codecov pip package

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,5 +1,4 @@
 codecov:
-  token: a570973b-0fb7-4c26-867c-ce2fc9d7458e
   require_ci_to_pass: no
 
 coverage:

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -111,7 +111,7 @@ install_linux() {
                clang-tidy \
                protobuf-compiler
   pip3 install -U pip
-  pip3 install codecov nanopb
+  pip3 install nanopb
   pip3 install platformio==${PIO_VERSION}
   source ${HOME}/.profile
 }


### PR DESCRIPTION
# Description

Codecov have deprecated the pip package for their uploader:
https://about.codecov.io/blog/message-regarding-the-pypi-package/

Turns out we are already using their uploader correctly, but there was still a line to install the old pip package.
This has been eliminated.

Furthermore, the upload token has been renewed, removed from the repo and is now an environment variable provided by circleci. Security hole plugged.


## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- [x] All tests pass - new and old, locally and on CI
- [x] No new warnings or static check failures
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them