### PR TITLE
Maintain/update CI: Conan2, CodeCov upload script, dead links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
             ./software/common/common.sh test --cov --no-checks
             ./software/common/common.sh cov_upload
       - codecov/upload:
-          name: Upload coverage reports
           file: './software/common/coverage_reports/coverage.info'
           flags: 'common'
 
@@ -67,7 +66,6 @@ jobs:
             ./software/controller/controller.sh test --cov --no-checks
             ./software/controller/controller.sh cov_upload
       - codecov/upload:
-          name: Upload coverage reports
           file: './software/controller/coverage_reports/coverage.info'
           flags: 'controller'
 
@@ -98,7 +96,6 @@ jobs:
             export FORCED_ROOT=1
             ./software/gui/gui.sh test -j
       - codecov/upload:
-          name: Upload coverage reports
           file: './software/gui/coverage_reports/coverage.info'
           flags: 'gui'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,9 @@ jobs:
           command: |
             ./software/controller/controller.sh test --cov --no-checks
             ./software/controller/controller.sh cov_upload
+      - codecov/upload:
+          file: './software/common/coverage_reports/coverage.info'
+          flags: 'controller'
 
   gui-tests:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             ./software/controller/controller.sh test --cov --no-checks
             ./software/controller/controller.sh cov_upload
       - codecov/upload:
-          file: './software/common/coverage_reports/coverage.info'
+          file: './software/controller/coverage_reports/coverage.info'
           flags: 'controller'
 
   gui-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   pre-commit-checks:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.12.3
     environment:
       GIT_LFS_SKIP_SMUDGE: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,12 @@ jobs:
             export FORCED_ROOT=1
             ./software/common/common.sh install
       - run:
-          name: Run tests & publish coverage
+          name: Run tests & generate coverage reports
           command: |
             ./software/common/common.sh test --cov --no-checks
             ./software/common/common.sh cov_upload
       - codecov/upload:
+          name: Upload coverage reports
           file: './software/common/coverage_reports/coverage.info'
           flags: 'common'
 
@@ -61,11 +62,12 @@ jobs:
             export FORCED_ROOT=1
             ./software/controller/controller.sh install
       - run:
-          name: Run tests & publish coverage
+          name: Run tests & generate coverage reports
           command: |
             ./software/controller/controller.sh test --cov --no-checks
             ./software/controller/controller.sh cov_upload
       - codecov/upload:
+          name: Upload coverage reports
           file: './software/controller/coverage_reports/coverage.info'
           flags: 'controller'
 
@@ -91,11 +93,12 @@ jobs:
             ./software/gui/gui.sh build -j --no-checks
             ./software/gui/gui.sh run --startup-only
       - run:
-          name: Run tests & publish coverage
+          name: Run tests & generate coverage reports
           command: |
             export FORCED_ROOT=1
             ./software/gui/gui.sh test -j
       - codecov/upload:
+          name: Upload coverage reports
           file: './software/gui/coverage_reports/coverage.info'
           flags: 'gui'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
-
+orbs:
+  codecov: codecov/codecov@1.0.2
 jobs:
   pre-commit-checks:
     docker:
@@ -40,6 +41,9 @@ jobs:
           command: |
             ./software/common/common.sh test --cov --no-checks
             ./software/common/common.sh cov_upload
+      - codecov/upload:
+          file: './software/common/coverage_reports/coverage.info'
+          flags: common
 
   controller-tests:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,10 @@ jobs:
           name: Run tests & publish coverage
           command: |
             export FORCED_ROOT=1
-            ./software/gui/gui.sh test -j --upload-cov
+            ./software/gui/gui.sh test -j
+      - codecov/upload:
+          file: './software/gui/coverage_reports/coverage.info'
+          flags: 'gui'
 
   debug-tests:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,7 @@ jobs:
             ./software/common/common.sh test --cov --no-checks
             ./software/common/common.sh cov_upload
       - codecov/upload:
-          file: './software/common/coverage_reports/coverage.info'
-          flags: common
+          flags: 'common'
 
   controller-tests:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
             ./software/common/common.sh test --cov --no-checks
             ./software/common/common.sh cov_upload
       - codecov/upload:
+          file: './software/common/coverage_reports/coverage.info'
           flags: 'common'
 
   controller-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: Run tests & generate coverage reports
           command: |
             ./software/common/common.sh test --cov --no-checks
-            ./software/common/common.sh cov_upload
+            ./software/common/common.sh cov_cleanup
       - codecov/upload:
           file: './software/common/coverage_reports/coverage.info'
           flags: 'common'
@@ -64,7 +64,7 @@ jobs:
           name: Run tests & generate coverage reports
           command: |
             ./software/controller/controller.sh test --cov --no-checks
-            ./software/controller/controller.sh cov_upload
+            ./software/controller/controller.sh cov_cleanup
       - codecov/upload:
           file: './software/controller/coverage_reports/coverage.info'
           flags: 'controller'

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ fp-info-cache
 #performance test data
 local_data/
 test_data/
+
+#Conan created files
+CMakeUserPresets.json

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -80,6 +80,7 @@ exclude = [
     '.*\.uflowvalve.com\.*',
     '.*\.valispace.com\.*',
     '.*\wonsmart-motor.en.made-in-china.com\.*',
+    '.*\.raspberrypi.com\.*'
 ]
 
 # Exclude these filesystem paths from getting checked.

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -191,7 +191,7 @@ upload_coverage_reports() {
 
 #  echo "Uploading to codecov..."
 
-  codecovcli do-upload --flag common
+#  codecovcli do-upload --flag common
 }
 
 generate_coverage_reports() {

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -109,10 +109,10 @@ install_linux() {
                gcovr \
                lcov \
                clang-tidy \
-               protobuf-compiler \
-               codecov-cli
+               protobuf-compiler
   pip3 install -U pip
   pip3 install nanopb
+  pip3 install codecov-cli
   pip3 install platformio==${PIO_VERSION}
   source ${HOME}/.profile
 }

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -112,7 +112,7 @@ install_linux() {
                protobuf-compiler
   pip3 install -U pip
   pip3 install nanopb
-  pip3 install codecov-cli
+#  pip3 install codecov-cli
   pip3 install platformio==${PIO_VERSION}
   source ${HOME}/.profile
 }
@@ -165,9 +165,9 @@ run_checks() {
 }
 
 upload_coverage_reports() {
-  echo "Uploading coverage reports to Codecov"
+#  echo "Uploading coverage reports to Codecov"
 
-  echo "Generating test coverage reports for controller and common code..."
+  echo "Generating test coverage reports for common code..."
 
   SRC_DIR=".pio/build/$COVERAGE_ENVIRONMENT"
 
@@ -188,7 +188,9 @@ upload_coverage_reports() {
   rm $COVERAGE_OUTPUT_DIR/processed/test*
   rm $COVERAGE_OUTPUT_DIR/processed/.pio*
 
-  codecovcli do-upload --flag common
+#  echo "Uploading to codecov..."
+
+#  codecovcli do-upload --flag common
 }
 
 generate_coverage_reports() {

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -109,10 +109,10 @@ install_linux() {
                gcovr \
                lcov \
                clang-tidy \
-               protobuf-compiler \
-               setuptools
+               protobuf-compiler
   pip3 install -U pip
   pip3 install nanopb
+  pip3 install setuptools
   pip3 install platformio==${PIO_VERSION}
   source ${HOME}/.profile
 }

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -72,7 +72,7 @@ The following options are available:
   test        Builds and runs all unit tests, integration tests, static checks, generates coverage
                 [--no-checks] - do not run static checks (for CI)
                 [--cov]       - generate coverage reports
-  cov_upload  Upload coverage reports to Codecov server
+  cov_cleanup Prepare coverage reports for uploading to server
   unit        Builds and runs unit tests only (and generates coverage reports)
                   <name>  - run specific unit test, may include wildcards, i.e. '*checksum*'
                   [-o]    - open coverage report in browser when done
@@ -112,8 +112,6 @@ install_linux() {
                protobuf-compiler
   pip3 install -U pip
   pip3 install nanopb
-  pip3 install coverage
-  pip3 install codecov-cli
   pip3 install platformio==${PIO_VERSION}
   source ${HOME}/.profile
 }
@@ -165,10 +163,8 @@ run_checks() {
     pio check -e native --fail-on-defect=high
 }
 
-upload_coverage_reports() {
-#  echo "Uploading coverage reports to Codecov"
-
-  echo "Generating test coverage reports for common code..."
+cleanup_coverage_reports() {
+  echo "Cleaning up coverage reports for common code..."
 
   SRC_DIR=".pio/build/$COVERAGE_ENVIRONMENT"
 
@@ -188,10 +184,6 @@ upload_coverage_reports() {
   rm $COVERAGE_OUTPUT_DIR/processed/#usr*
   rm $COVERAGE_OUTPUT_DIR/processed/test*
   rm $COVERAGE_OUTPUT_DIR/processed/.pio*
-
-#  echo "Uploading to codecov..."
-
-#  codecovcli do-upload --flag common
 }
 
 generate_coverage_reports() {
@@ -332,12 +324,11 @@ elif [ "$1" == "test" ]; then
 
   exit $EXIT_SUCCESS
 
-###################
-# UPLOAD COVERAGE #
-###################
-elif [ "$1" == "cov_upload" ]; then
-  upload_coverage_reports
-
+####################
+# CLEANUP COVERAGE #
+####################
+elif [ "$1" == "cov_cleanup" ]; then
+  cleanup_coverage_reports
   exit $EXIT_SUCCESS
 
 ##############################

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -112,7 +112,8 @@ install_linux() {
                protobuf-compiler
   pip3 install -U pip
   pip3 install nanopb
-#  pip3 install codecov-cli
+  pip3 install coverage
+  pip3 install codecov-cli
   pip3 install platformio==${PIO_VERSION}
   source ${HOME}/.profile
 }
@@ -190,7 +191,7 @@ upload_coverage_reports() {
 
 #  echo "Uploading to codecov..."
 
-#  codecovcli do-upload --flag common
+  codecovcli do-upload --flag common
 }
 
 generate_coverage_reports() {

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -109,7 +109,8 @@ install_linux() {
                gcovr \
                lcov \
                clang-tidy \
-               protobuf-compiler
+               protobuf-compiler \
+               setuptools
   pip3 install -U pip
   pip3 install nanopb
   pip3 install platformio==${PIO_VERSION}

--- a/software/common/common.sh
+++ b/software/common/common.sh
@@ -109,7 +109,8 @@ install_linux() {
                gcovr \
                lcov \
                clang-tidy \
-               protobuf-compiler
+               protobuf-compiler \
+               codecov-cli
   pip3 install -U pip
   pip3 install nanopb
   pip3 install platformio==${PIO_VERSION}
@@ -187,10 +188,7 @@ upload_coverage_reports() {
   rm $COVERAGE_OUTPUT_DIR/processed/test*
   rm $COVERAGE_OUTPUT_DIR/processed/.pio*
 
-  curl -Os https://uploader.codecov.io/latest/linux/codecov
-  chmod +x codecov
-  ./codecov -F common
-  rm codecov
+  codecovcli do-upload --flag common
 }
 
 generate_coverage_reports() {

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -172,7 +172,7 @@ run_checks() {
 }
 
 upload_coverage_reports() {
-  echo "Uploading coverage reports to Codecov"
+#  echo "Uploading coverage reports to Codecov"
 
   echo "Generating test coverage reports for controller code..."
 
@@ -196,11 +196,11 @@ upload_coverage_reports() {
   rm $COVERAGE_OUTPUT_DIR/processed/test*
   rm $COVERAGE_OUTPUT_DIR/processed/.pio*
   rm $COVERAGE_OUTPUT_DIR/processed/*common*
-
-  curl -Os https://uploader.codecov.io/latest/linux/codecov
-  chmod +x codecov
-  ./codecov -F controller
-  rm codecov
+#
+#  curl -Os https://uploader.codecov.io/latest/linux/codecov
+#  chmod +x codecov
+#  ./codecov -F controller
+#  rm codecov
 }
 
 generate_coverage_reports() {

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -97,7 +97,7 @@ The following options are available:
   integrate   Run integration tests
                 all [delay_time] - run all integration tests, pause for [delay_time] in between
                 <test_name> [parameters...] - run specific integration test with parameters
-  cov_upload  Upload coverage reports to Codecov server
+  cov_cleanup Prepare coverage reports for uploading to server
   help/-h     Display this help info
 
 Additionally, the following environment variables may be evaluated:
@@ -171,10 +171,8 @@ run_checks() {
     pio check -e native --fail-on-defect=high
 }
 
-upload_coverage_reports() {
-#  echo "Uploading coverage reports to Codecov"
-
-  echo "Generating test coverage reports for controller code..."
+cleanup_coverage_reports() {
+  echo "Cleaning up coverage reports for controller code..."
 
   SRC_DIR=".pio/build/$COVERAGE_ENVIRONMENT"
 
@@ -196,11 +194,6 @@ upload_coverage_reports() {
   rm $COVERAGE_OUTPUT_DIR/processed/test*
   rm $COVERAGE_OUTPUT_DIR/processed/.pio*
   rm $COVERAGE_OUTPUT_DIR/processed/*common*
-#
-#  curl -Os https://uploader.codecov.io/latest/linux/codecov
-#  chmod +x codecov
-#  ./codecov -F controller
-#  rm codecov
 }
 
 generate_coverage_reports() {
@@ -473,12 +466,11 @@ elif [ "$1" == "test" ]; then
 
   exit $EXIT_SUCCESS
 
-###################
-# UPLOAD COVERAGE #
-###################
-elif [ "$1" == "cov_upload" ]; then
-  upload_coverage_reports
-
+####################
+# CLEANUP COVERAGE #
+####################
+elif [ "$1" == "cov_cleanup" ]; then
+  cleanup_coverage_reports
   exit $EXIT_SUCCESS
 
 #######

--- a/software/controller/controller.sh
+++ b/software/controller/controller.sh
@@ -174,7 +174,7 @@ run_checks() {
 upload_coverage_reports() {
   echo "Uploading coverage reports to Codecov"
 
-  echo "Generating test coverage reports for controller and common code..."
+  echo "Generating test coverage reports for controller code..."
 
   SRC_DIR=".pio/build/$COVERAGE_ENVIRONMENT"
 

--- a/software/design/GUI_alarm_subsystem.md
+++ b/software/design/GUI_alarm_subsystem.md
@@ -18,7 +18,7 @@ The following is out of scope:
 
 ## Concepts
 
-ISO-60601-8 ([here](https://drive.google.com/file/d/1wr9WwpoUfvIk1hiBeBqECrA6jUgHHmgL/view?usp=sharing)) defines some
+ISO-60601-8 ([here](https://www.iso.org/standard/41986.html)) defines some
 very useful terminology and principles for alarm management, which we will use and slightly extend. Terms below are in
 more informal language than in the standard.
 

--- a/software/design/README.md
+++ b/software/design/README.md
@@ -95,11 +95,6 @@ change the protocol and potentially interoperate with other systems.
 
 ## Other documents
 
-For an overview of the software modules, see the Ventilator software architecture
-[document](https://docs.google.com/document/d/1FPB31V72r_keu1_xjUfYCUXGLxBC5hoyCT1naPNNNTA).
-
-**TODO:** Migrate contents of the above document to github.
-
 There is a document defining the [ventilation modes](ventilation_modes.md) we intend to support.
 
 ## Testing considerations

--- a/software/design/UI_requirements.md
+++ b/software/design/UI_requirements.md
@@ -105,7 +105,7 @@ The screen resolution is 1024x600.
 
 **Remote observation/control**
 * Things must be **visible from a distance of N meters**. The Covent reqs say from 1 meter, but per
-[notes](https://docs.google.com/document/d/1QFFcg2gL3PXXzyqgSBz3XZQm_oobZ2osFuErh492UEA/edit) drs often want to observe
+[notes](https://docs.google.com/document/d/1QFFcg2gL3PXXzyqgSBz3XZQm_oobZ2osFuErh492UEA) drs often want to observe
 the screen from outside the patient's room, to decrease exposure to infection.
 * Nice-to-have: remote control - also to decrease exposure.
 

--- a/software/design/milestone_v0.2.md
+++ b/software/design/milestone_v0.2.md
@@ -56,7 +56,7 @@ We also need:
 * Architecture / preliminary design review
 * Calibration tools/modes for subsystems
 * Validation testing plans for specific subsystems (this might be software or additional documentation overhead)
-* Listing and managing the software-specific risks (note: this work is underway [here](https://docs.google.com/spreadsheets/d/1qlTV5HqxnhlJXuhbSsEIfU-YwnN6PzgASv9_2dc5-cM/edit?usp=sharing) by jam@)
+* Listing and managing the software-specific risks (note: this work is underway [here](https://docs.google.com/spreadsheets/d/1p26b3XyhEte8BvnE9otj118MW5ajGM21dGfTXldG8sM) by jam@)
 * We need a software architecture review
 * We need 1 or 2 people to help physical design team publish their content on github and document things in a colleague- and people-friendly way
 

--- a/software/design/milestone_v0.2.md
+++ b/software/design/milestone_v0.2.md
@@ -4,7 +4,7 @@ _Information below only for posterity._
 
 ## How to use this page
 This is a high-level overview of what we want to achieve for v0.2 (a.k.a Covent) milestone. Up-to-date state of its implementation
-is [here](https://docs.google.com/document/d/1CHgz-y6wV6duTg66s1h8-wZZ6Tn22U1iL5WtjhSYQgk/edit#). Requirements are captured on Valispace.
+is [here](https://docs.google.com/document/d/1CHgz-y6wV6duTg66s1h8-wZZ6Tn22U1iL5WtjhSYQgk). Requirements are captured on Valispace.
 
 ## Date
 

--- a/software/gui/CMakeLists.txt
+++ b/software/gui/CMakeLists.txt
@@ -1,49 +1,23 @@
 cmake_minimum_required(VERSION 3.7.0 FATAL_ERROR)
-project(ventilator_gui
-    LANGUAGES CXX C
-    VERSION 0.0.1
-    )
 
 set(EXTRA_MODULES_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH ${EXTRA_MODULES_DIR})
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 
 #=============================================================================
-# ensure build type first
+# ensure build type before calling ConanConfig
 #=============================================================================
-
 include(EnsureBuildType)
 
-#=============================================================================
-# Conan
-#=============================================================================
+# This MUST run before the call to project()
+# Otherwise the appropriate variables will not be set
+include(ConanConfig)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_BINARY_DIR}/conan_toolchain.cmake)
 
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-  message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
-    "${CMAKE_BINARY_DIR}/conan.cmake"
-    TLS_VERIFY ON)
-endif()
-
-set(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
-set(CONAN "AUTO" CACHE STRING "conan options AUTO (conan must be in path), MANUAL (expects conanbuildinfo.cmake in build directory) or DISABLE")
-if(${CONAN} MATCHES "AUTO")
-  include(${CMAKE_BINARY_DIR}/conan.cmake)
-  conan_cmake_run(CONANFILE conanfile.txt
-      PROFILE ${CONAN_PROFILE}
-      BASIC_SETUP NO_OUTPUT_DIRS KEEP_RPATHS
-      BUILD_TYPE "None"
-      BUILD outdated)
-elseif(${CONAN} MATCHES "MANUAL")
-  if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    conan_basic_setup(NO_OUTPUT_DIRS KEEP_RPATHS)
-  else()
-    message(FATAL_ERROR "CONAN set to MANUAL but no file named conanbuildinfo.cmake found in build directory")
-  endif()
-elseif(NOT ${CONAN} MATCHES "DISABLE")
-  message(FATAL_ERROR "Unrecognised option for CONAN (${CONAN}), use AUTO, MANUAL or DISABLE")
-endif()
+project(ventilator_gui
+    LANGUAGES CXX C
+    VERSION 0.0.1
+)
 
 include(CompilerConfig)
 include(OutputDirConfig)

--- a/software/gui/CMakeUserPresets.json
+++ b/software/gui/CMakeUserPresets.json
@@ -1,9 +1,0 @@
-{
-    "version": 4,
-    "vendor": {
-        "conan": {}
-    },
-    "include": [
-        "/home/martin/dev/ventilator2/software/gui/build/CMakePresets.json"
-    ]
-}

--- a/software/gui/CMakeUserPresets.json
+++ b/software/gui/CMakeUserPresets.json
@@ -1,0 +1,9 @@
+{
+    "version": 4,
+    "vendor": {
+        "conan": {}
+    },
+    "include": [
+        "/home/martin/dev/ventilator2/software/gui/build/CMakePresets.json"
+    ]
+}

--- a/software/gui/cmake/ConanConfig.cmake
+++ b/software/gui/cmake/ConanConfig.cmake
@@ -1,0 +1,24 @@
+find_program(
+  CONAN
+  NAMES conan
+  HINT ENV PATH
+  DOC "conan executable location"
+  )
+
+if(NOT CONAN)
+  message(FATAL_ERROR "Could not find the command 'conan', which is required")
+else()
+  message(STATUS "Found conan executable at: ${CONAN}")
+endif()
+
+set(
+  CONAN_ARGS
+  "install" "${CMAKE_SOURCE_DIR}" "--output-folder=${CMAKE_CURRENT_BINARY_DIR}" "--build=missing" "--settings=build_type=${CMAKE_BUILD_TYPE}"
+  )
+
+execute_process(
+  COMMAND ${CONAN} ${CONAN_ARGS}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND_ECHO STDOUT
+  COMMAND_ERROR_IS_FATAL ANY
+  )

--- a/software/gui/conanfile.txt
+++ b/software/gui/conanfile.txt
@@ -1,12 +1,13 @@
 [requires]
-fmt/9.1.0
-spdlog/1.11.0
+spdlog/1.13.0
+fmt/10.2.1
 
 [generators]
-cmake
-cmake_find_package
-virtualbuildenv
-virtualrunenv
+CMakeDeps
+CMakeToolchain
+
+[options]
+date/*:use_system_tz_db=True
 
 [imports]
 ., *.dylib* -> ./lib @ keep_path=False

--- a/software/gui/gui.sh
+++ b/software/gui/gui.sh
@@ -18,7 +18,7 @@
 # ./gui.sh --help
 
 # \todo: keep CONAN_VERSION updated, test thoroughly whenever you do, leave this "todo" here
-CONAN_VERSION=1.59
+CONAN_VERSION=2.2.3
 
 # Fail if any command fails
 set -e
@@ -126,8 +126,7 @@ configure_conan() {
   pip3 install gitpython
   pip3 install conan==$CONAN_VERSION
   source "${HOME}/.profile"
-  conan profile new --detect default
-  conan profile update settings.compiler.libcxx=libstdc++11 default
+  conan profile detect
 }
 
 run_cppcheck() {
@@ -201,15 +200,6 @@ generate_coverage_reports() {
 
 launch_browser() {
   python -m webbrowser "${COVERAGE_OUTPUT_DIR}/index.html"
-}
-
-upload_coverage_reports() {
-  echo "Uploading coverage reports to Codecov"
-
-  curl -Os https://uploader.codecov.io/latest/linux/codecov
-  chmod +x codecov
-  ./codecov -F gui
-  rm codecov
 }
 
 ########
@@ -359,10 +349,6 @@ elif [ "$1" == "test" ]; then
   if [ "$2" != "--no-cov" ] && [ "$3" != "--no-cov" ] \
    && [ "$4" != "--no-cov" ] && [ "$5" != "--no-cov" ]; then
     generate_coverage_reports
-    if [ "$2" == "--upload-cov" ] || [ "$3" == "--upload-cov" ] \
-     || [ "$4" == "--upload-cov" ] || [ "$5" == "--upload-cov" ]; then
-      upload_coverage_reports
-    fi
   fi
 
   exit $EXIT_SUCCESS

--- a/software/gui/gui.sh
+++ b/software/gui/gui.sh
@@ -151,7 +151,7 @@ run_clang_tidy() {
   j_opt=$1
 
   CLANG_TIDY_EXEC=""
-  CLANG_TIDY_VERSION=$(echo "$(clang-tidy --version | sed -n 1p)" | awk -F[" ".] '{print $5}')
+  CLANG_TIDY_VERSION=$(echo "$(clang-tidy --version | sed -n 2p)" | awk -F[" ".] '{print $5}')
   if [ "$CLANG_TIDY_VERSION" = "6" ]; then
     CLANG_TIDY_EXEC="run-clang-tidy-6.0.py"
   else

--- a/software/gui/gui.sh
+++ b/software/gui/gui.sh
@@ -56,6 +56,7 @@ RespiraWorks Ventilator UI build & test utilities.
 The following options are available:
   install     One-time installation of build toolchain and dependencies
   clean       Clean build directory
+  check       Runs static checks only (must build first)
   build       Build the gui to /build, options:
       [--relase/--debug] - what it says (default=release)
       [-j]               - parallel build (auto select max-1 cores)
@@ -132,6 +133,7 @@ configure_conan() {
 run_cppcheck() {
   create_clean_directory  build/cppcheck
   cppcheck --enable=all --std=c++17 --inconclusive --force --inline-suppr --quiet \
+           --enable=information --check-config \
            -I ../common/generated_libs/protocols \
            -I ../common/libs/units \
            -ibuild -icmake-build-stm32 -isrc/protocols \
@@ -149,11 +151,11 @@ run_clang_tidy() {
   j_opt=$1
 
   CLANG_TIDY_EXEC=""
-  CLANG_TIDY_VERSION=$(echo "$(clang-tidy --version | sed -n 2p)" | awk -F[" ".] '{print $5}')
+  CLANG_TIDY_VERSION=$(echo "$(clang-tidy --version | sed -n 1p)" | awk -F[" ".] '{print $5}')
   if [ "$CLANG_TIDY_VERSION" = "6" ]; then
     CLANG_TIDY_EXEC="run-clang-tidy-6.0.py"
   else
-    CLANG_TIDY_EXEC="run-clang-tidy-${CLANG_TIDY_VERSION}.py"
+    CLANG_TIDY_EXEC="run-clang-tidy"
   fi
   echo "running $CLANG_TIDY_EXEC"
   find . -name '*.cpp' -not -path "*build*" \

--- a/software/gui/src/gui_state_container.cpp
+++ b/software/gui/src/gui_state_container.cpp
@@ -47,7 +47,7 @@ GuiStatus GuiStateContainer::GetGuiStatus() {
         return VentMode::VentMode_HIGH_FLOW_NASAL_CANNULA;
       default:
         // Should never happen.
-        CRIT("Unexpected commanded_mode: {}", commanded_mode_);
+        CRIT("Unexpected commanded_mode: {}", fmt::underlying(commanded_mode_));
         return VentMode::VentMode_PRESSURE_CONTROL;
     }
   }();


### PR DESCRIPTION
# Description

General CI update that ensure all builds and tests pass.
* `gui` project updated to use Conan v.2, seeing as Conan v1.6 is now deprecated and many packages are not updated for it
* using the new Codecov coverage uploader utility directly from CircleCI orbs.
* `common`, `controller` and `gui` build scripts updated to no longer use `codecov-cli` utility but instead assume external tool is used.
* A number of links to google docs updated to pass link checker
* A number of google docs had access settings updated to allow public viewer access
* Raspberry pi links excluded from link checker, as their server appears to block the crawler


## Self-review checklist:

- [x] Self-review: looked through the `Files changed` tab, browsed repository in branch
- [x] Documentation updated - reflects changes in code, electrical or mechanical design
- [x] Documentation and graphics follow the [documentation style guide](https://github.com/RespiraWorks/Ventilator/wiki/Documentation-style-guide)
- [x] New content is linked, easily discoverable, does not require too many clicks
- [x] Follows other relevant parts of [contributor wiki](https://github.com/RespiraWorks/Ventilator/wiki)
- [x] PR has a descriptive name
- [x] Tagged relevant reviewers

### Software only:

- [x] Follows our [code style](https://github.com/RespiraWorks/Ventilator/wiki/Code-style)
- [x] Commented code, particularly in hard-to-understand areas
- ~[ ] All tests pass - new and old, locally and on CI~
  - Tests passing on CI and locally
  - Do not have a ventilator to deploy and test with hardware, so no integration tests performed
- ~[ ] No new warnings or static check failures~
  - static checks fail, but they were failing before anyways, they were never enabled on CI
- [x] Tests that prove fix is effective or new feature works
- [x] Manual tests are explained, with instructions for reproducing them
